### PR TITLE
refactor: split options-dropdown into two separate triggers (actions + filters)

### DIFF
--- a/apps/frontend/src/app/shared/components/options-dropdown/options-dropdown.component.html
+++ b/apps/frontend/src/app/shared/components/options-dropdown/options-dropdown.component.html
@@ -1,15 +1,31 @@
 <div class="options-dropdown-container" #dropdownContainer>
-  <!-- Trigger Button -->
+  <!-- Actions Trigger (Left) -->
   <button
-    #triggerButton
+    *ngIf="hasActions"
+    #actionsTriggerButton
     type="button"
-    class="options-dropdown-trigger"
-    (click)="toggleDropdown()"
-    [attr.aria-expanded]="isOpen"
+    class="options-dropdown-trigger actions-trigger"
+    (click)="toggleActionsDropdown()"
+    [attr.aria-expanded]="isActionsOpen"
     [attr.aria-haspopup]="true"
   >
-    <app-icon [name]="triggerIcon" [size]="18"></app-icon>
-    <span class="trigger-label-text">{{ triggerLabel }}</span>
+    <app-icon name="zap" [size]="16"></app-icon>
+    <span class="trigger-label-text">Acciones</span>
+    <app-icon name="chevron-down" [size]="14" class="chevron-icon"></app-icon>
+  </button>
+
+  <!-- Filters Trigger (Right) -->
+  <button
+    *ngIf="hasFilters"
+    #filtersTriggerButton
+    type="button"
+    class="options-dropdown-trigger filters-trigger"
+    (click)="toggleFiltersDropdown()"
+    [attr.aria-expanded]="isFiltersOpen"
+    [attr.aria-haspopup]="true"
+  >
+    <app-icon name="filter" [size]="16"></app-icon>
+    <span class="trigger-label-text">Filtros</span>
     <span
       *ngIf="activeFiltersCount > 0"
       class="filter-count-badge"
@@ -20,15 +36,42 @@
     <app-icon name="chevron-down" [size]="14" class="chevron-icon"></app-icon>
   </button>
 
-  <!-- Dropdown Content -->
+  <!-- Actions Dropdown Content -->
   <div
-    *ngIf="isOpen"
-    class="options-dropdown-content"
+    *ngIf="isActionsOpen && hasActions"
+    class="options-dropdown-content actions-dropdown"
     [class.mobile-fixed]="isMobileOrTablet"
     (click)="$event.stopPropagation()"
   >
     <div class="dropdown-header">
-      <h3 class="dropdown-title">{{ title }}</h3>
+      <h3 class="dropdown-title">Acciones</h3>
+    </div>
+
+    <div class="actions-list">
+      <button
+        *ngFor="let action of actions"
+        class="action-item"
+        [class.action-primary]="action.variant === 'primary'"
+        [class.action-destructive]="action.variant === 'destructive'"
+        [disabled]="action.disabled || false"
+        (click)="onActionClick(action.action)"
+        type="button"
+      >
+        <app-icon [name]="action.icon" [size]="16"></app-icon>
+        <span>{{ action.label }}</span>
+      </button>
+    </div>
+  </div>
+
+  <!-- Filters Dropdown Content -->
+  <div
+    *ngIf="isFiltersOpen && hasFilters"
+    class="options-dropdown-content filters-dropdown"
+    [class.mobile-fixed]="isMobileOrTablet"
+    (click)="$event.stopPropagation()"
+  >
+    <div class="dropdown-header">
+      <h3 class="dropdown-title">Filtros</h3>
       <button
         *ngIf="activeFiltersCount > 0"
         class="clear-all-btn"
@@ -36,12 +79,12 @@
         type="button"
       >
         <app-icon name="x" [size]="14"></app-icon>
-        Limpiar todos
+        Limpiar
       </button>
     </div>
 
-    <!-- Filters Section -->
-    <div *ngIf="filters.length > 0" class="filters-body">
+    <!-- Filters Body -->
+    <div class="filters-body">
       <ng-container *ngFor="let filter of filters">
         <div class="filter-section">
           <div class="filter-section-header">
@@ -97,27 +140,6 @@
           </div>
         </div>
       </ng-container>
