### PR TITLE
feat(products): allow choosing main product image

### DIFF
--- a/apps/frontend/src/app/private/modules/store/products/pages/product-create-page/product-create-page.component.html
+++ b/apps/frontend/src/app/private/modules/store/products/pages/product-create-page/product-create-page.component.html
@@ -482,7 +482,7 @@
 
                                 <!-- Status Badges -->
                                 <div class="absolute top-3 left-3 flex flex-col gap-2">
-                                    <div *ngIf="activeImageIndex === 0"
+                                    <div *ngIf="activeImageIndex === mainImageIndex"
                                         class="px-2 py-1 bg-primary-600/90 text-white text-[10px] font-bold uppercase rounded-md tracking-wider shadow-sm backdrop-blur-sm">
                                         Principal
                                     </div>
@@ -519,8 +519,12 @@
                                 [class.ring-2]="activeImageIndex === i" [class.ring-primary]="activeImageIndex === i"
                                 class="relative flex-none w-16 h-16 bg-white rounded-lg overflow-hidden border border-gray-200 cursor-pointer shadow-sm transition-all hover:border-primary-300">
                                 <img [src]="url" class="w-full h-full object-cover" (error)="onImageError($event)">
-                                <div *ngIf="i === 0" class="absolute top-0 left-0 w-3 h-3 bg-primary-500 rounded-br-md">
-                                </div>
+                                <!-- Star button to mark as main -->
+                                <button type="button" (click)="setMainImage(i); $event.stopPropagation()"
+                                    [class]="i === mainImageIndex ? '!text-yellow-400' : 'text-gray-400 hover:text-yellow-300'"
+                                    class="absolute top-0 right-0 w-6 h-6 flex items-center justify-center bg-black/40 hover:bg-black/60 rounded-bl-md transition-colors">
+                                    <app-icon name="star" size="12"></app-icon>
+                                </button>
                             </div>
 
                             <!-- Small Plus Button (only if < 5) -->

--- a/apps/frontend/src/app/private/modules/store/products/pages/product-create-page/product-create-page.component.ts
+++ b/apps/frontend/src/app/private/modules/store/products/pages/product-create-page/product-create-page.component.ts
@@ -349,6 +349,7 @@ export class ProductCreatePageComponent implements OnInit {
   imageUrls: string[] = [];
   imageIds: (number | null)[] = []; // Parallel array: DB image ID (null for new/unsaved images)
   activeImageIndex = 0;
+  mainImageIndex = 0;
   isStockDetailsOpen = false;
   isReleasingReservations = false;
   categoryOptions: MultiSelectorOption[] = [];
@@ -1378,12 +1379,24 @@ export class ProductCreatePageComponent implements OnInit {
 
     this.imageUrls.splice(index, 1);
     this.imageIds.splice(index, 1);
-    if (this.activeImageIndex >= this.imageUrls.length) {
+    // Adjust mainImageIndex first since activeImageIndex may depend on it
+    if (index === this.mainImageIndex) {
+      this.mainImageIndex = Math.max(0, index - 1);
+      this.activeImageIndex = this.mainImageIndex;
+    } else if (index < this.mainImageIndex) {
+      this.mainImageIndex--;
+      this.activeImageIndex--;
+    } else if (this.activeImageIndex >= this.imageUrls.length) {
       this.activeImageIndex = Math.max(0, this.imageUrls.length - 1);
     }
   }
 
   setActiveImage(index: number): void {
+    this.activeImageIndex = index;
+  }
+
+  setMainImage(index: number): void {
+    this.mainImageIndex = index;
     this.activeImageIndex = index;
   }
 
@@ -1443,7 +1456,7 @@ export class ProductCreatePageComponent implements OnInit {
     const images: CreateProductImageDto[] = this.imageUrls.map(
       (url, index) => ({
         image_url: url,
-        is_main: index === 0,
+        is_main: index === this.mainImageIndex,
       }),
     );
 


### PR DESCRIPTION
- Add mainImageIndex state to track which image is main
- Add setMainImage() method to mark any image as principal
- Add star button on thumbnails to mark image as main (yellow color)
- Fix removeImage() to correctly adjust activeImageIndex when main image is deleted
- Update badge "Principal" to use mainImageIndex instead of hardcoded 0
- Remove deprecated corner indicator div

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
