### PR TITLE
fix: agregar @Min(1) a campos de ID en DTOs de checkout y wishlist

### DIFF
--- a/apps/backend/src/domains/ecommerce/checkout/dto/checkout.dto.ts
+++ b/apps/backend/src/domains/ecommerce/checkout/dto/checkout.dto.ts
@@ -78,6 +78,7 @@ export class CheckoutDto {
 
 class CheckoutBookingDto {
   @IsInt()
+  @Min(1)
   product_id: number;
 
   @IsDateString()

--- a/apps/backend/src/domains/ecommerce/checkout/dto/checkout.dto.ts
+++ b/apps/backend/src/domains/ecommerce/checkout/dto/checkout.dto.ts
@@ -11,6 +11,21 @@ import {
 } from 'class-validator';
 import { Type } from 'class-transformer';
 
+class CheckoutCartItemDto {
+  @IsInt()
+  @Min(1)
+  product_id: number;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  product_variant_id?: number;
+
+  @IsInt()
+  @Min(1)
+  quantity: number;
+}
+
 export class CheckoutDto {
   // Booking selections for bookable services
   @IsOptional()
@@ -21,10 +36,12 @@ export class CheckoutDto {
 
   @IsOptional()
   @IsInt()
+  @Min(1)
   shipping_method_id?: number;
 
   @IsOptional()
   @IsInt()
+  @Min(1)
   shipping_rate_id?: number;
 
   @IsOptional()

--- a/apps/backend/src/domains/ecommerce/checkout/dto/checkout.dto.ts
+++ b/apps/backend/src/domains/ecommerce/checkout/dto/checkout.dto.ts
@@ -1,77 +1,80 @@
-import { IsInt, IsOptional, IsString, IsObject, IsArray, ValidateNested, Min, IsDateString, Matches } from 'class-validator';
+import {
+  IsInt,
+  IsOptional,
+  IsString,
+  IsObject,
+  IsArray,
+  ValidateNested,
+  Min,
+  IsDateString,
+  Matches,
+} from 'class-validator';
 import { Type } from 'class-transformer';
 
-class CheckoutCartItemDto {
-  @IsInt()
-  product_id: number;
+export class CheckoutDto {
+  // Booking selections for bookable services
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CheckoutBookingDto)
+  bookings?: CheckoutBookingDto[];
 
   @IsOptional()
   @IsInt()
-  product_variant_id?: number;
+  shipping_method_id?: number;
+
+  @IsOptional()
+  @IsInt()
+  shipping_rate_id?: number;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  shipping_address_id?: number;
+
+  @IsOptional()
+  @IsObject()
+  shipping_address?: {
+    address_line1: string;
+    address_line2?: string;
+    city: string;
+    state_province?: string;
+    country_code: string;
+    postal_code?: string;
+    phone_number?: string;
+  };
 
   @IsInt()
   @Min(1)
-  quantity: number;
-}
+  payment_method_id: number;
 
-export class CheckoutDto {
-    // Booking selections for bookable services
-    @IsOptional()
-    @IsArray()
-    @ValidateNested({ each: true })
-    @Type(() => CheckoutBookingDto)
-    bookings?: CheckoutBookingDto[];
+  @IsOptional()
+  @IsString()
+  notes?: string;
 
-    @IsOptional()
-    @IsInt()
-    shipping_method_id?: number;
-
-    @IsOptional()
-    @IsInt()
-    shipping_rate_id?: number;
-
-    @IsOptional()
-    @IsInt()
-    shipping_address_id?: number;
-
-    @IsOptional()
-    @IsObject()
-    shipping_address?: {
-        address_line1: string;
-        address_line2?: string;
-        city: string;
-        state_province?: string;
-        country_code: string;
-        postal_code?: string;
-        phone_number?: string;
-    };
-
-    @IsInt()
-    payment_method_id: number;
-
-    @IsOptional()
-    @IsString()
-    notes?: string;
-
-    @IsOptional()
-    @IsArray()
-    @ValidateNested({ each: true })
-    @Type(() => CheckoutCartItemDto)
-    items?: CheckoutCartItemDto[];
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CheckoutCartItemDto)
+  items?: CheckoutCartItemDto[];
 }
 
 class CheckoutBookingDto {
-    @IsInt()
-    product_id: number;
+  @IsInt()
+  product_id: number;
 
-    @IsDateString()
-    date: string;
+  @IsDateString()
+  date: string;
 
-    @IsString()
-    @Matches(/^([01]\d|2[0-3]):([0-5]\d)$/, { message: 'start_time debe tener formato HH:mm' })
-    start_time: string;
+  @IsString()
+  @Matches(/^([01]\d|2[0-3]):([0-5]\d)$/, {
+    message: 'start_time debe tener formato HH:mm',
+  })
+  start_time: string;
 
-    @IsString()
-    @Matches(/^([01]\d|2[0-3]):([0-5]\d)$/, { message: 'end_time debe tener formato HH:mm' })
-    end_time: string;
+  @IsString()
+  @Matches(/^([01]\d|2[0-3]):([0-5]\d)$/, {
+    message: 'end_time debe tener formato HH:mm',
+  })
+  end_time: string;
 }

--- a/apps/backend/src/domains/ecommerce/wishlist/dto/wishlist.dto.ts
+++ b/apps/backend/src/domains/ecommerce/wishlist/dto/wishlist.dto.ts
@@ -1,10 +1,12 @@
-import { IsInt, IsOptional } from 'class-validator';
+import { IsInt, IsOptional, Min } from 'class-validator';
 
 export class AddToWishlistDto {
     @IsInt()
+    @Min(1)
     product_id: number;
 
     @IsOptional()
     @IsInt()
+    @Min(1)
     product_variant_id?: number;
 }

--- a/bruno/Vendix/Store/Checkout/Checkout - ID Cero.bru
+++ b/bruno/Vendix/Store/Checkout/Checkout - ID Cero.bru
@@ -1,0 +1,33 @@
+meta {
+  name: Checkout - Validacion Min(1) IDs
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{url}}/ecommerce/checkout
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "payment_method_id": 0,
+    "items": [
+      {
+        "product_id": 0,
+        "quantity": 1
+      }
+    ]
+  }
+}
+
+tests {
+  test("Debe fallar con payment_method_id = 0", function() {
+    expect(res.status).to.equal(400);
+  });
+  
+  test("Error debe mencionar validation error", function() {
+    expect(res.body.message).to.include("validation");
+  });
+}

--- a/bruno/Vendix/Store/Checkout/Checkout - IDs Validos.bru
+++ b/bruno/Vendix/Store/Checkout/Checkout - IDs Validos.bru
@@ -12,10 +12,10 @@ post {
 
 body:json {
   {
-    "payment_method_id": 1,
+    "payment_method_id": 5,
     "items": [
       {
-        "product_id": 1,
+        "product_id": 20,
         "quantity": 2
       }
     ]

--- a/bruno/Vendix/Store/Checkout/Checkout - IDs Validos.bru
+++ b/bruno/Vendix/Store/Checkout/Checkout - IDs Validos.bru
@@ -1,0 +1,29 @@
+meta {
+  name: Checkout - Con IDs validos
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{url}}/ecommerce/checkout
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "payment_method_id": 1,
+    "items": [
+      {
+        "product_id": 1,
+        "quantity": 2
+      }
+    ]
+  }
+}
+
+tests {
+  test("No debe ser 400 por validacion de IDs", function() {
+    expect(res.status).to.not.equal(400);
+  });
+}

--- a/bruno/Vendix/Store/Checkout/Create Product Test.bru
+++ b/bruno/Vendix/Store/Checkout/Create Product Test.bru
@@ -1,0 +1,33 @@
+meta {
+  name: Create Product Test
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{url}}/store/products
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "name": "Producto Prueba Checkout",
+    "base_price": 10000,
+    "sku": "PROD-TEST-001",
+    "stock_quantity": 100,
+    "track_inventory": true,
+    "available_for_ecommerce": true,
+    "state": "active"
+  }
+}
+
+tests {
+  test("Debe crear producto exitosamente", function() {
+    expect(res.status).to.equal(201);
+  });
+  
+  test("Debe retornar el ID del producto", function() {
+    expect(res.body.data.id).to.be.greaterThan(0);
+  });
+}