-    </div>
-
-    <!-- Actions Section -->
-    <div *ngIf="actions.length > 0" class="actions-section">
-      <div class="actions-header">
-        <span class="actions-title">Acciones</span>
-      </div>
-      <div class="actions-list">
-        <button
-          *ngFor="let action of actions"
-          class="action-item"
-          [class.action-primary]="action.variant === 'primary'"
-          [class.action-destructive]="action.variant === 'destructive'"
-          [disabled]="action.disabled || false"
-          (click)="onActionClick(action.action)"
-          type="button"
-        >
-          <app-icon [name]="action.icon" [size]="16"></app-icon>
-          <span>{{ action.label }}</span>
-        </button>
-      </div>
     </div>
   </div>
 </div>

--- a/apps/frontend/src/app/shared/components/options-dropdown/options-dropdown.component.scss
+++ b/apps/frontend/src/app/shared/components/options-dropdown/options-dropdown.component.scss
@@ -3,7 +3,9 @@
 
 .options-dropdown-container {
   position: relative;
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
   // Stacking context for dropdown content; must stay below sidebar backdrop (z-index: 54)
   z-index: var(--z-dropdown);
   // Ensure dropdown can overflow outside this container
@@ -19,17 +21,16 @@
   font-weight: var(--fw-medium);
   font-family: var(--font-primary);
   background-color: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: 0.75rem;
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-md);
   color: var(--color-text-primary);
-  min-width: 120px;
-  transition: all 0.2s ease;
+  min-width: 110px;
+  transition: all var(--transition-fast) ease;
   cursor: pointer;
 
   &:hover {
     background-color: var(--color-surface);
-    border-color: var(--color-primary);
-    box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+    border-color: var(--color-text-secondary);
   }
 
   &:focus {
@@ -39,7 +40,7 @@
   }
 
   &:active {
-    transform: scale(0.97);
+    transform: scale(0.98);
   }
 
   .trigger-label-text {
@@ -49,17 +50,81 @@
   .chevron-icon {
     margin-left: auto;
   }
+
+  // Actions trigger styles
+  &.actions-trigger {
+    .filter-count-badge {
+      display: none;
+    }
+  }
+
+  // Filters trigger styles
+  &.filters-trigger {
+    // Additional styles if needed
+  }
 }
 
 // Responsive: Compact mode for mobile/tablet
 @media (max-width: 1023px) {
+  .options-dropdown-container {
+    flex-direction: row;
+    align-items: center;
+    gap: 0.5rem;
+    width: 100%;
+  }
+
   .options-dropdown-trigger {
     min-width: auto;
-    width: 40px;
+    flex: 1;
     height: 40px;
+    padding: 0 0.75rem;
+
+    &.actions-trigger {
+      order: 1;
+    }
+
+    &.filters-trigger {
+      order: 2;
+    }
+
+    .trigger-label-text {
+      display: inline;
+    }
+
+    .chevron-icon {
+      display: inline-flex;
+      margin-left: auto;
+    }
+
+    .filter-count-badge {
+      position: absolute;
+      top: -4px;
+      right: -4px;
+      margin-left: 0;
+    }
+  }
+
+  .options-dropdown-content {
+    &.actions-dropdown,
+    &.filters-dropdown {
+      left: 0 !important;
+      right: 0 !important;
+      width: 100%;
+      max-width: 100%;
+      transform: none !important;
+    }
+  }
+}
+
+// Small mobile - icon only mode
+@media (max-width: 640px) {
+  .options-dropdown-trigger {
+    min-width: 44px;
+    width: 44px;
+    height: 44px;
     padding: 0;
     justify-content: center;
-    border-radius: 0.75rem;
+    flex: none;
 
     .trigger-label-text {
       display: none;
@@ -71,14 +136,25 @@
 
     .filter-count-badge {
       position: absolute;
-      top: -4px;
-      right: -4px;
+      top: -2px;
+      right: -2px;
       margin-left: 0;
     }
   }
 
   .options-dropdown-container {
-    position: relative;
+    justify-content: flex-end;
+  }
+
+  .options-dropdown-content {
+    &.actions-dropdown,
+    &.filters-dropdown {
+      left: auto !important;
+      right: 0 !important;
+      width: calc(100vw - 2rem);
+      max-width: 320px;
+      transform: translateX(0) !important;
+    }
   }
 }
 
@@ -86,31 +162,41 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 1.25rem;
+  min-width: 1.25rem;
   height: 1.25rem;
+  padding: 0 0.375rem;
   font-size: var(--fs-xs);
-  font-weight: var(--fw-bold);
+  font-weight: var(--fw-semibold);
   background-color: var(--color-primary);
   color: var(--color-text-on-primary);
-  border-radius: 50%;
+  border-radius: 0.625rem;
   margin-left: auto;
 }
 
 .options-dropdown-content {
   position: absolute;
   top: 100%;
-  right: 0;
   margin-top: 0.5rem;
   width: 20rem;
   max-width: 90vw;
   max-height: 80vh;
   background-color: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: 0.75rem;
-  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
   overflow: hidden;
   font-family: var(--font-primary);
   z-index: 99999;
+
+  // Actions dropdown: align to left
+  &.actions-dropdown {
+    left: 0;
+  }
+
+  // Filters dropdown: align to right
+  &.filters-dropdown {
+    right: 0;
+  }
 }
 
 .dropdown-header {
@@ -118,7 +204,7 @@
   align-items: center;
   justify-content: space-between;
   padding: 0.75rem 1rem;
-  border-bottom: 1px solid var(--color-border);
+  border-bottom: var(--border-width) solid var(--color-border);
   background-color: var(--color-surface);
 }
 
