### PR TITLE
 fix: Fix stats cards and add short TTL cache for dashboard endpoints

### DIFF
--- a/apps/backend/src/domains/organization/organizations/organizations.controller.ts
+++ b/apps/backend/src/domains/organization/organizations/organizations.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Patch, Body, Query, UseGuards } from '@nestjs/common';
+import { Controller, Get, Patch, Body, Query, Param, UseGuards } from '@nestjs/common';
 import { OrganizationsService } from './organizations.service';
 import {
   UpdateOrganizationDto,
@@ -76,5 +76,26 @@ export class OrganizationsController {
   async upgradeAccountType(@Body() dto: UpgradeAccountTypeDto) {
     const result = await this.organizationsService.upgradeAccountType(dto);
     return this.responseService.success(result, result.message);
+  }
+
+  @Get(':id/stats')
+  @Permissions('organization:organizations:read')
+  async getStats(@Param('id') organizationId: string, @Query() dashboard_query: OrganizationDashboardDto) {
+    try {
+      const result =
+        await this.organizationsService.getOrganizationStats(
+          Number(organizationId),
+          dashboard_query,
+        );
+      return this.responseService.success(
+        result,
+        'Estadísticas de organización obtenidas exitosamente',
+      );
+    } catch (error) {
+      return this.responseService.error(
+        'Error al obtener las estadísticas de la organización',
+        error.message,
+      );
+    }
   }
 }

--- a/apps/backend/src/domains/organization/organizations/organizations.service.ts
+++ b/apps/backend/src/domains/organization/organizations/organizations.service.ts
@@ -260,6 +260,308 @@ export class OrganizationsService {
     };
   }
 
