### PR TITLE
fix/module_superadmin_users

### DIFF
--- a/apps/backend/src/domains/superadmin/users/users.service.ts
+++ b/apps/backend/src/domains/superadmin/users/users.service.ts
@@ -195,9 +195,29 @@ export class UsersService {
       updateData.password = await bcrypt.hash(updateUserDto.password, 10);
     }
 
+    // Filter out fields that don't exist in the users model
+    const allowedFields = [
+      'first_name',
+      'last_name',
+      'username',
+      'email',
+      'password',
+      'organization_id',
+      'state',
+      'failed_login_attempts',
+      'locked_until',
+    ];
+
+    const sanitizedData: any = {};
+    for (const field of allowedFields) {
+      if (updateData[field] !== undefined) {
+        sanitizedData[field] = updateData[field];
+      }
+    }
+
     const updatedUser = await this.prisma.users.update({
       where: { id },
-      data: updateData,
+      data: sanitizedData,
       include: {
         organizations: true,
         user_roles: {

--- a/apps/frontend/src/app/private/modules/super-admin/users/components/user-edit-modal.component.ts
+++ b/apps/frontend/src/app/private/modules/super-admin/users/components/user-edit-modal.component.ts
@@ -115,25 +115,6 @@ import { Subject, takeUntil } from 'rxjs';
             <label
               class="block text-sm font-medium text-[var(--color-text-primary)]"
             >
-              Aplicación
-            </label>
-            <select
-              formControlName="app"
-              class="w-full px-3 py-2 border border-[var(--color-border)] rounded-md bg-[var(--color-surface)] text-[var(--color-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)] focus:border-[var(--color-primary)]"
-              [disabled]="isUpdating"
-            >
-              <option value="">Seleccionar aplicación</option>
-              <option value="ORG_ADMIN">ORG_ADMIN</option>
-              <option value="STORE_ADMIN">STORE_ADMIN</option>
-              <option value="STORE_ECOMMERCE">STORE_ECOMMERCE</option>
-              <option value="VENDIX_LANDING">VENDIX_LANDING</option>
-            </select>
-          </div>
-
-          <div class="space-y-2">
-            <label
-              class="block text-sm font-medium text-[var(--color-text-primary)]"
-            >
               Estado
             </label>
             <select
@@ -312,7 +293,6 @@ export class UserEditModalComponent implements OnInit, OnChanges, OnDestroy {
     ],
     organization_id: [null, [Validators.required]],
     password: ['', [Validators.minLength(8)]],
-    app: [''],
     state: [UserState.ACTIVE],
   });
 
@@ -340,7 +320,6 @@ export class UserEditModalComponent implements OnInit, OnChanges, OnDestroy {
       username: user.username,
       email: user.email,
       organization_id: user.organization_id,
-      app: user.app || '',
       state: user.state,
       password: '',
     });


### PR DESCRIPTION
Resumen
Corregido error 500 al actualizar usuarios desde el panel de superadmin.

Problema
El formulario enviaba un campo app que no existe en el modelo users de Prisma, causando error 500 en todas las actualizaciones de usuario.

Solución
Frontend: Eliminado campo app del modal de edición
Backend: Agregada validación para filtrar solo campos válidos antes de enviar a Prisma
Cambios
✅ Actualización de email ahora funciona
✅ Todos los campos de usuario son editables
✅ Defensa en profundidad contra campos inválidos en el backend
Archivos modificados
apps/frontend/src/.../user-edit-modal.component.ts
apps/backend/src/.../users.service.ts