@@ -137,41 +223,61 @@
   color: var(--color-text-secondary);
   background-color: transparent;
   border: none;
-  padding: 0.25rem;
-  border-radius: 0.25rem;
+  padding: 0.375rem 0.5rem;
+  border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: all var(--transition-fast) ease;
 
   &:hover {
     color: var(--color-destructive);
-    background-color: rgba(239, 68, 68, 0.1);
+    background-color: rgba(239, 68, 68, 0.08);
   }
 
   &:focus {
     outline: none;
-    box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.5);
+    box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.2);
   }
 }
 
 .filters-body {
-  padding: 1rem;
-  max-height: 60vh;
+  padding: 0.75rem 1rem;
+  max-height: 40vh;
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.75rem;
+
+  // Custom scrollbar
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: var(--color-background);
+    border-radius: 3px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: var(--color-border);
+    border-radius: 3px;
+
+    &:hover {
+      background: var(--color-text-secondary);
+    }
+  }
 }
 
 .filter-section {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.375rem;
 }
 
 .filter-section-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 0.5rem;
 }
 
 .filter-label {
@@ -179,7 +285,6 @@
   font-size: var(--fs-sm);
   font-weight: var(--fw-medium);
   color: var(--color-text-primary);
-  margin-bottom: 0.25rem;
 }
 
 .clear-filter-btn {
@@ -188,29 +293,29 @@
   justify-content: center;
   width: 1.25rem;
   height: 1.25rem;
-  color: var(--color-text-secondary);
+  color: var(--color-text-muted);
   background-color: transparent;
   border: none;
-  border-radius: 0.25rem;
+  border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: all var(--transition-fast) ease;
   flex-shrink: 0;
 
   &:hover {
     color: var(--color-destructive);
-    background-color: rgba(239, 68, 68, 0.1);
+    background-color: rgba(239, 68, 68, 0.08);
   }
 
   &:focus {
     outline: none;
-    box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.5);
+    box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.2);
   }
 }
 
 .filter-help-text {
   font-size: var(--fs-xs);
   color: var(--color-text-secondary);
-  margin-top: 0.25rem;
+  margin-top: 0.125rem;
 }
 
 .date-filter-input {
@@ -218,11 +323,11 @@
   padding: 0.375rem 0.75rem;
   font-size: var(--fs-sm);
   font-family: var(--font-primary);
-  border: 1px solid var(--color-border);
-  border-radius: 0.5rem;
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-sm);
   background-color: var(--color-surface);
   color: var(--color-text-primary);
