### PR TITLE
fix: Add multi-architecture support for Rollup in Dockerfile.dev

### DIFF
--- a/apps/frontend/Dockerfile.dev
+++ b/apps/frontend/Dockerfile.dev
@@ -2,7 +2,11 @@ FROM node:20-alpine
 WORKDIR /app
 COPY package*.json ./
 RUN npm install --legacy-peer-deps --force && \
-    npm install --save-optional @rollup/rollup-linux-arm64-musl --force
+    if [ "$(uname -m)" = "aarch64" ]; then \
+        npm install --save-optional @rollup/rollup-linux-arm64-musl --force; \
+    else \
+        npm install --save-optional @rollup/rollup-linux-x64-musl --force; \
+    fi
 COPY . .
 EXPOSE 4200
 CMD ["npx", "ng", "serve", "--host", "0.0.0.0", "--poll", "2000"]


### PR DESCRIPTION
Detect architecture (aarch64 vs x86_64) and install the appropriate Rollup binary package to support both ARM64 and x64 platforms.