### PR TITLE
fix: agregar @Min(1) a product_id en DTOs del carrito

### DIFF
--- a/apps/backend/src/domains/ecommerce/cart/dto/cart.dto.ts
+++ b/apps/backend/src/domains/ecommerce/cart/dto/cart.dto.ts
@@ -3,6 +3,7 @@ import { Type } from 'class-transformer';
 
 export class AddToCartDto {
     @IsInt()
+    @Min(1)
     product_id: number;
 
     @IsOptional()
@@ -22,6 +23,7 @@ export class UpdateCartItemDto {
 
 export class SyncCartItemDto {
     @IsInt()
+    @Min(1)
     product_id: number;
 
     @IsOptional()

--- a/bruno/Vendix/Store/Cart/Error Cases/Add to Cart - product_id negative.bru
+++ b/bruno/Vendix/Store/Cart/Error Cases/Add to Cart - product_id negative.bru
@@ -1,0 +1,33 @@
+meta {
+  name: Add to Cart - product_id negative
+  type: http
+  seq: 2
+}
+
+post {
+  url: http://{{baseUrl}}/ecommerce/cart/items
+  body: json
+  headers: {
+    Authorization: Bearer {{customerToken}}
+    Content-Type: application/json
+  }
+}
+
+body:json {
+  {
+    "product_id": -1,
+    "quantity": 1
+  }
+}
+
+tests {
+  test("negative product_id is rejected", function() {
+    expect(res.status).to.equal(400);
+    expect(res.body.success).to.equal(false);
+  });
+
+  test("validation error mentions product_id", function() {
+    const errorMsg = JSON.stringify(res.body);
+    expect(errorMsg).to.include('product_id');
+  });
+}

--- a/bruno/Vendix/Store/Cart/Error Cases/Add to Cart - product_id zero.bru
+++ b/bruno/Vendix/Store/Cart/Error Cases/Add to Cart - product_id zero.bru
@@ -1,0 +1,33 @@
+meta {
+  name: Add to Cart - product_id zero
+  type: http
+  seq: 1
+}
+
+post {
+  url: http://{{baseUrl}}/ecommerce/cart/items
+  body: json
+  headers: {
+    Authorization: Bearer {{customerToken}}
+    Content-Type: application/json
+  }
+}
+
+body:json {
+  {
+    "product_id": 0,
+    "quantity": 1
+  }
+}
+
+tests {
+  test("product_id 0 is rejected", function() {
+    expect(res.status).to.equal(400);
+    expect(res.body.success).to.equal(false);
+  });
+
+  test("validation error mentions product_id", function() {
+    const errorMsg = JSON.stringify(res.body);
+    expect(errorMsg).to.include('product_id');
+  });
+}

--- a/bruno/Vendix/Store/Cart/Error Cases/Add to Cart - quantity zero.bru
+++ b/bruno/Vendix/Store/Cart/Error Cases/Add to Cart - quantity zero.bru
@@ -1,0 +1,33 @@
+meta {
+  name: Add to Cart - quantity zero
+  type: http
+  seq: 3
+}
+
+post {
+  url: http://{{baseUrl}}/ecommerce/cart/items
+  body: json
+  headers: {
+    Authorization: Bearer {{customerToken}}
+    Content-Type: application/json
+  }
+}
+
+body:json {
+  {
+    "product_id": 1,
+    "quantity": 0
+  }
+}
+
+tests {
+  test("quantity 0 is rejected", function() {
+    expect(res.status).to.equal(400);
+    expect(res.body.success).to.equal(false);
+  });
+
+  test("validation error mentions quantity", function() {
+    const errorMsg = JSON.stringify(res.body);
+    expect(errorMsg).to.include('quantity');
+  });
+}

--- a/bruno/Vendix/Store/Cart/Error Cases/folder.bru
+++ b/bruno/Vendix/Store/Cart/Error Cases/folder.bru
@@ -1,0 +1,4 @@
+meta {
+  name: Error Cases
+  type: http
+}

--- a/bruno/Vendix/Store/Cart/folder.bru
+++ b/bruno/Vendix/Store/Cart/folder.bru
@@ -1,0 +1,4 @@
+meta {
+  name: Cart
+  type: http
+}


### PR DESCRIPTION
## Summary
- Agregar decorador `@Min(1)` a `product_id` en `AddToCartDto` y `SyncCartItemDto`
- Validación existente `@IsInt()` solo verificaba tipo, ahora también valida rango positivo

## Test plan
- [x] Verificar que `product_id: 0` es rechazado con error de validación
- [x] Verificar que `product_id: -1` es rechazado con error de validación
- [x] Verificar que `product_id: 1` pasa validación correctamente