-  transition: all 0.2s ease;
+  transition: all var(--transition-fast) ease;
 
   &:focus {
     outline: none;
@@ -236,50 +341,33 @@
   }
 }
 
-// Actions Section
-.actions-section {
-  border-top: 1px solid var(--color-border);
-}
-
-.actions-header {
-  padding: 0.5rem 1rem;
-  background-color: var(--color-surface-secondary);
-}
-
-.actions-title {
-  font-size: var(--fs-xs);
-  font-weight: var(--fw-semibold);
-  color: var(--color-text-secondary);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
+// Actions List (direct in dropdown)
 .actions-list {
   padding: 0.5rem;
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.125rem;
 }
 
 .action-item {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.625rem;
   width: 100%;
-  padding: 0.625rem 0.75rem;
+  padding: 0.5rem 0.625rem;
   font-size: var(--fs-sm);
   font-weight: var(--fw-medium);
   font-family: var(--font-primary);
   color: var(--color-text-primary);
   background-color: transparent;
   border: none;
-  border-radius: 0.375rem;
+  border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: all 0.15s ease;
+  transition: all var(--transition-fast) ease;
   text-align: left;
 
   &:hover:not(:disabled) {
-    background-color: var(--color-surface-secondary);
+    background-color: var(--color-background);
   }
 
   &:focus {
@@ -300,7 +388,7 @@
     color: var(--color-primary);
 
     &:hover:not(:disabled) {
-      background-color: rgba(var(--color-primary-rgb, 59, 130, 246), 0.1);
+      background-color: rgba(var(--color-primary-rgb, 59, 130, 246), 0.08);
     }
   }
 
@@ -308,7 +396,7 @@
     color: var(--color-destructive);
 
     &:hover:not(:disabled) {
-      background-color: rgba(239, 68, 68, 0.1);
+      background-color: rgba(239, 68, 68, 0.08);
     }
   }
 }
@@ -317,30 +405,66 @@
 .options-dropdown-content.mobile-fixed {
   position: absolute;
   top: calc(100% + 4px);
-  right: 0;
-  left: auto;
-  bottom: auto;
   width: auto;
   min-width: 14rem;
   max-width: min(18rem, calc(100vw - 1rem));
   margin-top: 0;
   max-height: 70vh;
-  border-radius: 0.75rem;
-  box-shadow: 0 4px 25px -5px rgba(0, 0, 0, 0.15),
-    0 10px 10px -5px rgba(0, 0, 0, 0.04);
+  border-radius: var(--radius-md);
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+
+  &.actions-dropdown {
+    left: 0;
+    right: auto;
+  }
+
+  &.filters-dropdown {
+    right: 0;
+    left: auto;
+  }
 }
 
 @media (max-width: 1023px) {
   .filters-body {
-    max-height: 50vh;
+    max-height: 35vh;
+  }
+
+  .actions-list {
+    gap: 0.125rem;
+  }
+
+  .action-item {
+    padding: 0.5rem 0.625rem;
+  }
+
+  .options-dropdown-content.mobile-fixed {
+    &.actions-dropdown,
+    &.filters-dropdown {
+      left: 0 !important;
+      right: 0 !important;
+      width: 100%;
+      max-width: 100%;
+    }
   }
 }
 
-// Small mobile - slightly wider dropdown but still aligned to button
+// Small mobile - icon only triggers, dropdowns aligned to right
 @media (max-width: 640px) {
   .options-dropdown-content.mobile-fixed {
     min-width: 14rem;
-    max-width: min(18rem, calc(100vw - 1rem));
+    max-width: calc(100vw - 2rem);
+
+    &.actions-dropdown,
+    &.filters-dropdown {
+      left: auto !important;
+      right: 0 !important;
+      max-width: calc(100vw - 2rem);
+    }
+  }
+
+  .filters-body {
+    padding: 0.625rem 0.75rem;
+    gap: 0.625rem;
   }
 }
 
@@ -351,5 +475,5 @@
 
 .clear-all-btn:focus-visible,
 .clear-filter-btn:focus-visible {
-  box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.5);
+  box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.2);
 }

