### PR TITLE
fix(audit): fix audit counters and add settings change tracking

### DIFF
--- a/apps/backend/src/domains/store/settings/settings.module.ts
+++ b/apps/backend/src/domains/store/settings/settings.module.ts
@@ -3,9 +3,10 @@ import { SettingsService } from './settings.service';
 import { SettingsController } from './settings.controller';
 import { ResponseService } from '@common/responses/response.service';
 import { PrismaModule } from '../../../prisma/prisma.module';
+import { AuditModule } from '../../../common/audit/audit.module';
 
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, AuditModule],
   controllers: [SettingsController],
   providers: [SettingsService, ResponseService],
   exports: [SettingsService],

--- a/apps/frontend/src/app/private/modules/organization/audit/interfaces/audit.interface.ts
+++ b/apps/frontend/src/app/private/modules/organization/audit/interfaces/audit.interface.ts
@@ -13,6 +13,8 @@ export enum AuditAction {
     ACCOUNT_UNLOCKED = 'ACCOUNT_UNLOCKED',
     SUSPICIOUS_ACTIVITY = 'SUSPICIOUS_ACTIVITY',
     PASSWORD_RESET = 'PASSWORD_RESET',
+    VIEW = 'VIEW',
+    SEARCH = 'SEARCH',
 }
 
 export enum AuditResource {
@@ -26,6 +28,7 @@ export enum AuditResource {
     ROLES = 'roles',
     PERMISSIONS = 'permissions',
     SYSTEM = 'system',
+    SETTINGS = 'settings',
 }
 
 export interface AuditLog {
@@ -59,6 +62,7 @@ export interface AuditStats {
     total_logs: number;
     logs_by_action: Record<string, number>;
     logs_by_resource: Record<string, number>;
+    logs_by_action_and_resource: Record<string, number>; // Formato: "CREATE_users", "UPDATE_settings", etc.
 }
 
 export interface AuditQueryDto {


### PR DESCRIPTION
- Fix audit interceptor to handle ResponseService wrapper structure
  - Extract actual data from { success, message, data } wrapper
  - Apply to logCreateOperation and logUpdateOperation methods
- Add precise statistics grouping by action AND resource
  - New logs_by_action_and_resource field (e.g., CREATE_users, UPDATE_settings)
- Add audit logging for store settings changes
  - Track only changed sections to avoid size issues
- Add VIEW and SEARCH actions to frontend AuditAction enum
- Add SETTINGS to frontend AuditResource enum
- Update card labels for clarity (Modificaciones, Gestionados)
- Count only real changes (CREATE/UPDATE/DELETE) excluding VIEW/SEARCH