--- a/bruno/Vendix/Store/Checkout/Get Payment Methods.bru
+++ b/bruno/Vendix/Store/Checkout/Get Payment Methods.bru
@@ -1,0 +1,16 @@
+meta {
+  name: Get Payment Methods
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{url}}/ecommerce/checkout/payment-methods
+  auth: inherit
+}
+
+tests {
+  test("Debe retornar metodos de pago", function() {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/bruno/Vendix/Store/Wishlist/Wishlist - product_id Cero.bru
+++ b/bruno/Vendix/Store/Wishlist/Wishlist - product_id Cero.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Wishlist - Validacion Min(1) product_id
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{url}}/ecommerce/wishlist
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "product_id": 0
+  }
+}
+
+tests {
+  test("Debe fallar con product_id = 0", function() {
+    expect(res.status).to.equal(400);
+  });
+  
+  test("Error debe mencionar validation error", function() {
+    expect(res.body.message).to.include("validation");
+  });
+}

--- a/bruno/Vendix/Store/Wishlist/Wishlist - product_id Valido.bru
+++ b/bruno/Vendix/Store/Wishlist/Wishlist - product_id Valido.bru
@@ -1,0 +1,23 @@
+meta {
+  name: Wishlist - Con product_id valido
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{url}}/ecommerce/wishlist
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "product_id": 1
+  }
+}
+
+tests {
+  test("No debe ser 400 por validacion de ID", function() {
+    expect(res.status).to.not.equal(400);
+  });
+}


### PR DESCRIPTION
## Summary
- Agregar `@Min(1)` a `payment_method_id` y `shipping_address_id` en `CheckoutDto`
- Agregar `@Min(1)` a `product_id` y `product_variant_id` en `AddToWishlistDto`

Previene valores 0 o negativos en campos de ID que podrían causar errores en la lógica de negocio.

## Test plan
- [x] Verificar que el build compile sin errores
- [x] Verificar que los tests existentes pasen