--- a/apps/frontend/src/app/shared/components/options-dropdown/options-dropdown.component.ts
+++ b/apps/frontend/src/app/shared/components/options-dropdown/options-dropdown.component.ts
@@ -78,11 +78,13 @@ export class OptionsDropdownComponent implements OnChanges, OnDestroy {
   @Output() clearAllFilters = new EventEmitter<void>();
 
   @ViewChild('dropdownContainer') dropdownContainer!: ElementRef<HTMLElement>;
-  @ViewChild('triggerButton') triggerButton!: ElementRef<HTMLButtonElement>;
+  @ViewChild('actionsTriggerButton') actionsTriggerButton!: ElementRef<HTMLButtonElement>;
+  @ViewChild('filtersTriggerButton') filtersTriggerButton!: ElementRef<HTMLButtonElement>;
 
   private cdr = inject(ChangeDetectorRef);
 
-  isOpen: boolean = false;
+  isActionsOpen: boolean = false;
+  isFiltersOpen: boolean = false;
   activeFiltersCount: number = 0;
 
   /** Position for mobile dropdown */
@@ -144,8 +146,19 @@ export class OptionsDropdownComponent implements OnChanges, OnDestroy {
     this.activeFiltersCount = count;
   }
 
-  toggleDropdown(): void {
-    this.isOpen = !this.isOpen;
+  toggleActionsDropdown(): void {
+    this.isActionsOpen = !this.isActionsOpen;
+    this.isFiltersOpen = false;
+  }
+
+  toggleFiltersDropdown(): void {
+    this.isFiltersOpen = !this.isFiltersOpen;
+    this.isActionsOpen = false;
+  }
+
+  closeAllDropdowns(): void {
+    this.isActionsOpen = false;
+    this.isFiltersOpen = false;
   }
 
   private calculateDropdownPosition(): void {
@@ -155,7 +168,7 @@ export class OptionsDropdownComponent implements OnChanges, OnDestroy {
   }
 
   closeDropdown(): void {
-    this.isOpen = false;
+    this.closeAllDropdowns();
   }
 
   @HostListener('document:click', ['$event'])
@@ -164,7 +177,7 @@ export class OptionsDropdownComponent implements OnChanges, OnDestroy {
       this.dropdownContainer &&
       !this.dropdownContainer.nativeElement.contains(event.target as Node)
     ) {
-      this.closeDropdown();
+      this.closeAllDropdowns();
     }
   }
 
@@ -175,7 +188,7 @@ export class OptionsDropdownComponent implements OnChanges, OnDestroy {
 
   @HostListener('window:scroll')
   onWindowScroll(): void {
-    if (this.isOpen) {
+    if (this.isActionsOpen || this.isFiltersOpen) {
       this.calculateDropdownPosition();
     }
   }
@@ -228,7 +241,15 @@ export class OptionsDropdownComponent implements OnChanges, OnDestroy {
 
   onActionClick(action: string): void {
     this.actionClick.emit(action);
-    this.closeDropdown();
+    this.closeAllDropdowns();
+  }
+
+  get hasActions(): boolean {
+    return this.actions.length > 0;
+  }
+
+  get hasFilters(): boolean {
+    return this.filters.length > 0;
   }
 
   /**


### PR DESCRIPTION
## Problem
- Single dropdown became too tall with many filters
- Actions were hidden at the bottom, requiring scroll
- Poor UX on mobile devices with limited vertical space

## Solution
Divided the `options-dropdown` component into two independent triggers:

### **Left Trigger: Actions** ⚡
- Always visible, opens compact action dropdown
- No scroll needed to access actions

### **Right Trigger: Filters** 🔍
- Collapsible, opens filter dropdown with custom scrollbar
- Badge shows active filter count
- Mobile optimization: icon-only mode (≤640px)

## Changes
- **TypeScript**: Split `isOpen` into `isActionsOpen` and `isFiltersOpen`
- **HTML**: Two separate trigger buttons with independent dropdowns
- **SCSS**: Responsive layout with flex container, icon-only mode for small screens

## Benefits
✅ Actions always accessible without scroll
✅ Compact filter dropdown with custom scrollbar
✅ Better horizontal space utilization
✅ Touch-friendly 44x44px buttons on mobile
✅ Dropdowns don't get cut off on mobile