### PR TITLE
feat(stores): implement soft delete for stores with confirmation modal

### DIFF
--- a/apps/frontend/src/app/private/modules/organization/stores/components/index.ts
+++ b/apps/frontend/src/app/private/modules/organization/stores/components/index.ts
@@ -1,4 +1,5 @@
 export * from './store-create-modal/store-create-modal.component';
+export * from './store-delete-confirmation/store-delete-confirmation.component';
 export * from './store-empty-state/store-empty-state.component';
 export * from './store-edit-modal/store-edit-modal.component';
 export * from './store-settings-modal/store-settings-modal.component';

--- a/apps/frontend/src/app/private/modules/organization/stores/components/store-delete-confirmation/store-delete-confirmation.component.html
+++ b/apps/frontend/src/app/private/modules/organization/stores/components/store-delete-confirmation/store-delete-confirmation.component.html
@@ -1,0 +1,58 @@
+<app-modal
+  [(isOpen)]="isOpen"
+  (isOpenChange)="onOpenChange($event)"
+  [title]="'Eliminar Tienda'"
+  [size]="'md'"
+  [showCloseButton]="true"
+  [customClasses]="'delete-confirmation-modal'"
+>
+  <div class="modal-body">
+    <p class="confirmation-message">
+      Está a punto de eliminar la tienda
+      <strong class="text-primary">{{ store?.name }}</strong
+      >. Esta acción no se puede deshacer.
+    </p>
+
+    <div class="slug-confirmation-box">
+      <p class="slug-label">Para confirmar, escribe el slug de la tienda:</p>
+      <code class="slug-display">{{ store?.slug }}</code>
+    </div>
+
+    <div class="input-group">
+      <input
+        id="slug-input"
+        type="text"
+        [formControl]="slugInput"
+        [placeholder]="placeholderText"
+        class="slug-input"
+        [class.input-error]="showError"
+      />
+      <div *ngIf="showError" class="error-message">
+        <app-icon name="x-circle" [size]="16"></app-icon>
+        <span>El texto ingresado no coincide con el slug de la tienda</span>
+      </div>
+    </div>
+
+    <div class="warning-box">
+      <app-icon name="alert-triangle" [size]="16" class="warning-icon"></app-icon>
+      <p class="warning-text">
+        Esta acción eliminará permanentemente la tienda y todos sus datos
+        asociados.
+      </p>
+    </div>
+  </div>
+
+  <div slot="footer" class="modal-footer">
+    <app-button variant="outline" (clicked)="onCancel()">
+      Cancelar
+    </app-button>
+    <app-button
+      variant="danger"
+      [disabled]="!isSlugValid"
+      (clicked)="onConfirm()"
+    >
+      <app-icon name="trash-2" [size]="16" slot="icon"></app-icon>
+      Eliminar Tienda
+    </app-button>
+  </div>
+</app-modal>

