### PR TITLE
fix(prisma): remove duplicate schema definitions

### DIFF
--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -1369,21 +1369,6 @@ model system_zone_updates {
   @@index([created_at])
 }
 
-// Tracking de cambios en zonas del sistema para notificar a tiendas
-model system_zone_updates {
-  id             Int            @id @default(autoincrement())
-  system_zone_id Int
-  change_type    String         @db.VarChar(50) // 'updated' | 'new_rate' | 'rate_updated' | 'deleted'
-  description    String
-  created_at     DateTime       @default(now()) @db.Timestamp(6)
-
-  // Relación con la zona del sistema
-  system_zone shipping_zones @relation(fields: [system_zone_id], references: [id], onDelete: Cascade)
-
-  @@index([system_zone_id])
-  @@index([created_at])
-}
-
 // ===== ECOMMERCE MODELS =====
 
 model carts {
@@ -1834,11 +1819,6 @@ enum shipping_rate_type_enum {
   price_based
   carrier_calculated
   free
-}
-
-enum zone_source_type_enum {
-  system_copy // Copiada automáticamente del sistema al habilitar un método
-  custom      // Creada desde cero o duplicada para personalizar
 }
 
 enum zone_source_type_enum {


### PR DESCRIPTION
## Summary
- Remove duplicate `system_zone_updates` model definition (lines 1372-1385)
- Remove duplicate `zone_source_type_enum` enum definition (lines 1844-1847)
- Fixes Prisma schema validation error P1012 that blocks `prisma generate` during Docker build

## Context
The deploy was failing at Docker build step `RUN npx prisma generate` because the schema contained exact duplicate definitions — likely from a merge conflict resolution that kept both copies.

## Test plan
- [x] `npx prisma validate` passes locally
- [x] No other duplicate model/enum definitions remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)