### PR TITLE
fix: agregar espacio al final de páginas del admin

### DIFF
--- a/apps/frontend/src/app/private/modules/store/analytics/pages/customers/customer-summary.component.html
+++ b/apps/frontend/src/app/private/modules/store/analytics/pages/customers/customer-summary.component.html
@@ -1,4 +1,4 @@
-<div>
+<div class="pb-6">
   <!-- Stats Cards -->
   @if (loading$ | async) {
     <div class="stats-container">

--- a/apps/frontend/src/app/private/modules/store/analytics/pages/sales/sales-summary/sales-summary.component.html
+++ b/apps/frontend/src/app/private/modules/store/analytics/pages/sales/sales-summary/sales-summary.component.html
@@ -1,4 +1,4 @@
-<div>
+<div class="pb-6">
   <!-- Stats Cards -->
   @if (loading$ | async) {
     <div class="stats-container">

--- a/apps/frontend/src/app/private/modules/store/dashboard/dashboard.component.ts
+++ b/apps/frontend/src/app/private/modules/store/dashboard/dashboard.component.ts
@@ -62,7 +62,7 @@ const QUICK_LINKS: QuickLink[] = [
     OptionsDropdownComponent,
   ],
   template: `
-    <div class="w-full space-y-4">
+    <div class="w-full space-y-4 pb-6">
       <!-- 4 Stats Cards -->
       <div class="stats-container">
         <app-stats


### PR DESCRIPTION
## Summary
- Agregar `pb-6` (padding-bottom) al dashboard de store admin (`/admin/dashboard`)
- Agregar `pb-6` a sales-summary para separador al final
- Agregar `pb-6` a customer-summary para separador al final

## Issue
QUI-280, QUI-282, QUI-284

## Test plan
- [x] Verificar que `/admin/dashboard` tenga espacio al final
- [x] Verificar que `/admin/analytics/sales/summary` tenga espacio al final
- [x] Verificar que `/admin/analytics/customers/summary` tenga espacio al final