--- a/apps/frontend/src/app/private/modules/organization/stores/components/store-delete-confirmation/store-delete-confirmation.component.scss
+++ b/apps/frontend/src/app/private/modules/organization/stores/components/store-delete-confirmation/store-delete-confirmation.component.scss
@@ -1,0 +1,160 @@
+:host {
+  display: block;
+}
+
+// Delete confirmation modal styles
+.delete-confirmation-modal {
+  .modal-content {
+    border-radius: 12px;
+    overflow: hidden;
+  }
+
+  .modal-header {
+    border-bottom: 1px solid var(--color-border);
+    padding: 1.5rem;
+    background-color: var(--color-background);
+
+  }
+
+  .modal-body {
+    padding: 1.5rem;
+  }
+
+  .modal-footer {
+    border-top: 1px solid var(--color-border);
+    padding: 1rem 1.5rem;
+    background-color: var(--color-background-secondary);
+  }
+}
+
+// Confirmation message
+.confirmation-message {
+  color: var(--color-text-secondary);
+  margin-bottom: 1.5rem;
+  line-height: 1.6;
+}
+
+.text-primary {
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
+// Slug confirmation box
+.slug-confirmation-box {
+  background-color: #fef3c7;
+  border: 1px solid #f59e0b;
+  border-radius: 8px;
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.slug-label {
+  color: #92400e;
+  font-size: 0.875rem;
+  font-weight: 500;
+  margin: 0 0 0.5rem 0;
+}
+
+.slug-display {
+  background-color: #fef3c7;
+  color: #92400e;
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  font-family: 'Courier New', monospace;
+  font-size: 0.875rem;
+  font-weight: 600;
+  display: block;
+  user-select: all;
+  word-break: break-all;
+}
+
+// Input group
+.input-group {
+  margin-bottom: 1.5rem;
+}
+
+.input-label {
+  display: block;
+  color: var(--color-text-primary);
+  font-size: 0.875rem;
+  font-weight: 500;
+  margin-bottom: 0.5rem;
+}
+
+.slug-input {
+  width: 100%;
+  padding: 0.625rem 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background-color: var(--color-background);
+  color: var(--color-text-primary);
+  font-size: 0.875rem;
+  transition: border-color 0.2s, box-shadow 0.2s;
+
+  &:focus {
+    outline: none;
+    border-color: var(--color-danger);
+    box-shadow: 0 0 0 3px rgba(220, 38, 38, 0.1);
+  }
+
+  &::placeholder {
+    color: var(--color-text-tertiary);
+  }
+
+  &.input-error {
+    border-color: var(--color-danger);
+    animation: shake 0.3s ease-in-out;
+  }
+}
+
+.error-message {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--color-danger);
+  font-size: 0.875rem;
+  margin-top: 0.5rem;
+}
+
+// Warning box
+.warning-box {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  background-color: #fee2e2;
+  border: 1px solid #ef4444;
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+}
+
+.warning-icon {
+  color: #dc2626;
+  flex-shrink: 0;
+  margin-top: 0.125rem;
+}
+
+.warning-text {
+  color: #991b1b;
+  font-size: 0.8125rem;
+  margin: 0;
+  line-height: 1.5;
+}
+
+// Modal footer buttons
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+
+  app-button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+// Shake animation for error state
+@keyframes shake {
+  0%, 100% { transform: translateX(0); }
+  25% { transform: translateX(-5px); }
+  75% { transform: translateX(5px); }
+}

--- a/apps/frontend/src/app/private/modules/organization/stores/components/store-delete-confirmation/store-delete-confirmation.component.ts
+++ b/apps/frontend/src/app/private/modules/organization/stores/components/store-delete-confirmation/store-delete-confirmation.component.ts
@@ -1,0 +1,96 @@
+import { Component, Input, Output, EventEmitter, OnDestroy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import {
+  FormsModule,
+  ReactiveFormsModule,
+  FormControl,
+  Validators,
+} from '@angular/forms';
+import { Subject } from 'rxjs';
+
+import { ModalComponent } from '../../../../../../shared/components/modal/modal.component';
+import { ButtonComponent } from '../../../../../../shared/components/button/button.component';
+import { IconComponent } from '../../../../../../shared/components/icon/icon.component';
+
+import { StoreListItem } from '../../interfaces/store.interface';
+
+@Component({
+  selector: 'app-store-delete-confirmation',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
+    ModalComponent,
+    ButtonComponent,
+    IconComponent,
+  ],
+  templateUrl: './store-delete-confirmation.component.html',
+  styleUrl: './store-delete-confirmation.component.scss',
+})
+export class StoreDeleteConfirmationComponent implements OnDestroy {
+  @Input() isOpen = false;
+  @Input() store: StoreListItem | null = null;
+
+  @Output() openChange = new EventEmitter<boolean>();
+  @Output() confirm = new EventEmitter<void>();
+  @Output() cancel = new EventEmitter<void>();
+
+  slugInput = new FormControl('', {
+    validators: [Validators.required],
+    nonNullable: true,
+  });
+
+  private destroy$ = new Subject<void>();
+
+  constructor() {
+    this.slugInput.valueChanges.subscribe(() => {
+      if (this.showError && this.isSlugValid) {
+        this.showError = false;
+      }
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  get placeholderText(): string {
+    return this.store ? `Escribe '${this.store.slug}' para confirmar` : '';
+  }
+
+  get isSlugValid(): boolean {
+    if (!this.store || !this.slugInput.value) {
+      return false;
+    }
+    return this.slugInput.value.trim() === this.store.slug;
+  }
+
+  showError = false;
+
+  onConfirm(): void {
+    if (!this.isSlugValid) {
+      this.showError = true;
+      return;
+    }
+
+    this.confirm.emit();
+    this.slugInput.reset();
+    this.showError = false;
+  }
+
+  onCancel(): void {
+    this.cancel.emit();
+    this.slugInput.reset();
+    this.showError = false;
+  }
+
+  onOpenChange(isOpen: boolean): void {
+    this.openChange.emit(isOpen);
+    if (!isOpen) {
+      this.slugInput.reset();
+      this.showError = false;
+    }
+  }
+}


### PR DESCRIPTION
- Change backend deleteStore to soft delete by setting is_active to false
- Update dashboard metrics to count only active stores
- Add confirmation modal in frontend for store deletion
- Replace browser confirm dialog with custom modal component

BREAKING CHANGE: deleteStore now performs soft delete instead of hard delete, preserving data integrity