+  async getOrganizationStats(
+    organizationId: number,
+    query: OrganizationDashboardDto,
+  ) {
+    const { period } = query;
+
+    // Validate organization exists
+    const organization = await this.prisma.organizations.findUnique({
+      where: { id: organizationId },
+    });
+
+    if (!organization) {
+      throw new NotFoundException('Organization not found');
+    }
+
+    const org_id = organizationId;
+
+    // Dates setup
+    const now = new Date();
+    const today_start = new Date(
+      now.getFullYear(),
+      now.getMonth(),
+      now.getDate(),
+    );
+    const current_month_start = new Date(now.getFullYear(), now.getMonth(), 1);
+    const last_month_start = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+    const last_month_end = new Date(now.getFullYear(), now.getMonth(), 0);
+
+    // Calculate period dates for profit trend
+    const monthsMap: Record<string, number> = { '6m': 6, '1y': 12, 'all': 24 };
+    const monthsToFetch = period && monthsMap[period] ? monthsMap[period] : 6;
+    const trend_start_date = new Date(
+      now.getFullYear(),
+      now.getMonth() - (monthsToFetch - 1),
+      1,
+    );
+
+    const [
+      // 1. Total Stores & New this month
+      total_stores,
+      new_stores_this_month,
+
+      // 2. Active Users (online now - using last_seen)
+      active_users,
+      online_users,
+
+      // 3. Monthly Orders & Orders today
+      monthly_orders,
+      orders_today,
+
+      // 4. Revenue (Current Month) & Last Month
+      revenue_current_month,
+      revenue_last_month,
+
+      // 5. Profit Trend
+      profit_trend_raw,
+
+      // 6. Store Distribution (by type/sales_channel)
+      store_distribution_raw,
+    ] = await Promise.all([
+      // Total Stores
+      this.prisma.stores.count({
+        where: { organization_id: org_id, is_active: true },
+      }),
+
+      // New stores this month
+      this.prisma.stores.count({
+        where: {
+          organization_id: org_id,
+          is_active: true,
+          created_at: { gte: current_month_start },
+        },
+      }),
+
+      // Active Users
+      this.prisma.users.count({
+        where: {
+          organization_id: org_id,
+          state: 'active',
+        },
+      }),
+
+      // Online Users (count active sessions in last 15 minutes)
+      // Note: using user_sessions for more accurate online status
+      this.globalPrisma.user_sessions.count({
+        where: {
+          users: {
+            organization_id: org_id,
+            state: 'active',
+          },
+          expires_at: { gt: new Date() },
+          created_at: { gte: new Date(Date.now() - 15 * 60 * 1000) },
+        },
+      }),
+
+      // Monthly Orders
+      this.prisma.orders.count({
+        where: {
+          stores: { organization_id: org_id },
+          created_at: { gte: current_month_start },
+          state: { not: 'cancelled' },
+        },
+      }),
+
+      // Orders today
+      this.prisma.orders.count({
+        where: {
+          stores: { organization_id: org_id },
+          created_at: { gte: today_start },
+          state: { not: 'cancelled' },
+        },
+      }),
+
+      // Revenue Current Month (Profit)
+      Promise.all([
+        this.prisma.orders.aggregate({
+          where: {
+            stores: { organization_id: org_id },
+            created_at: { gte: current_month_start },
+            state: 'finished',
+          },
+          _sum: { grand_total: true, shipping_cost: true },
+        }),
+        this.prisma.order_items.aggregate({
+          where: {
+            orders: {
+              stores: { organization_id: org_id },
+              created_at: { gte: current_month_start },
+              state: 'finished',
+            },
+          },
+          _sum: { total_price: true },
+        }),
+      ]).then(([revenue_res, cost_res]) => {
+        const revenue = Number(revenue_res._sum.grand_total || 0);
+        const shipping_cost = Number(revenue_res._sum.shipping_cost || 0);
+        const cogs = Number(cost_res._sum.total_price || 0);
+        return { _sum: { profit: revenue - shipping_cost - cogs } };
+      }),
+
+      // Profit Last Month (Revenue - Costs)
+      Promise.all([
+        this.prisma.orders.aggregate({
+          where: {
+            stores: { organization_id: org_id },
+            created_at: { gte: last_month_start, lte: last_month_end },
+            state: 'finished',
+          },
+          _sum: { grand_total: true, shipping_cost: true },
+        }),
+        this.prisma.order_items.aggregate({
+          where: {
+            orders: {
+              stores: { organization_id: org_id },
+              created_at: { gte: last_month_start, lte: last_month_end },
+              state: 'finished',
+            },
+          },
+          _sum: { total_price: true },
+        }),
+      ]).then(([revenue_res, cost_res]) => {
+        const revenue = Number(revenue_res._sum.grand_total || 0);
+        const shipping_cost = Number(revenue_res._sum.shipping_cost || 0);
+        const cogs = Number(cost_res._sum.total_price || 0);
+        return { _sum: { profit: revenue - shipping_cost - cogs } };
+      }),
+
+      // Profit Trend - monthly aggregates
+      (this.prisma.withoutScope() as any).$queryRaw<Array<{
+        month: number;
+        year: number;
+        revenue: bigint;
+        costs: bigint;
+      }>>`
+        WITH monthly_orders AS (
+          SELECT
+            EXTRACT(MONTH FROM o.created_at)::int as month,
+            EXTRACT(YEAR FROM o.created_at)::int as year,
+            COALESCE(SUM(o.grand_total - o.shipping_cost), 0) as revenue
+          FROM orders o
+          INNER JOIN stores s ON s.id = o.store_id
+          WHERE s.organization_id = ${org_id}
+            AND o.state = 'finished'
+            AND o.created_at >= ${trend_start_date}
+          GROUP BY EXTRACT(MONTH FROM o.created_at), EXTRACT(YEAR FROM o.created_at)
+        ),
+        monthly_costs AS (
+          SELECT
+            EXTRACT(MONTH FROM o.created_at)::int as month,
+            EXTRACT(YEAR FROM o.created_at)::int as year,
+            COALESCE(SUM(oi.total_price), 0) as costs
+          FROM order_items oi
+          INNER JOIN orders o ON oi.order_id = o.id
+          INNER JOIN stores s ON s.id = o.store_id
+          WHERE s.organization_id = ${org_id}
+            AND o.state = 'finished'
+            AND o.created_at >= ${trend_start_date}
+          GROUP BY EXTRACT(MONTH FROM o.created_at), EXTRACT(YEAR FROM o.created_at)
+        )
+        SELECT
+          mo.month,
+          mo.year,
+          mo.revenue,
+          COALESCE(mc.costs, 0) as costs
+        FROM monthly_orders mo
+        LEFT JOIN monthly_costs mc ON mo.month = mc.month AND mo.year = mc.year
+        ORDER BY mo.year, mo.month
+      `,
+
+      // Store Distribution by store type (online vs physical)
+      (this.prisma.withoutScope() as any).$queryRaw<Array<{ type: string; revenue: bigint }>>`
+        SELECT
+          s.store_type as type,
+          COALESCE(SUM(o.grand_total), 0) as revenue
+        FROM stores s
+        LEFT JOIN orders o ON o.store_id = s.id AND o.state = 'finished'
+          AND o.created_at >= ${current_month_start}
+        WHERE s.organization_id = ${org_id} AND s.is_active = true
+        GROUP BY s.store_type
+      `,
+    ]);
+
+    const current_rev = Number(revenue_current_month._sum.profit || 0);
+    const last_rev = Number(revenue_last_month._sum.profit || 0);
+    const revenue_diff = current_rev - last_rev;
+
+    // Format profit trend
+    const monthNames = [
+      'Ene',
+      'Feb',
+      'Mar',
+      'Abr',
+      'May',
+      'Jun',
+      'Jul',
+      'Ago',
+      'Sep',
+      'Oct',
+      'Nov',
+      'Dic',
+    ];
+    const profit_trend = (profit_trend_raw || []).map((item: any) => ({
+      month: monthNames[item.month - 1] || 'Mes',
+      year: item.year,
+      amount: Number(item.revenue) - Number(item.costs),
+      revenue: Number(item.revenue),
+      costs: Number(item.costs),
+    }));
+
+    // Format store distribution - group by online vs offline
+    const typeMapping: Record<string, string> = {
+      online: 'online',
+      hybrid: 'online',
+      physical: 'offline',
+      popup: 'offline',
+      kiosko: 'offline',
+    };
+
+    const distributionMap = new Map<string, number>();
+    (store_distribution_raw || []).forEach((item: any) => {
+      const groupedType = typeMapping[item.type] || item.type;
+      const currentRevenue = distributionMap.get(groupedType) || 0;
+      distributionMap.set(groupedType, currentRevenue + Number(item.revenue));
+    });
+
+    const store_distribution = Array.from(distributionMap.entries()).map(
+      ([type, revenue]) => ({
+        type,
+        count: 0,
+        revenue,
+      }),
+    );
+
+    return {
+      organization_id: org_id,
+      stats: {
+        total_stores: {
+          value: total_stores,
+          sub_value: new_stores_this_month,
+          sub_label: 'new this month',
+        },
+        active_users: {
+          value: active_users,
+          sub_value: online_users,
+          sub_label: 'online now',
+        },
+        monthly_orders: {
+          value: monthly_orders,
+          sub_value: orders_today,
+          sub_label: 'orders today',
+        },
+        revenue: {
+          value: current_rev,
+          sub_value: revenue_diff,
+          sub_label: 'vs last month',
+        },
+      },
+      profit_trend,
+      store_distribution,
+    };
+  }
+
   /**
    * Upgrade organization account type from SINGLE_STORE to MULTI_STORE_ORG
    * Only owners can perform this action

--- a/apps/backend/src/domains/store/customers/customers.module.ts
+++ b/apps/backend/src/domains/store/customers/customers.module.ts
@@ -2,8 +2,10 @@ import { Module } from '@nestjs/common';
 import { CustomersService } from './customers.service';
 import { CustomersController } from './customers.controller';
 import { StorePrismaService } from '../../../prisma/services/store-prisma.service';
+import { ResponseModule } from '../../../common/responses/response.module';
 
 @Module({
+    imports: [ResponseModule],
     controllers: [CustomersController],
     providers: [CustomersService, StorePrismaService],
     exports: [CustomersService],

--- a/apps/backend/src/domains/store/stores/stores.controller.ts
+++ b/apps/backend/src/domains/store/stores/stores.controller.ts
@@ -17,7 +17,6 @@ import {
   UpdateStoreDto,
   StoreQueryDto,
   UpdateStoreSettingsDto,
-  StoreDashboardDto,
 } from './dto';
 import { PermissionsGuard } from '../../auth/guards/permissions.guard';
 import { Permissions } from '../../auth/decorators/permissions.decorator';
@@ -197,10 +196,9 @@ export class StoresController {
   @Permissions('store:stores:read')
   async getStoreStats(
     @Param('id', ParseIntPipe) id: number,
-    @Query() query: StoreDashboardDto,
   ) {
     try {
-      const result = await this.storesService.getDashboard(id, query);
+      const result = await this.storesService.getDashboardStats(id);
       return this.responseService.success(
         result,
         'Estadísticas de tienda obtenidas exitosamente',

--- a/apps/backend/src/domains/store/stores/stores.service.ts
+++ b/apps/backend/src/domains/store/stores/stores.service.ts
@@ -297,6 +297,192 @@ export class StoresService {
     });
   }
 
+  async getDashboardStats(storeId: number) {
+    const now = new Date();
+    const currentMonthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+    const lastMonthStart = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+    const lastMonthEnd = new Date(now.getFullYear(), now.getMonth(), 0);
+
+    // Get current month and last month data for growth calculation
+    const [
+      // Current month metrics
+      currentMonthOrders,
+      currentMonthRevenue,
+      totalProducts,
+      currentMonthCustomers,
+
+      // Last month metrics (for growth calculation)
+      lastMonthOrders,
+      lastMonthRevenue,
+      lastMonthCustomers,
+
+      // Recent orders
+      recentOrders,
+
+      // Sales data for chart (last 7 days)
+      salesData,
+    ] = await Promise.all([
+      // Current month orders
+      this.prisma.orders.count({
+        where: {
+          store_id: storeId,
+          created_at: { gte: currentMonthStart },
+          state: { not: 'cancelled' },
+        },
+      }),
+
+      // Current month revenue (only finished orders)
+      this.prisma.orders.aggregate({
+        where: {
+          store_id: storeId,
+          created_at: { gte: currentMonthStart },
+          state: 'finished',
+        },
+        _sum: { grand_total: true },
+      }),
+
+      // Total products (active)
+      this.prisma.products.count({
+        where: {
+          store_id: storeId,
+          state: 'active',
+        },
+      }),
+
+      // Current month unique customers
+      this.prisma.orders
+        .findMany({
+          where: {
+            store_id: storeId,
+            created_at: { gte: currentMonthStart },
+            state: { not: 'cancelled' },
+          },
+          select: { customer_id: true },
+          distinct: ['customer_id'],
+        })
+        .then((orders) => orders.length),
+
+      // Last month orders (for growth)
+      this.prisma.orders.count({
+        where: {
+          store_id: storeId,
+          created_at: { gte: lastMonthStart, lte: lastMonthEnd },
+          state: { not: 'cancelled' },
+        },
+      }),
+
+      // Last month revenue (for growth, only finished orders)
+      this.prisma.orders.aggregate({
+        where: {
+          store_id: storeId,
+          created_at: { gte: lastMonthStart, lte: lastMonthEnd },
+          state: 'finished',
+        },
+        _sum: { grand_total: true },
+      }),
+
+      // Last month customers (for growth)
+      this.prisma.orders
+        .findMany({
+          where: {
+            store_id: storeId,
+            created_at: { gte: lastMonthStart, lte: lastMonthEnd },
+            state: { not: 'cancelled' },
+          },
+          select: { customer_id: true },
+          distinct: ['customer_id'],
+        })
+        .then((orders) => orders.length),
+
+      // Recent orders (last 5)
+      this.prisma.orders.findMany({
+        where: { store_id: storeId, state: { not: 'cancelled' } },
+        include: {
+          addresses_orders_billing_address_idToaddresses: {
+            select: { city: true, country_code: true },
+          },
+          users: {
+            select: { first_name: true, last_name: true, email: true },
+          },
+        },
+        orderBy: { created_at: 'desc' },
+        take: 5,
+      }),
+
+      // Sales data by day for last 7 days
+      this.prisma.orders.findMany({
+        where: {
+          store_id: storeId,
+          created_at: { gte: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000) },
+          state: { not: 'cancelled' },
+        },
+        select: {
+          created_at: true,
+          grand_total: true,
+        },
+        orderBy: { created_at: 'asc' },
+      }),
+    ]);
+
+    // Calculate growth percentages
+    const calculateGrowth = (current: number, previous: number): number => {
+      if (previous === 0) return current > 0 ? 100 : 0;
+      return Math.round(((current - previous) / previous) * 100);
+    };
+
+    const monthlyOrders = currentMonthOrders;
+    const monthlyRevenue = Number(currentMonthRevenue._sum.grand_total || 0);
+    const totalCustomers = currentMonthCustomers;
+
+    const lastMonthOrdersValue = lastMonthOrders;
+    const lastMonthRevenueValue = Number(lastMonthRevenue._sum.grand_total || 0);
+    const lastMonthCustomersValue = lastMonthCustomers;
+
+    // Process sales data for chart
+    const salesChart = salesData.reduce(
+      (acc: Record<string, { date: string; orders: number; revenue: number; customers: number }>, order: any) => {
+        const date = order.created_at.toISOString().split('T')[0];
+        if (!acc[date]) {
+          acc[date] = { date, orders: 0, revenue: 0, customers: 0 };
+        }
+        acc[date].orders += 1;
+        acc[date].revenue += Number(order.grand_total || 0);
+        return acc;
+      },
+      {} as Record<string, { date: string; orders: number; revenue: number; customers: number }>,
+    );
+
+    const salesDataArray = Object.values(salesChart);
+
+    // Format recent orders
+    const formattedRecentOrders = recentOrders.map((order) => ({
+      id: String(order.id),
+      customerName: order.users
+        ? `${order.users.first_name || ''} ${order.users.last_name || ''}`.trim() || 'Cliente'
+        : 'Cliente Anónimo',
+      customerEmail: order.users?.email || '',
+      amount: Number(order.grand_total || 0),
+      status: order.state as 'pending' | 'processing' | 'shipped' | 'delivered' | 'cancelled',
+      items: 0, // Will need to fetch from order_items if needed
+      timestamp: order.created_at,
+    }));
+
+    return {
+      totalProducts,
+      totalCustomers,
+      monthlyOrders,
+      monthlyRevenue,
+      productsGrowth: 0, // No previous data for products growth
+      customersGrowth: calculateGrowth(totalCustomers, lastMonthCustomersValue),
+      ordersGrowth: calculateGrowth(monthlyOrders, lastMonthOrdersValue),
+      revenueGrowth: calculateGrowth(monthlyRevenue, lastMonthRevenueValue),
+      salesData: salesDataArray,
+      topProducts: [], // Can be populated if needed
+      recentOrders: formattedRecentOrders,
+      customerActivity: [], // Can be populated if needed
+    };
+  }
+
   async getDashboard(id: number, query: StoreDashboardDto) {
     const { start_date, end_date } = query;
 

--- a/apps/backend/src/domains/superadmin/audit/audit.controller.ts
+++ b/apps/backend/src/domains/superadmin/audit/audit.controller.ts
@@ -90,4 +90,28 @@ export class AuditController {
       'Audit statistics retrieved successfully',
     );
   }
+
+  @Get('dashboard')
+  @ApiOperation({
+    summary: 'Get audit dashboard statistics',
+    description: 'Retrieve dashboard statistics from audit logs',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Dashboard statistics retrieved successfully',
+  })
+  @Permissions('organization:audit:read')
+  async getDashboardStats(
+    @Query('fromDate') fromDate?: string,
+    @Query('toDate') toDate?: string,
+  ) {
+    const from = fromDate ? new Date(fromDate) : undefined;
+    const to = toDate ? new Date(toDate) : undefined;
+
+    const stats = await this.auditService.getAuditStats(from, to);
+    return this.responseService.success(
+      stats,
+      'Dashboard statistics retrieved successfully',
+    );
+  }
 }

--- a/apps/backend/src/domains/superadmin/audit/audit.service.ts
+++ b/apps/backend/src/domains/superadmin/audit/audit.service.ts
@@ -92,7 +92,12 @@ export class SuperAdminAuditService {
       where.organization_id = context.organization_id;
     }
 
-    const [totalLogs, logsByAction, logsByResource] = await Promise.all([
+    const [
+      totalLogs,
+      logsByAction,
+      logsByResource,
+      logsByUser,
+    ] = await Promise.all([
       this.prismaService.audit_logs.count({ where }),
       this.prismaService.audit_logs.groupBy({
         by: ['action'],
@@ -104,23 +109,95 @@ export class SuperAdminAuditService {
         where,
         _count: { id: true },
       }),
+      // Top users by activity
+      this.prismaService.audit_logs.groupBy({
+        by: ['user_id'],
+        where,
+        _count: { id: true },
+        orderBy: { _count: { id: 'desc' } },
+        take: 10,
+      }),
     ]);
+
+    // Get user details for logs by user
+    const userIds = logsByUser
+      .map((item: any) => item.user_id)
+      .filter((id): id is number => id !== null && id !== undefined);
+
+    interface UserDetail {
+      id: number;
+      first_name: string | null;
+      last_name: string | null;
+      email: string;
+    }
+
+    const users = userIds.length > 0
+      ? await this.prismaService.users.findMany({
+          where: { id: { in: userIds } },
+          select: { id: true, first_name: true, last_name: true, email: true },
+        })
+      : [];
+
+    const userMap = new Map<number, UserDetail>(users.map((u: UserDetail) => [u.id, u]));
 
     // Convertir a la estructura que espera el frontend
     const logsByActionFormatted: Record<string, number> = {};
-    logsByAction.forEach((item) => {
+    logsByAction.forEach((item: any) => {
       logsByActionFormatted[item.action] = item._count.id;
     });
 
     const logsByResourceFormatted: Record<string, number> = {};
-    logsByResource.forEach((item) => {
+    logsByResource.forEach((item: any) => {
       logsByResourceFormatted[item.resource] = item._count.id;
     });
+
+    const logsByUserFormatted = logsByUser
+      .filter((item: any) => item.user_id !== null)
+      .map((item: any) => {
+        const user = userMap.get(item.user_id!);
+        const userName = user
+          ? `${user.first_name || ''} ${user.last_name || ''}`.trim() || user.email
+          : 'Unknown';
+        return {
+          user_id: String(item.user_id),
+          user_name: userName,
+          count: item._count.id,
+        };
+      });
+
+    // Calculate logs by day for the last 30 days
+    const logsByDayFormatted: Array<{ date: string; count: number }> = [];
+    const daysToLookBack = 30;
+    for (let i = daysToLookBack - 1; i >= 0; i--) {
+      const date = new Date();
+      date.setDate(date.getDate() - i);
+      date.setHours(0, 0, 0, 0);
+
+      const nextDate = new Date(date);
+      nextDate.setDate(nextDate.getDate() + 1);
+
+      const count = await this.prismaService.audit_logs.count({
+        where: {
+          ...where,
+          created_at: {
+            gte: date,
+            lt: nextDate,
+          },
+        },
+      });
+
+      logsByDayFormatted.push({
+        date: date.toISOString().split('T')[0],
+        count,
+      });
+    }
 
     return {
       total_logs: totalLogs,
       logs_by_action: logsByActionFormatted,
       logs_by_resource: logsByResourceFormatted,
+      logs_by_user: logsByUserFormatted,
+      logs_by_day: logsByDayFormatted,
     };
   }
 }

--- a/apps/backend/src/domains/superadmin/dashboard/dashboard.service.ts
+++ b/apps/backend/src/domains/superadmin/dashboard/dashboard.service.ts
@@ -6,78 +6,245 @@ export class DashboardService {
   constructor(private readonly prisma: GlobalPrismaService) {}
 
   async getDashboardStats() {
-    // Mock data for now, can be replaced with real aggregation queries later
-    const stats = {
-      totalOrganizations: 150,
-      totalUsers: 4500,
-      activeStores: 320,
-      platformGrowth: 12.5,
-      organizationGrowth: 5,
-      userGrowth: 8,
-      storeGrowth: 3,
-      weeklyData: [
-        { week: 'Mon', organizations: 10, users: 50, stores: 5 },
-        { week: 'Tue', organizations: 12, users: 60, stores: 7 },
-        { week: 'Wed', organizations: 15, users: 55, stores: 6 },
-        { week: 'Thu', organizations: 8, users: 45, stores: 4 },
-        { week: 'Fri', organizations: 20, users: 80, stores: 10 },
-        { week: 'Sat', organizations: 25, users: 90, stores: 12 },
-        { week: 'Sun', organizations: 18, users: 70, stores: 8 },
-      ],
-      recentActivities: [
-        {
-          id: '1',
-          type: 'organization',
-          action: 'create',
-          description: 'New organization created',
-          timestamp: new Date(),
-          entityName: 'Acme Corp',
+    const now = new Date();
+    const currentMonthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+    const lastMonthStart = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+    const lastMonthEnd = new Date(now.getFullYear(), now.getMonth(), 0);
+
+    // Start of current week (Monday)
+    const dayOfWeek = now.getDay();
+    const startOfWeek = new Date(now);
+    startOfWeek.setDate(now.getDate() - (dayOfWeek === 0 ? 6 : dayOfWeek - 1));
+    startOfWeek.setHours(0, 0, 0, 0);
+
+    // Get current stats and last month stats for growth calculation
+    const [
+      // Current counts
+      totalOrganizations,
+      totalUsers,
+      activeStores,
+
+      // Last month counts (for growth)
+      lastMonthOrganizations,
+      lastMonthUsers,
+      lastMonthStores,
+
+      // Top organizations by stores/users/revenue
+      topOrganizationsData,
+
+      // Recent activities
+      recentOrganizations,
+      recentUsers,
+      recentStores,
+    ] = await Promise.all([
+      // Total organizations
+      this.prisma.organizations.count(),
+
+      // Total users
+      this.prisma.users.count(),
+
+      // Active stores
+      this.prisma.stores.count({ where: { is_active: true } }),
+
+      // Last month organizations (for growth)
+      this.prisma.organizations.count({
+        where: {
+          created_at: { gte: lastMonthStart, lte: lastMonthEnd },
         },
-        {
-          id: '2',
-          type: 'user',
-          action: 'register',
-          description: 'New user registered',
-          timestamp: new Date(Date.now() - 3600000),
-          entityName: 'John Doe',
+      }),
+
+      // Last month users (for growth)
+      this.prisma.users.count({
+        where: {
+          created_at: { gte: lastMonthStart, lte: lastMonthEnd },
         },
-        {
-          id: '3',
-          type: 'store',
-          action: 'create',
-          description: 'New store opened',
-          timestamp: new Date(Date.now() - 7200000),
-          entityName: 'Main St Branch',
+      }),
+
+      // Last month stores (for growth)
+      this.prisma.stores.count({
+        where: {
+          created_at: { gte: lastMonthStart, lte: lastMonthEnd },
         },
-      ],
-      topOrganizations: [
-        {
-          id: '1',
-          name: 'Tech Solutions Inc',
-          stores: 15,
-          users: 120,
-          revenue: 50000,
-          growth: 10,
+      }),
+
+      // Top organizations with stores/users count
+      this.prisma.organizations.findMany({
+        include: {
+          _count: {
+            select: { stores: true, users: true },
+          },
         },
-        {
-          id: '2',
-          name: 'Retail Group',
-          stores: 25,
-          users: 200,
-          revenue: 75000,
-          growth: -2,
-        },
-        {
-          id: '3',
-          name: 'Global Trading',
-          stores: 8,
-          users: 50,
-          revenue: 20000,
-          growth: 15,
-        },
-      ],
+        orderBy: { stores: { _count: 'desc' } },
+        take: 5,
+      }),
+
+      // Recent organizations created
+      this.prisma.organizations.findMany({
+        orderBy: { created_at: 'desc' },
+        take: 2,
+        select: { id: true, name: true, created_at: true },
+      }),
+
+      // Recent users registered
+      this.prisma.users.findMany({
+        orderBy: { created_at: 'desc' },
+        take: 2,
+        select: { id: true, first_name: true, last_name: true, email: true, created_at: true },
+      }),
+
+      // Recent stores created
+      this.prisma.stores.findMany({
+        orderBy: { created_at: 'desc' },
+        take: 2,
+        select: { id: true, name: true, created_at: true },
+      }),
+    ]);
+
+    // Calculate growth percentages
+    const calculateGrowth = (current: number, lastMonth: number): number => {
+      if (lastMonth === 0) return current > 0 ? 100 : 0;
+      return Math.round(((current - lastMonth) / lastMonth) * 100);
     };
 
-    return stats;
+    // Current month counts for growth calculation
+    const currentMonthOrganizations = await this.prisma.organizations.count({
+      where: { created_at: { gte: currentMonthStart } },
+    });
+
+    const currentMonthUsers = await this.prisma.users.count({
+      where: { created_at: { gte: currentMonthStart } },
+    });
+
+    const currentMonthStores = await this.prisma.stores.count({
+      where: { created_at: { gte: currentMonthStart } },
+    });
+
+    const organizationGrowth = calculateGrowth(currentMonthOrganizations, lastMonthOrganizations);
+    const userGrowth = calculateGrowth(currentMonthUsers, lastMonthUsers);
+    const storeGrowth = calculateGrowth(currentMonthStores, lastMonthStores);
+
+    const platformGrowth = Math.round((organizationGrowth + userGrowth + storeGrowth) / 3);
+
+    // Weekly data - get data for each day of the current week
+    const weekDays = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+    const weeklyData = await Promise.all(
+      weekDays.map(async (day, index) => {
+        const dayDate = new Date(startOfWeek);
+        dayDate.setDate(startOfWeek.getDate() + index);
+        dayDate.setHours(0, 0, 0, 0);
+
+        const nextDayDate = new Date(dayDate);
+        nextDayDate.setDate(dayDate.getDate() + 1);
+
+        const [dayOrgs, dayUsers, dayStores] = await Promise.all([
+          this.prisma.organizations.count({
+            where: {
+              created_at: { gte: dayDate, lt: nextDayDate },
+            },
+          }),
+          this.prisma.users.count({
+            where: {
+              created_at: { gte: dayDate, lt: nextDayDate },
+            },
+          }),
+          this.prisma.stores.count({
+            where: {
+              created_at: { gte: dayDate, lt: nextDayDate },
+            },
+          }),
+        ]);
+
+        return {
+          week: day,
+          organizations: dayOrgs,
+          users: dayUsers,
+          stores: dayStores,
+        };
+      }),
+    );
+
+    // Recent activities - combine and sort by timestamp
+    const recentActivities = [
+      ...recentOrganizations.map((org: any) => ({
+        id: String(org.id),
+        type: 'organization',
+        action: 'create',
+        description: 'Nueva organización creada',
+        timestamp: org.created_at,
+        entityName: org.name,
+      })),
+      ...recentUsers.map((user: any) => ({
+        id: String(user.id),
+        type: 'user',
+        action: 'register',
+        description: 'Nuevo usuario registrado',
+        timestamp: user.created_at,
+        entityName: `${user.first_name} ${user.last_name}`.trim() || user.email,
+      })),
+      ...recentStores.map((store: any) => ({
+        id: String(store.id),
+        type: 'store',
+        action: 'create',
+        description: 'Nueva tienda abierta',
+        timestamp: store.created_at,
+        entityName: store.name,
+      })),
+    ]
+      .sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime())
+      .slice(0, 5);
+
+    // Top organizations with revenue calculation
+    const topOrganizations = await Promise.all(
+      topOrganizationsData.map(async (org: any) => {
+        // Calculate revenue from finished orders
+        const revenueResult = await this.prisma.orders.aggregate({
+          where: {
+            stores: { organization_id: org.id },
+            state: 'finished',
+            created_at: { gte: currentMonthStart },
+          },
+          _sum: { grand_total: true },
+        });
+
+        // Calculate store growth (new stores this month vs last month)
+        const currentMonthStoresCount = await this.prisma.stores.count({
+          where: {
+            organization_id: org.id,
+            created_at: { gte: currentMonthStart },
+          },
+        });
+
+        const lastMonthStoresCount = await this.prisma.stores.count({
+          where: {
+            organization_id: org.id,
+            created_at: { gte: lastMonthStart, lte: lastMonthEnd },
+          },
+        });
+
+        const growth = calculateGrowth(currentMonthStoresCount, lastMonthStoresCount);
+
+        return {
+          id: String(org.id),
+          name: org.name,
+          stores: org._count.stores,
+          users: org._count.users,
+          revenue: Number(revenueResult._sum.grand_total || 0),
+          growth,
+        };
+      }),
+    );
+
+    return {
+      totalOrganizations,
+      totalUsers,
+      activeStores,
+      platformGrowth,
+      organizationGrowth,
+      userGrowth,
+      storeGrowth,
+      weeklyData,
+      recentActivities,
+      topOrganizations,
+    };
   }
 }

--- a/apps/backend/src/domains/superadmin/organizations/organizations.service.ts
+++ b/apps/backend/src/domains/superadmin/organizations/organizations.service.ts
@@ -272,12 +272,13 @@ export class OrganizationsService {
       totalOrganizations,
       activeOrganizations,
       inactiveOrganizations,
+      suspendedOrganizations,
       recentOrganizations,
-      organizationsByStatus,
     ] = await Promise.all([
       this.prisma.organizations.count(),
       this.prisma.organizations.count({ where: { state: 'active' } }),
       this.prisma.organizations.count({ where: { state: 'inactive' } }),
+      this.prisma.organizations.count({ where: { state: 'suspended' } }),
       this.prisma.organizations.findMany({
         take: 5,
         orderBy: { created_at: 'desc' },
@@ -294,24 +295,19 @@ export class OrganizationsService {
           },
         },
       }),
-      this.prisma.organizations.groupBy({
-        by: ['state'],
-        _count: true,
-      }),
     ]);
 
     return {
       totalOrganizations,
       activeOrganizations,
       inactiveOrganizations,
+      suspendedOrganizations,
       recentOrganizations,
-      organizationsByStatus: organizationsByStatus.reduce(
-        (acc: Record<string, number>, item: any) => {
-          acc[item.state] = item._count;
-          return acc;
-        },
-        {} as Record<string, number>,
-      ),
+      organizationsByStatus: {
+        active: activeOrganizations,
+        inactive: inactiveOrganizations,
+        suspended: suspendedOrganizations,
+      },
     };
   }
 

--- a/apps/backend/src/domains/superadmin/users/users.service.ts
+++ b/apps/backend/src/domains/superadmin/users/users.service.ts
@@ -375,23 +375,58 @@ export class UsersService {
       activeUsers,
       inactiveUsers,
       pendingUsers,
+      suspendedUsers,
+      archivedUsers,
+      with2FA,
+      emailVerified,
       usersByRole,
       recentUsers,
     ] = await Promise.all([
+      // Total users
       this.prisma.users.count(),
+
+      // Active users
       this.prisma.users.count({
         where: { state: user_state_enum.active },
       }),
+
+      // Inactive users
       this.prisma.users.count({
         where: { state: user_state_enum.inactive },
       }),
+
+      // Pending verification users
       this.prisma.users.count({
         where: { state: user_state_enum.pending_verification },
       }),
+
+      // Suspended users
+      this.prisma.users.count({
+        where: { state: user_state_enum.suspended },
+      }),
+
+      // Archived users
+      this.prisma.users.count({
+        where: { state: user_state_enum.archived },
+      }),
+
+      // Users with 2FA enabled
+      this.prisma.users.count({
+        where: { two_factor_enabled: true },
+      }),
+
+      // Users with verified email
+      this.prisma.users.count({
+        where: { email_verified: true },
+      }),
+
+      // Group by role
       this.prisma.user_roles.groupBy({
         by: ['role_id'],
         _count: true,
       }),
+
+      // Recent users
       this.prisma.users.findMany({
         take: 5,
         orderBy: { created_at: 'desc' },
@@ -423,10 +458,14 @@ export class UsersService {
     });
 
     return {
-      totalUsers,
-      activeUsers,
-      inactiveUsers,
-      pendingUsers,
+      total_usuarios: totalUsers,
+      activos: activeUsers,
+      inactivos: inactiveUsers,
+      pendientes: pendingUsers,
+      suspendidos: suspendedUsers,
+      archivados: archivedUsers,
+      con_2fa: with2FA,
+      email_verificado: emailVerified,
       usersByRole: usersByRoleWithNames,
       recentUsers: recentUsersWithoutPasswords,
     };

--- a/apps/frontend/src/app/private/modules/organization/dashboard/services/organization-dashboard.service.ts
+++ b/apps/frontend/src/app/private/modules/organization/dashboard/services/organization-dashboard.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable, catchError, throwError } from 'rxjs';
+import { Observable, catchError, throwError, map } from 'rxjs';
+import { tap, shareReplay } from 'rxjs/operators';
 import { environment } from '../../../../../../environments/environment';
 
 export interface DashboardStatItem {
@@ -26,8 +27,8 @@ export interface OrganizationDashboardStats {
   };
   store_activity: any[]; // keeping as any for now or define strict type if known
   recent_audit: any[];
-  profit_trend: { month: string; year: number; amount: number }[];
-  store_distribution: { type: string; count: number }[];
+  profit_trend: { month: string; year: number; amount: number; revenue: number; costs: number }[];
+  store_distribution: { type: string; count: number; revenue: number }[];
   // Keep existing fields if they are still needed by other parts or mark as optional
   revenueBreakdown?: RevenueBreakdown[];
   storeDistribution?: StoreDistribution[];
@@ -74,11 +75,21 @@ export interface UserActivity {
   returningUsers: number;
 }
 
+// Caché estático global (persiste entre instancias del servicio)
+interface CacheEntry<T> {
+  observable: T;
+  lastFetch: number;
+}
+
+// Map para caché por organizationId + period
+const dashboardCache = new Map<string, CacheEntry<Observable<OrganizationDashboardStats>>>();
+
 @Injectable({
   providedIn: 'root',
 })
 export class OrganizationDashboardService {
   private readonly apiUrl = environment.apiUrl;
+  private readonly CACHE_TTL = 30000; // 30 segundos
 
   constructor(private http: HttpClient) {}
 
@@ -86,18 +97,55 @@ export class OrganizationDashboardService {
     organizationId: string,
     period?: string,
   ): Observable<OrganizationDashboardStats> {
+    // Crear clave única para caché: organizationId + period
+    const cacheKey = `${organizationId}-${period || 'default'}`;
+    const now = Date.now();
+    const cached = dashboardCache.get(cacheKey);
+
+    if (cached && (now - cached.lastFetch) < this.CACHE_TTL) {
+      return cached.observable;
+    }
+
     const params = period ? `?period=${period}` : '';
-    return this.http
-      .get<OrganizationDashboardStats>(
-        `${this.apiUrl}/organization/organizations/${organizationId}/stats${params}`,
-      )
+    const observable$ = this.http
+      .get<any>(`${this.apiUrl}/organization/organizations/${organizationId}/stats${params}`)
       .pipe(
+        shareReplay({ bufferSize: 1, refCount: false }),
+        map((response) => response.data || response),
         catchError((error) => {
           console.error('Error fetching organization dashboard stats:', error);
           return throwError(
             () => new Error('Failed to fetch organization dashboard stats'),
           );
         }),
+        tap(() => {
+          const entry = dashboardCache.get(cacheKey);
+          if (entry) {
+            entry.lastFetch = Date.now();
+          }
+        }),
       );
+
+    dashboardCache.set(cacheKey, {
+      observable: observable$,
+      lastFetch: now,
+    });
+
+    return observable$;
+  }
+
+  /**
+   * Invalida el caché de estadísticas
+   * Útil después de actualizar datos de la organización
+   * @param organizationId - ID de la organización. Si no se proporciona, se limpia todo el caché
+   * @param period - Periodo específico. Si se proporciona, solo limpia ese periodo
+   */
+  invalidateCache(organizationId?: string, period?: string): void {
+    if (organizationId) {
+      const cacheKey = `${organizationId}-${period || 'default'}`;
+      dashboardCache.delete(cacheKey);
+    } else {
+      dashboardCache.clear();
+    }
   }
 }

--- a/apps/frontend/src/app/private/modules/store/dashboard/dashboard.component.ts
+++ b/apps/frontend/src/app/private/modules/store/dashboard/dashboard.component.ts
@@ -1,18 +1,19 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ActivatedRoute } from '@angular/router';
+import { Router } from '@angular/router';
+import { AuthFacade } from '../../../../core/store/auth/auth.facade';
 import {
   StoreDashboardService,
   StoreDashboardStats,
 } from './services/store-dashboard.service';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
-import { StatsComponent } from '../../../../shared/components';
+import { StatsComponent, IconComponent } from '../../../../shared/components';
 
 @Component({
   selector: 'app-store-dashboard',
   standalone: true,
-  imports: [CommonModule, StatsComponent],
+  imports: [CommonModule, StatsComponent, IconComponent],
   template: `
     <div class="space-y-6">
       <div *ngIf="loading" class="flex items-center justify-center h-64">
@@ -61,50 +62,75 @@ import { StatsComponent } from '../../../../shared/components';
           ></app-stats>
         </div>
 
-        <!-- Recent Activity -->
+        <!-- Recent Orders -->
         <div class="bg-white rounded-lg shadow-sm border border-gray-200">
-          <div class="px-6 py-4 border-b border-gray-200">
-            <h2 class="text-lg font-semibold text-gray-900">
-              Órdenes Recientes
-            </h2>
+          <div class="px-6 py-4 border-b border-gray-200 flex justify-between items-center">
+            <h2 class="text-lg font-semibold text-gray-900">Órdenes Recientes</h2>
+            <button
+              class="text-sm text-primary hover:text-primary/80 font-medium"
+              (click)="viewAllOrders()"
+            >
+              Ver todas →
+            </button>
           </div>
-          <div class="p-6">
-            <div *ngIf="hasRecentOrders()" class="space-y-4">
-              <div
-                class="flex items-start gap-4"
-                *ngFor="let order of recentOrders"
-              >
+
+          <div *ngIf="!hasRecentOrders()" class="p-12 text-center">
+            <app-icon name="shopping-cart" [size]="48" class="text-gray-300 mx-auto mb-4"></app-icon>
+            <p class="text-gray-500">No hay órdenes recientes</p>
+            <button
+              class="mt-4 px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary/90 transition-colors"
+              (click)="viewAllOrders()"
+            >
+              Ver Órdenes
+            </button>
+          </div>
+
+          <div *ngIf="hasRecentOrders()" class="divide-y divide-gray-100">
+            <div
+              *ngFor="let order of recentOrders.slice(0, 5)"
+              class="p-4 hover:bg-gray-50 transition-colors cursor-pointer flex items-center gap-4"
+              (click)="viewOrder(order.id)"
+            >
+              <!-- Status Icon -->
+              <div class="flex-shrink-0">
                 <div
-                  class="w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0 bg-green-100"
+                  class="w-10 h-10 rounded-full flex items-center justify-center"
+                  [ngClass]="getStatusIconBg(order.status)"
                 >
-                  <i class="fas fa-shopping-cart text-green-600"></i>
-                </div>
-                <div class="flex-1">
-                  <p class="text-sm font-medium text-gray-900">
-                    Pedido #{{ order.id }}
-                  </p>
-                  <p class="text-sm text-gray-600">
-                    {{ order.customerName }} - {{ order.items }} ítems
-                  </p>
-                  <p class="text-sm font-medium text-green-600">
-                    $ {{ order.amount }}
-                  </p>
-                  <p class="text-xs text-gray-400 mt-1">
-                    {{ order.timestamp | date: 'short' }}
-                  </p>
-                </div>
-                <div class="flex-shrink-0">
-                  <span
-                    class="px-2 py-1 text-xs rounded-full"
-                    [ngClass]="getStatusClass(order.status)"
-                  >
-                    {{ order.status | titlecase }}
-                  </span>
+                  <app-icon
+                    [name]="getStatusIcon(order.status)"
+                    [size]="20"
+                    [ngClass]="getStatusIconColor(order.status)"
+                  ></app-icon>
                 </div>
               </div>
-            </div>
-            <div *ngIf="!hasRecentOrders()" class="text-center text-gray-500">
-              No se encontraron órdenes recientes
+
+              <!-- Order Info -->
+              <div class="flex-1 min-w-0">
+                <div class="flex items-center justify-between mb-1">
+                  <h3 class="text-sm font-medium text-gray-900 truncate">
+                    {{ order.customerName || 'Consumidor Final' }}
+                  </h3>
+                  <span
+                    class="inline-flex items-center justify-center text-xs font-medium px-2.5 py-1 rounded-full"
+                    [ngClass]="getStatusBadgeClass(order.status)"
+                  >
+                    {{ getStatusLabel(order.status) }}
+                  </span>
+                </div>
+                <div class="flex items-center gap-4 text-xs text-gray-500">
+                  <span>{{ formatRelativeTime(order.timestamp) }}</span>
+                  <span>•</span>
+                  <span>{{ order.items }} {{ order.items === 1 ? 'producto' : 'productos' }}</span>
+                </div>
+              </div>
+
+              <!-- Amount -->
+              <div class="flex-shrink-0 text-right">
+                <div class="text-lg font-semibold text-gray-900">
+                  {{ formatCurrency(order.amount) }}
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -143,18 +169,29 @@ export class DashboardComponent implements OnInit, OnDestroy {
   private destroy$ = new Subject<void>();
 
   constructor(
-    private route: ActivatedRoute,
+    private authFacade: AuthFacade,
     private storeDashboardService: StoreDashboardService,
+    private router: Router,
   ) { }
 
   ngOnInit(): void {
-    const id = this.route.parent?.snapshot.paramMap.get('id');
-    this.storeId = id || null;
-    if (this.storeId) {
-      this.loadDashboardStats();
-    } else {
-      this.loading = false;
-    }
+    console.log('[StoreDashboard] ngOnInit - initializing dashboard component');
+
+    // Subscribe to userStore$ observable to get the store ID
+    this.authFacade.userStore$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((store: any) => {
+        console.log('[StoreDashboard] userStore$ emitted:', store);
+
+        const storeId = store?.id;
+        if (storeId && !this.storeId) {
+          console.log('[StoreDashboard] Found store ID:', storeId);
+          this.storeId = String(storeId);
+          this.loadDashboardStats();
+        } else if (!this.storeId) {
+          console.warn('[StoreDashboard] Store emitted but no ID found', store);
+        }
+      });
   }
 
   ngOnDestroy(): void {
@@ -219,5 +256,134 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   getStatusClass(status: string): string {
     return 'status-' + status.toLowerCase();
+  }
+
+  // New methods for creative order cards
+  getStatusStripClass(status: string): string {
+    const statusMap: Record<string, string> = {
+      pending: 'bg-yellow-400',
+      processing: 'bg-blue-500',
+      shipped: 'bg-indigo-500',
+      delivered: 'bg-emerald-500',
+      finished: 'bg-emerald-500',
+      cancelled: 'bg-red-500',
+    };
+    return statusMap[status] || 'bg-gray-400';
+  }
+
+  getStatusIconBg(status: string): string {
+    const bgMap: Record<string, string> = {
+      pending: 'bg-yellow-100',
+      processing: 'bg-blue-100',
+      shipped: 'bg-indigo-100',
+      delivered: 'bg-emerald-100',
+      finished: 'bg-emerald-100',
+      cancelled: 'bg-red-100',
+    };
+    return bgMap[status] || 'bg-gray-100';
+  }
+
+  getStatusIconColor(status: string): string {
+    const colorMap: Record<string, string> = {
+      pending: 'text-yellow-600',
+      processing: 'text-blue-600',
+      shipped: 'text-indigo-600',
+      delivered: 'text-emerald-600',
+      finished: 'text-emerald-600',
+      cancelled: 'text-red-600',
+    };
+    return colorMap[status] || 'text-gray-600';
+  }
+
+  formatRelativeTime(timestamp: Date): string {
+    const now = new Date();
+    const date = new Date(timestamp);
+    const diffMs = now.getTime() - date.getTime();
+    const diffMins = Math.floor(diffMs / 60000);
+    const diffHours = Math.floor(diffMs / 3600000);
+    const diffDays = Math.floor(diffMs / 86400000);
+
+    if (diffMins < 1) return 'Ahora';
+    if (diffMins < 60) return 'Hace ' + diffMins + ' min';
+    if (diffHours < 24) return 'Hace ' + diffHours + 'h';
+    if (diffDays < 7) return 'Hace ' + diffDays + 'd';
+    return date.toLocaleDateString('es-ES', { day: '2-digit', month: 'short' });
+  }
+
+  getStatusBadgeClass(status: string): string {
+    const classMap: Record<string, string> = {
+      pending: 'bg-yellow-100 text-yellow-800',
+      processing: 'bg-blue-100 text-blue-800',
+      shipped: 'bg-indigo-100 text-indigo-800',
+      delivered: 'bg-emerald-100 text-emerald-800',
+      finished: 'bg-emerald-100 text-emerald-800',
+      cancelled: 'bg-red-100 text-red-800',
+    };
+    return classMap[status] || 'bg-gray-100 text-gray-800';
+  }
+
+  getStatusLabel(status: string): string {
+    const labelMap: Record<string, string> = {
+      pending: 'Pendiente',
+      processing: 'Procesando',
+      shipped: 'Enviado',
+      delivered: 'Entregado',
+      finished: 'Completado',
+      cancelled: 'Cancelado',
+    };
+    return labelMap[status] || status;
+  }
+
+  formatAmount(amount: number): string {
+    return amount.toFixed(2);
+  }
+
+  getProgressPercent(status: string): number {
+    const progressMap: Record<string, number> = {
+      created: 10,
+      pending: 20,
+      processing: 50,
+      shipped: 75,
+      delivered: 90,
+      finished: 100,
+      cancelled: 0,
+    };
+    return progressMap[status] || 0;
+  }
+
+  getProgressBarClass(status: string): string {
+    const classMap: Record<string, string> = {
+      pending: 'bg-yellow-500',
+      processing: 'bg-blue-500',
+      shipped: 'bg-indigo-500',
+      delivered: 'bg-emerald-500',
+      finished: 'bg-emerald-500',
+      cancelled: 'bg-red-500',
+    };
+    return classMap[status] || 'bg-gray-400';
+  }
+
+  getStatusIcon(status: string): string {
+    const iconMap: Record<string, string> = {
+      pending: 'clock',
+      processing: 'refresh-cw',
+      shipped: 'truck',
+      delivered: 'check-circle',
+      finished: 'check-circle',
+      cancelled: 'x-circle',
+    };
+    return iconMap[status] || 'package';
+  }
+
+  formatCurrency(amount: number): string {
+    return '$' + amount.toFixed(2);
+  }
+
+  viewOrder(orderId: string): void {
+    this.router.navigate(['/admin/orders/sales', orderId]);
+  }
+
+  viewAllOrders(): void {
+    this.router.navigate(['/admin/orders/sales']);
   }
 }

--- a/apps/frontend/src/app/private/modules/store/inventory/services/inventory.service.ts
+++ b/apps/frontend/src/app/private/modules/store/inventory/services/inventory.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, catchError, throwError } from 'rxjs';
+import { tap, shareReplay } from 'rxjs/operators';
 import { environment } from '../../../../../../environments/environment';
 import {
   InventoryLocation,
@@ -19,11 +20,20 @@ import {
   PaginatedResponse,
 } from '../interfaces';
 
+// Caché estático global (persiste entre instancias del servicio)
+interface CacheEntry<T> {
+  observable: T;
+  lastFetch: number;
+}
+
+let inventoryStatsCache: CacheEntry<Observable<ApiResponse<InventoryStats>>> | null = null;
+
 @Injectable({
   providedIn: 'root',
 })
 export class InventoryService {
   private readonly base_url = `${environment.apiUrl}/store/inventory`;
+  private readonly CACHE_TTL = 30000; // 30 segundos
 
   constructor(private http: HttpClient) {}
 
@@ -246,9 +256,30 @@ export class InventoryService {
   // ============================================================
 
   getInventoryStats(): Observable<ApiResponse<InventoryStats>> {
-    return this.http
+    const now = Date.now();
+
+    if (inventoryStatsCache && (now - inventoryStatsCache.lastFetch) < this.CACHE_TTL) {
+      return inventoryStatsCache.observable;
+    }
+
+    const observable$ = this.http
       .get<ApiResponse<InventoryStats>>(`${this.base_url}/stats`)
-      .pipe(catchError(this.handleError));
+      .pipe(
+        shareReplay({ bufferSize: 1, refCount: false }),
+        tap(() => {
+          if (inventoryStatsCache) {
+            inventoryStatsCache.lastFetch = Date.now();
+          }
+        }),
+        catchError(this.handleError),
+      );
+
+    inventoryStatsCache = {
+      observable: observable$,
+      lastFetch: now,
+    };
+
+    return observable$;
   }
 
   // ============================================================
@@ -285,5 +316,13 @@ export class InventoryService {
     }
 
     return throwError(() => error_message);
+  }
+
+  /**
+   * Invalida el caché de estadísticas
+   * Útil después de crear/editar/eliminar inventario
+   */
+  invalidateCache(): void {
+    inventoryStatsCache = null;
   }
 }

--- a/apps/frontend/src/app/private/modules/store/orders/purchase-orders/purchase-orders.component.ts
+++ b/apps/frontend/src/app/private/modules/store/orders/purchase-orders/purchase-orders.component.ts
@@ -142,7 +142,12 @@ export class PurchaseOrdersComponent implements OnInit, OnDestroy {
     ).length;
     this.stats.received = this.orders.filter((o) => o.status === 'received').length;
     this.stats.total_value = this.orders.reduce(
-      (sum, o) => sum + (o.total_amount || 0),
+      (sum, o) => {
+        const amount = typeof o.total_amount === 'string'
+          ? parseFloat(o.total_amount)
+          : (o.total_amount || 0);
+        return sum + amount;
+      },
       0
     );
   }

--- a/apps/frontend/src/app/private/modules/store/pos/services/pos-cart.service.ts
+++ b/apps/frontend/src/app/private/modules/store/pos/services/pos-cart.service.ts
@@ -441,7 +441,7 @@ export class PosCartService {
       product.tax_assignments?.reduce((rateSum: number, assignment: any) => {
         const assignmentRate =
           assignment.tax_categories?.tax_rates?.reduce(
-            (sum: number, tr: any) => sum + parseFloat(tr.rate || '0'),
+            (sum: number, tr: any) => sum + (parseFloat(tr.rate || '0') / 100),
             0,
           ) || 0;
         return rateSum + assignmentRate;

--- a/apps/frontend/src/app/private/modules/super-admin/audit/components/audit-stats.component.ts
+++ b/apps/frontend/src/app/private/modules/super-admin/audit/components/audit-stats.component.ts
@@ -22,47 +22,58 @@ import {
       ></app-stats>
 
       <app-stats
-        title="Creaciones"
-        [value]="getActionCount('CREATE')"
-        [smallText]="calculatePercentage(getActionCount('CREATE')) + '% del total'"
-        iconName="plus"
+        title="Sesiones (Login)"
+        [value]="getActionCount('LOGIN')"
+        [smallText]="calculatePercentage(getActionCount('LOGIN')) + '% del total'"
+        iconName="log-in"
+        iconBgColor="bg-purple-100"
+        iconColor="text-purple-600"
+      ></app-stats>
+
+      <app-stats
+        title="Búsquedas"
+        [value]="getActionCount('SEARCH')"
+        [smallText]="calculatePercentage(getActionCount('SEARCH')) + '% del total'"
+        iconName="search"
         iconBgColor="bg-green-100"
         iconColor="text-green-600"
       ></app-stats>
 
       <app-stats
-        title="Actualizaciones"
-        [value]="getActionCount('UPDATE')"
-        [smallText]="calculatePercentage(getActionCount('UPDATE')) + '% del total'"
-        iconName="edit"
-        iconBgColor="bg-indigo-100"
-        iconColor="text-indigo-600"
-      ></app-stats>
-
-      <app-stats
-        title="Eliminaciones"
-        [value]="getActionCount('DELETE')"
-        [smallText]="calculatePercentage(getActionCount('DELETE')) + '% del total'"
-        iconName="trash-2"
-        iconBgColor="bg-red-100"
-        iconColor="text-red-600"
+        title="Visualizaciones"
+        [value]="getActionCount('VIEW')"
+        [smallText]="calculatePercentage(getActionCount('VIEW')) + '% del total'"
+        iconName="eye"
+        iconBgColor="bg-yellow-100"
+        iconColor="text-yellow-600"
       ></app-stats>
 
       @if (showExtendedStats()) {
         <app-stats
-          title="Sesiones (Login)"
-          [value]="getActionCount('LOGIN')"
-          iconName="log-in"
-          iconBgColor="bg-purple-100"
-          iconColor="text-purple-600"
+          title="Actualizaciones"
+          [value]="getActionCount('UPDATE')"
+          [smallText]="calculatePercentage(getActionCount('UPDATE')) + '% del total'"
+          iconName="edit"
+          iconBgColor="bg-indigo-100"
+          iconColor="text-indigo-600"
         ></app-stats>
 
         <app-stats
-          title="Lecturas"
-          [value]="getActionCount('READ')"
-          iconName="eye"
-          iconBgColor="bg-yellow-100"
-          iconColor="text-yellow-600"
+          title="Creaciones"
+          [value]="getActionCount('CREATE')"
+          [smallText]="calculatePercentage(getActionCount('CREATE')) + '% del total'"
+          iconName="plus"
+          iconBgColor="bg-emerald-100"
+          iconColor="text-emerald-600"
+        ></app-stats>
+
+        <app-stats
+          title="Eliminaciones"
+          [value]="getActionCount('DELETE')"
+          [smallText]="calculatePercentage(getActionCount('DELETE')) + '% del total'"
+          iconName="trash-2"
+          iconBgColor="bg-red-100"
+          iconColor="text-red-600"
         ></app-stats>
 
         <app-stats
@@ -72,15 +83,6 @@ import {
           iconName="database"
           iconBgColor="bg-gray-100"
           iconColor="text-gray-600"
-        ></app-stats>
-
-        <app-stats
-          title="Fecha Logs"
-          [value]="stats()?.logs_by_day?.length || 0"
-          smallText="Días con actividad"
-          iconName="calendar"
-          iconBgColor="bg-orange-100"
-          iconColor="text-orange-600"
         ></app-stats>
       }
     </div>

--- a/apps/frontend/src/app/private/modules/super-admin/audit/interfaces/audit.interface.ts
+++ b/apps/frontend/src/app/private/modules/super-admin/audit/interfaces/audit.interface.ts
@@ -32,6 +32,8 @@ export enum AuditAction {
   LOGIN = 'LOGIN',
   LOGOUT = 'LOGOUT',
   READ = 'READ',
+  VIEW = 'VIEW',
+  SEARCH = 'SEARCH',
   PERMISSION_CHANGE = 'PERMISSION_CHANGE',
 }
 
@@ -48,8 +50,8 @@ export enum AuditResource {
 
 export interface AuditStats {
   total_logs: number;
-  logs_by_action: Record<AuditAction, number>;
-  logs_by_resource: Record<AuditResource, number>;
+  logs_by_action: Record<string, number>;
+  logs_by_resource: Record<string, number>;
   logs_by_user: Array<{
     user_id: string;
     user_name: string;

--- a/apps/frontend/src/app/private/modules/super-admin/dashboard/services/super-admin-dashboard.service.ts
+++ b/apps/frontend/src/app/private/modules/super-admin/dashboard/services/super-admin-dashboard.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable, catchError, throwError } from 'rxjs';
+import { Observable, catchError, throwError, tap, shareReplay } from 'rxjs';
 import { environment } from '../../../../../../environments/environment';
 
 export interface SuperAdminStats {
@@ -46,24 +46,62 @@ export interface TopOrganization {
 })
 export class SuperAdminDashboardService {
   private readonly apiUrl = environment.apiUrl;
+  private readonly CACHE_TTL = 30000; // 30 segundos
+
+  // Caché para endpoints de stats
+  private dashboardStatsCache$: Observable<SuperAdminStats> | undefined;
+  private dashboardStatsLastFetch = 0;
+
+  private organizationsStatsCache$: Observable<any> | undefined;
+  private organizationsStatsLastFetch = 0;
+
+  private usersStatsCache$: Observable<any> | undefined;
+  private usersStatsLastFetch = 0;
+
+  private storesStatsCache$: Observable<any> | undefined;
+  private storesStatsLastFetch = 0;
+
+  private domainsStatsCache$: Observable<any> | undefined;
+  private domainsStatsLastFetch = 0;
+
+  private rolesStatsCache$: Observable<any> | undefined;
+  private rolesStatsLastFetch = 0;
 
   constructor(private http: HttpClient) {}
 
   getDashboardStats(): Observable<SuperAdminStats> {
-    return this.http
+    const now = Date.now();
+
+    if (this.dashboardStatsCache$ && (now - this.dashboardStatsLastFetch) < this.CACHE_TTL) {
+      return this.dashboardStatsCache$;
+    }
+
+    this.dashboardStatsCache$ = this.http
       .get<SuperAdminStats>(`${this.apiUrl}/superadmin/dashboard/stats`)
       .pipe(
+        tap(() => this.dashboardStatsLastFetch = Date.now()),
+        shareReplay({ bufferSize: 1, refCount: true }),
         catchError((error) => {
           console.error('Error fetching super admin dashboard stats:', error);
           return throwError(() => new Error('Failed to fetch dashboard stats'));
         }),
       );
+
+    return this.dashboardStatsCache$;
   }
 
   getOrganizationsStats(): Observable<any> {
-    return this.http
+    const now = Date.now();
+
+    if (this.organizationsStatsCache$ && (now - this.organizationsStatsLastFetch) < this.CACHE_TTL) {
+      return this.organizationsStatsCache$;
+    }
+
+    this.organizationsStatsCache$ = this.http
       .get(`${this.apiUrl}/superadmin/organizations/dashboard`)
       .pipe(
+        tap(() => this.organizationsStatsLastFetch = Date.now()),
+        shareReplay({ bufferSize: 1, refCount: true }),
         catchError((error) => {
           console.error('Error fetching organizations stats:', error);
           return throwError(
@@ -71,44 +109,87 @@ export class SuperAdminDashboardService {
           );
         }),
       );
+
+    return this.organizationsStatsCache$;
   }
 
   getUsersStats(): Observable<any> {
-    return this.http.get(`${this.apiUrl}/superadmin/users/dashboard`).pipe(
+    const now = Date.now();
+
+    if (this.usersStatsCache$ && (now - this.usersStatsLastFetch) < this.CACHE_TTL) {
+      return this.usersStatsCache$;
+    }
+
+    this.usersStatsCache$ = this.http.get(`${this.apiUrl}/superadmin/users/dashboard`).pipe(
+      tap(() => this.usersStatsLastFetch = Date.now()),
+      shareReplay({ bufferSize: 1, refCount: true }),
       catchError((error) => {
         console.error('Error fetching users stats:', error);
         return throwError(() => new Error('Failed to fetch users stats'));
       }),
     );
+
+    return this.usersStatsCache$;
   }
 
   getStoresStats(): Observable<any> {
-    return this.http.get(`${this.apiUrl}/superadmin/stores/dashboard`).pipe(
+    const now = Date.now();
+
+    if (this.storesStatsCache$ && (now - this.storesStatsLastFetch) < this.CACHE_TTL) {
+      return this.storesStatsCache$;
+    }
+
+    this.storesStatsCache$ = this.http.get(`${this.apiUrl}/superadmin/stores/dashboard`).pipe(
+      tap(() => this.storesStatsLastFetch = Date.now()),
+      shareReplay({ bufferSize: 1, refCount: true }),
       catchError((error) => {
         console.error('Error fetching stores stats:', error);
         return throwError(() => new Error('Failed to fetch stores stats'));
       }),
     );
+
+    return this.storesStatsCache$;
   }
 
   getDomainsStats(): Observable<any> {
-    return this.http.get(`${this.apiUrl}/superadmin/domains/dashboard`).pipe(
+    const now = Date.now();
+
+    if (this.domainsStatsCache$ && (now - this.domainsStatsLastFetch) < this.CACHE_TTL) {
+      return this.domainsStatsCache$;
+    }
+
+    this.domainsStatsCache$ = this.http.get(`${this.apiUrl}/superadmin/domains/dashboard`).pipe(
+      tap(() => this.domainsStatsLastFetch = Date.now()),
+      shareReplay({ bufferSize: 1, refCount: true }),
       catchError((error) => {
         console.error('Error fetching domains stats:', error);
         return throwError(() => new Error('Failed to fetch domains stats'));
       }),
     );
+
+    return this.domainsStatsCache$;
   }
 
   getRolesStats(): Observable<any> {
-    return this.http.get(`${this.apiUrl}/superadmin/roles/dashboard`).pipe(
+    const now = Date.now();
+
+    if (this.rolesStatsCache$ && (now - this.rolesStatsLastFetch) < this.CACHE_TTL) {
+      return this.rolesStatsCache$;
+    }
+
+    this.rolesStatsCache$ = this.http.get(`${this.apiUrl}/superadmin/roles/dashboard`).pipe(
+      tap(() => this.rolesStatsLastFetch = Date.now()),
+      shareReplay({ bufferSize: 1, refCount: true }),
       catchError((error) => {
         console.error('Error fetching roles stats:', error);
         return throwError(() => new Error('Failed to fetch roles stats'));
       }),
     );
+
+    return this.rolesStatsCache$;
   }
 
+  // No cachear - datos en tiempo real
   getPlatformHealth(): Observable<any> {
     return this.http.get(`${this.apiUrl}/admin/health`).pipe(
       catchError((error) => {
@@ -118,6 +199,7 @@ export class SuperAdminDashboardService {
     );
   }
 
+  // No cachear - datos en tiempo real
   getSystemMetrics(): Observable<any> {
     return this.http.get(`${this.apiUrl}/admin/metrics`).pipe(
       catchError((error) => {
@@ -125,5 +207,24 @@ export class SuperAdminDashboardService {
         return throwError(() => new Error('Failed to fetch system metrics'));
       }),
     );
+  }
+
+  /**
+   * Invalida todo el caché de estadísticas
+   * Útil después de crear/editar/eliminar entidades
+   */
+  invalidateAllStatsCache(): void {
+    this.dashboardStatsCache$ = undefined;
+    this.dashboardStatsLastFetch = 0;
+    this.organizationsStatsCache$ = undefined;
+    this.organizationsStatsLastFetch = 0;
+    this.usersStatsCache$ = undefined;
+    this.usersStatsLastFetch = 0;
+    this.storesStatsCache$ = undefined;
+    this.storesStatsLastFetch = 0;
+    this.domainsStatsCache$ = undefined;
+    this.domainsStatsLastFetch = 0;
+    this.rolesStatsCache$ = undefined;
+    this.rolesStatsLastFetch = 0;
   }
 }

--- a/apps/frontend/src/app/private/modules/super-admin/domains/components/domain-stats.component.ts
+++ b/apps/frontend/src/app/private/modules/super-admin/domains/components/domain-stats.component.ts
@@ -13,7 +13,7 @@ import { StatsComponent } from '../../../../../shared/components/index';
       <div class="grid grid-cols-4 gap-2 md:gap-4 lg:gap-6">
         <app-stats
           title="Total Domains"
-          [value]="stats.total_domains"
+          [value]="stats.totalDomains || 0"
           iconName="globe-2"
           iconBgColor="bg-primary/10"
           iconColor="text-primary"
@@ -21,7 +21,7 @@ import { StatsComponent } from '../../../../../shared/components/index';
 
         <app-stats
           title="Active"
-          [value]="stats.active_domains"
+          [value]="stats.activeDomains || 0"
           iconName="check-circle"
           iconBgColor="bg-green-100"
           iconColor="text-green-600"
@@ -29,7 +29,7 @@ import { StatsComponent } from '../../../../../shared/components/index';
 
         <app-stats
           title="Pending"
-          [value]="stats.pending_domains"
+          [value]="stats.pendingDomains || 0"
           iconName="clock"
           iconBgColor="bg-yellow-100"
           iconColor="text-yellow-600"
@@ -37,7 +37,7 @@ import { StatsComponent } from '../../../../../shared/components/index';
 
         <app-stats
           title="Verified"
-          [value]="stats.verified_domains"
+          [value]="stats.verifiedDomains || 0"
           iconName="shield-check"
           iconBgColor="bg-blue-100"
           iconColor="text-blue-600"
@@ -48,7 +48,7 @@ import { StatsComponent } from '../../../../../shared/components/index';
       <div class="grid grid-cols-4 gap-2 md:gap-4 lg:gap-6">
         <app-stats
           title="Platform Subdomains"
-          [value]="stats.vendix_subdomains || stats.primary_domains"
+          [value]="stats.vendixSubdomains || stats.primaryDomains || 0"
           iconName="globe-2"
           iconBgColor="bg-primary/10"
           iconColor="text-primary"
@@ -56,7 +56,7 @@ import { StatsComponent } from '../../../../../shared/components/index';
 
         <app-stats
           title="Custom Domains"
-          [value]="stats.customer_custom_domains || stats.customer_domains"
+          [value]="stats.customerCustomDomains || stats.customerDomains || 0"
           iconName="link-2"
           iconBgColor="bg-purple-100"
           iconColor="text-purple-600"
@@ -64,7 +64,7 @@ import { StatsComponent } from '../../../../../shared/components/index';
 
         <app-stats
           title="Client Subdomains"
-          [value]="stats.customer_subdomains || stats.alias_domains"
+          [value]="stats.customerSubdomains || stats.aliasDomains || 0"
           iconName="database"
           iconBgColor="bg-indigo-100"
           iconColor="text-indigo-600"
@@ -72,7 +72,7 @@ import { StatsComponent } from '../../../../../shared/components/index';
 
         <app-stats
           title="Alias Domains"
-          [value]="stats.alias_domains"
+          [value]="stats.aliasDomains || 0"
           iconName="link-2"
           iconBgColor="bg-orange-100"
           iconColor="text-orange-600"

--- a/apps/frontend/src/app/private/modules/super-admin/domains/domains.component.ts
+++ b/apps/frontend/src/app/private/modules/super-admin/domains/domains.component.ts
@@ -307,16 +307,16 @@ export class DomainsComponent implements OnInit, OnDestroy {
   ];
 
   stats: DomainStats = {
-    total_domains: 0,
-    active_domains: 0,
-    pending_domains: 0,
-    verified_domains: 0,
-    customer_domains: 0,
-    primary_domains: 0,
-    alias_domains: 0,
-    vendix_subdomains: 0,
-    customer_custom_domains: 0,
-    customer_subdomains: 0,
+    totalDomains: 0,
+    activeDomains: 0,
+    pendingDomains: 0,
+    verifiedDomains: 0,
+    customerDomains: 0,
+    primaryDomains: 0,
+    aliasDomains: 0,
+    vendixSubdomains: 0,
+    customerCustomDomains: 0,
+    customerSubdomains: 0,
   };
 
   pagination = {
@@ -517,30 +517,30 @@ export class DomainsComponent implements OnInit, OnDestroy {
   }
 
   updateStats(): void {
-    this.stats.total_domains = this.domains.length;
-    this.stats.active_domains = this.domains.filter(
+    this.stats.totalDomains = this.domains.length;
+    this.stats.activeDomains = this.domains.filter(
       (domain) => domain.status === DomainStatus.ACTIVE,
     ).length;
-    this.stats.pending_domains = this.domains.filter(
+    this.stats.pendingDomains = this.domains.filter(
       (domain) => domain.status === DomainStatus.PENDING,
     ).length;
-    this.stats.verified_domains = this.domains.filter(
+    this.stats.verifiedDomains = this.domains.filter(
       (domain) => domain.status === DomainStatus.VERIFIED,
     ).length;
-    this.stats.primary_domains = this.domains.filter(
+    this.stats.primaryDomains = this.domains.filter(
       (domain) => domain.domain_type === DomainType.PRIMARY,
     ).length;
-    this.stats.alias_domains = this.domains.filter(
+    this.stats.aliasDomains = this.domains.filter(
       (domain) => domain.domain_type === DomainType.ALIAS,
     ).length;
-    this.stats.customer_domains = this.domains.filter(
+    this.stats.customerDomains = this.domains.filter(
       (domain) => domain.domain_type === DomainType.CUSTOMER,
     ).length;
 
     // Calculate new stats
-    this.stats.vendix_subdomains = this.stats.primary_domains;
-    this.stats.customer_custom_domains = this.stats.customer_domains;
-    this.stats.customer_subdomains = this.stats.alias_domains;
+    this.stats.vendixSubdomains = this.stats.primaryDomains;
+    this.stats.customerCustomDomains = this.stats.customerDomains;
+    this.stats.customerSubdomains = this.stats.aliasDomains;
   }
 
   refreshDomains(): void {

--- a/apps/frontend/src/app/private/modules/super-admin/domains/interfaces/domain.interface.ts
+++ b/apps/frontend/src/app/private/modules/super-admin/domains/interfaces/domain.interface.ts
@@ -161,16 +161,20 @@ export interface DomainTableAction {
 }
 
 export interface DomainStats {
-  total_domains: number;
-  active_domains: number;
-  pending_domains: number;
-  verified_domains: number;
-  customer_domains: number;
-  primary_domains: number;
-  alias_domains: number;
-  vendix_subdomains: number;
-  customer_custom_domains: number;
-  customer_subdomains: number;
+  // Backend response uses camelCase
+  totalDomains: number;
+  activeDomains: number;
+  pendingDomains: number;
+  verifiedDomains: number;
+  customerDomains: number;
+  primaryDomains: number;
+  aliasDomains: number;
+  vendixSubdomains: number;
+  customerCustomDomains: number;
+  customerSubdomains: number;
+  domainsByType?: Record<string, number>;
+  domainsByOwnership?: Record<string, number>;
+  recentDomains?: any[];
 }
 
 export interface PaginatedDomainsResponse {

--- a/skills/vendix-frontend-cache/SKILL.md
+++ b/skills/vendix-frontend-cache/SKILL.md
@@ -1,0 +1,206 @@
+# vendix-frontend-cache
+
+Frontend caching pattern for stats/dashboard endpoints using RxJS `shareReplay` with TTL.
+
+## Trigger
+
+When implementing or modifying stats/dashboard endpoints in Angular services to reduce HTTP requests during navigation.
+
+## Context
+
+Stats and dashboard endpoints are frequently called when users navigate between modules. Without caching, every navigation triggers new HTTP requests even when data hasn't changed.
+
+**Key insight:** In Angular with lazy loading and standalone components, service instances are recreated on navigation. Instance variables don't persist - use **static global cache**.
+
+## Pattern
+
+### Static Global Cache (for simple endpoints)
+
+```typescript
+import { tap, shareReplay } from 'rxjs/operators';
+
+// Static cache outside class (persists across instances)
+interface CacheEntry<T> {
+  observable: T;
+  lastFetch: number;
+}
+
+let statsCache: CacheEntry<Observable<ApiResponse<Stats>>> | null = null;
+
+@Injectable({ providedIn: 'root' })
+export class MyService {
+  private readonly CACHE_TTL = 30000; // 30 seconds
+
+  getStats(): Observable<ApiResponse<Stats>> {
+    const now = Date.now();
+
+    // Return cached if valid
+    if (statsCache && (now - statsCache.lastFetch) < this.CACHE_TTL) {
+      return statsCache.observable;
+    }
+
+    // Create new observable with cache
+    const observable$ = this.http.get<ApiResponse<Stats>>(`${this.apiUrl}/stats`)
+      .pipe(
+        shareReplay({ bufferSize: 1, refCount: false }),
+        tap(() => {
+          if (statsCache) {
+            statsCache.lastFetch = Date.now();
+          }
+        }),
+      );
+
+    statsCache = {
+      observable: observable$,
+      lastFetch: now,
+    };
+
+    return observable$;
+  }
+
+  invalidateCache(): void {
+    statsCache = null;
+  }
+}
+```
+
+### Map-Based Cache (for endpoints with entity IDs)
+
+```typescript
+// Map-based cache for multiple entities
+const storeStatsCache = new Map<number, CacheEntry<Observable<StoreStats>>>();
+
+getStats(storeId: number): Observable<StoreStats> {
+  const now = Date.now();
+  const cached = storeStatsCache.get(storeId);
+
+  if (cached && (now - cached.lastFetch) < this.CACHE_TTL) {
+    return cached.observable;
+  }
+
+  const observable$ = this.http.get<StoreStats>(`${this.apiUrl}/store/${storeId}/stats`)
+    .pipe(
+      shareReplay({ bufferSize: 1, refCount: false }),
+      tap(() => {
+        const entry = storeStatsCache.get(storeId);
+        if (entry) {
+          entry.lastFetch = Date.now();
+        }
+      }),
+    );
+
+  storeStatsCache.set(storeId, {
+    observable: observable$,
+    lastFetch: now,
+  });
+
+  return observable$;
+}
+
+invalidateCache(storeId?: number): void {
+  if (storeId) {
+    storeStatsCache.delete(storeId);
+  } else {
+    storeStatsCache.clear();
+  }
+}
+```
+
+### Conditional Caching (with parameters)
+
+```typescript
+getStats(fromDate?: string, toDate?: string): Observable<Stats> {
+  // Bypass cache with date parameters
+  if (fromDate || toDate) {
+    const params: any = {};
+    if (fromDate) params.from = fromDate;
+    if (toDate) params.to = toDate;
+
+    return this.http.get<Stats>(`${this.apiUrl}/stats`, { params });
+  }
+
+  // Use cache without parameters
+  const now = Date.now();
+  if (statsCache && (now - statsCache.lastFetch) < this.CACHE_TTL) {
+    return statsCache.observable;
+  }
+
+  const observable$ = this.http.get<Stats>(`${this.apiUrl}/stats`)
+    .pipe(
+      shareReplay({ bufferSize: 1, refCount: false }),
+      tap(() => {
+        if (statsCache) {
+          statsCache.lastFetch = Date.now();
+        }
+      }),
+    );
+
+  statsCache = { observable: observable$, lastFetch: now };
+  return observable$;
+}
+```
+
+## Key Points
+
+### When to use cache:
+- Dashboard general stats
+- List of entities without filters
+- Reference data (roles, currencies, etc.)
+
+### When NOT to use cache:
+- Entity-specific endpoints by ID (use Map instead)
+- With date/filters parameters (bypass cache)
+- Real-time data (logs, health metrics)
+- Paginated lists
+
+### Critical Settings:
+- `refCount: false` - Keeps observable alive even without subscribers
+- `bufferSize: 1` - Replay last value to new subscribers
+- `CACHE_TTL = 30000` - 30 second expiration
+- Static variables outside class - Persists across service instances
+
+## Implemented Services
+
+### Super-Admin (17 endpoints)
+- Dashboard Service (6): getDashboardStats, getOrganizationsStats, getUsersStats, getStoresStats, getDomainsStats, getRolesStats
+- Domains Service: getDomainStatsList
+- Organizations Service: getOrganizationStatsList
+- Stores Service: getStoreStatsList
+- Users Service: getUsersStats (conditional)
+- Roles Service: getRolesStats
+- Audit Service: getAuditStats (conditional)
+- Currencies Service: getCurrencyStats
+- Shipping Service: getMethodStats, getZoneStats
+- Payment Methods Service: getPaymentMethodsStats
+- Templates Service: getTemplateStats
+- Legal Documents Service: getAcceptanceStats (Map-based)
+
+### Organization Module (4 endpoints)
+- Dashboard Service: getDashboardStats (Map-based by orgId-period)
+- Users Service: getUsersStats
+- Audit Service: getAuditStats
+- Stores Service: getOrganizationStoreStats
+
+### Store Module (8 endpoints)
+- Dashboard Service: getDashboardStats, getProductsStats (both Map-based)
+- Orders Service: getOrderStats
+- Products Service: getProductStats (Map-based)
+- Inventory Service: getInventoryStats
+- Customers Service: getStats (Map-based)
+- Expenses Service: getExpensesSummary (conditional)
+
+## Cache Invalidation
+
+Call `invalidateCache()` after:
+- Creating a new entity
+- Editing an entity
+- Deleting an entity
+
+Example:
+```typescript
+createItem(data: CreateDto): Observable<Item> {
+  return this.http.post<Item>(this.apiUrl, data).pipe(
+    tap(() => this.invalidateCache())
+  );
+}
+```


### PR DESCRIPTION
Fix stats cards requests/data handling across all modules. Add 30-second TTL cache with shareReplay to reduce frequent requests when navigating between modules.