### PR TITLE
fix: improve invoice OCR prompt and image preprocessing

### DIFF
--- a/apps/backend/prisma/seeds/ai-engine-apps.seed.ts
+++ b/apps/backend/prisma/seeds/ai-engine-apps.seed.ts
@@ -30,15 +30,43 @@ export async function seedAIEngineApps(
       temperature: 0.1,
       max_tokens: 4000,
       is_active: true,
-      system_prompt: `Eres un asistente especializado en extraer datos de facturas de compra colombianas. Tu tarea es analizar la imagen de una factura y extraer todos los datos relevantes en formato JSON estructurado.
+      system_prompt: `You are a purchase invoice data extraction system. You analyze invoice images and return structured JSON.
 
-Reglas importantes:
-1. Los numeros en facturas colombianas usan punto como separador de miles y coma como separador decimal (ej: 1.234.567,89). SIEMPRE convierte estos valores a formato numerico estandar (ej: 1234567.89).
-2. El NIT (Numero de Identificacion Tributaria) puede aparecer como "NIT", "N.I.T.", "Nit" o similar. Incluye el digito de verificacion si esta presente.
-3. El IVA en Colombia es generalmente del 19%. Identifica correctamente el valor del IVA.
-4. Si un campo no es legible o no esta presente, usa null en lugar de inventar datos.
-5. La confianza (confidence) debe reflejar tu seguridad general en la extraccion (0-100).
-6. SIEMPRE retorna JSON valido, sin markdown, sin texto adicional.`,
+You MUST return ONLY valid JSON matching this EXACT schema — no markdown, no explanations, no extra fields:
+
+{
+  "supplier": {
+    "name": "string — full business name",
+    "tax_id": "string or null — NIT with verification digit",
+    "address": "string or null",
+    "phone": "string or null"
+  },
+  "invoice_number": "string",
+  "invoice_date": "YYYY-MM-DD",
+  "payment_terms": "string or null",
+  "line_items": [
+    {
+      "description": "string — product name as printed",
+      "quantity": number,
+      "unit_price": number,
+      "total": number,
+      "sku_if_visible": "string or null — product code/reference if visible"
+    }
+  ],
+  "subtotal": number,
+  "tax_amount": number,
+  "total": number,
+  "confidence": number (0-100)
+}
+
+RULES:
+1. Use EXACTLY these field names. Do NOT translate, rename, or add fields not in the schema.
+2. Convert Colombian number formats (1.234.567,89) to standard (1234567.89). Never return formatted numbers.
+3. NIT may appear as "NIT", "N.I.T.", "CC". Include verification digit with hyphen (e.g., "900123456-7").
+4. tax_amount = ONLY IVA. Do not include retenciones (ReteFuente, ReteICA, ReteIVA).
+5. Use null when a field is not present. Never invent data.
+6. Extract ALL visible line items. Use "sku_if_visible" for codes in columns like "Código", "Ref", "SKU".
+7. confidence: 90-100 clear image, 70-89 partially unclear, below 70 poor quality.`,
       // prompt_template is null — for vision apps, text instructions must be
       // in the same message as the image (handled by scanInvoice()).
       prompt_template: null,
@@ -87,6 +115,22 @@ Reglas importantes:
       appsCreated++;
       console.log(`    Created: ${app.key}`);
     }
+  }
+
+  // Link invoice_ocr to MiniMax VL config if available
+  try {
+    const minimaxConfig = await client.ai_engine_configs.findFirst({
+      where: { model_id: 'MiniMax-VL-01' },
+    });
+    if (minimaxConfig) {
+      await client.ai_engine_applications.update({
+        where: { key: 'invoice_ocr' },
+        data: { config_id: minimaxConfig.id },
+      });
+      console.log(`    Linked invoice_ocr → MiniMax VL (config #${minimaxConfig.id})`);
+    }
+  } catch (err) {
+    console.log('    Could not link invoice_ocr to MiniMax config (may not exist yet)');
   }
 
   return { appsCreated, appsUpdated };

--- a/apps/backend/src/domains/store/orders/purchase-orders/invoice-scanner.service.ts
+++ b/apps/backend/src/domains/store/orders/purchase-orders/invoice-scanner.service.ts
@@ -15,6 +15,7 @@ import {
 } from './dto/scan-invoice.dto';
 import { CreatePurchaseOrderDto, PurchaseOrderItemDto } from './dto/create-purchase-order.dto';
 import { AddAttachmentDto } from './dto/add-attachment.dto';
+import * as sharp from 'sharp';
 
 @Injectable()
 export class InvoiceScannerService {
@@ -32,7 +33,8 @@ export class InvoiceScannerService {
       `[InvoiceScan] File: mimetype=${file.mimetype}, size=${file.size}, buffer=${file.buffer?.length ?? 'NO BUFFER'}`,
     );
 
-    const dataUri = `data:${file.mimetype};base64,${file.buffer.toString('base64')}`;
+    const { base64, mimeType } = await this.preprocessImage(file);
+    const dataUri = `data:${mimeType};base64,${base64}`;
 
     this.logger.debug(`[InvoiceScan] DataURI length: ${dataUri.length} chars`);
 
@@ -41,29 +43,7 @@ export class InvoiceScannerService {
       content: [
         {
           type: 'text',
-          text: `Analyze this purchase invoice image and extract all data. Return ONLY valid JSON with this exact structure (no markdown, no extra text):
-{
-  "supplier": { "name": "string", "tax_id": "string or null", "address": "string or null", "phone": "string or null" },
-  "invoice_number": "string",
-  "invoice_date": "YYYY-MM-DD",
-  "payment_terms": "string or null",
-  "line_items": [
-    { "description": "string", "quantity": number, "unit_price": number, "total": number, "sku_if_visible": "string or null" }
-  ],
-  "subtotal": number,
-  "tax_amount": number,
-  "total": number,
-  "confidence": number between 0 and 100
-}
-
-Important rules:
-- Extract ALL visible information. Use null ONLY when the field is truly absent from the document.
-- For numbers, extract the raw numeric value even if formatting is unusual (dots as thousands, commas as decimals, spaces, etc). Always return numbers without formatting (e.g., 1234567.89).
-- For supplier name, use the FULL business name exactly as shown on the invoice.
-- For dates, convert to YYYY-MM-DD format when possible.
-- Include ALL line items visible on the document, even if some fields are unclear — estimate values when necessary and set a lower confidence score.
-- If unit_price or total seems inconsistent, still extract both as-is — do not attempt to correct them.
-- Set confidence (0-100) reflecting overall extraction quality.`,
+          text: 'Extract all data from this purchase invoice image. Return ONLY the JSON object matching the schema defined in your system instructions.',
         },
         {
           type: 'image_url',
@@ -91,8 +71,8 @@ Important rules:
       if (content.startsWith('```')) {
         content = content.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '');
       }
-      const parsed: InvoiceScanResult = JSON.parse(content);
-      return parsed;
+      const parsed = JSON.parse(content);
+      return this.normalizeOcrResponse(parsed);
     } catch {
       this.logger.error(`Failed to parse AI OCR response: ${response.content}`);
       throw new VendixHttpException(ErrorCodes.INV_SCAN_PARSE_FAIL);
@@ -439,5 +419,73 @@ Important rules:
     }
 
     return Math.round((matches / qWords.length) * 80);
+  }
+
+  private async preprocessImage(file: Express.Multer.File): Promise<{ base64: string; mimeType: string }> {
+    const MAX_DIMENSION = 1536;
+    const JPEG_QUALITY = 85;
+
+    try {
+      const metadata = await sharp(file.buffer).metadata();
+      const needsResize = (metadata.width && metadata.width > MAX_DIMENSION) ||
+                          (metadata.height && metadata.height > MAX_DIMENSION);
+
+      let pipeline = sharp(file.buffer);
+
+      if (needsResize) {
+        pipeline = pipeline.resize(MAX_DIMENSION, MAX_DIMENSION, {
+          fit: 'inside',
+          withoutEnlargement: true,
+        });
+      }
+
+      const processedBuffer = await pipeline
+        .jpeg({ quality: JPEG_QUALITY })
+        .toBuffer();
+
+      this.logger.debug(
+        `[InvoiceScan] Image preprocessed: ${file.size} bytes → ${processedBuffer.length} bytes (${metadata.width}x${metadata.height}${needsResize ? ' resized' : ''})`,
+      );
+
+      return {
+        base64: processedBuffer.toString('base64'),
+        mimeType: 'image/jpeg',
+      };
+    } catch (err) {
+      this.logger.warn(`[InvoiceScan] Image preprocessing failed, using raw: ${err.message}`);
+      return {
+        base64: file.buffer.toString('base64'),
+        mimeType: file.mimetype,
+      };
+    }
+  }
+
+  private normalizeOcrResponse(parsed: any): InvoiceScanResult {
+    if (!parsed.supplier || !Array.isArray(parsed.line_items) || parsed.total == null) {
+      throw new Error('AI response missing required fields: supplier, line_items, or total');
+    }
+
+    return {
+      supplier: {
+        name: parsed.supplier?.name || 'Desconocido',
+        tax_id: parsed.supplier?.tax_id || undefined,
+        address: parsed.supplier?.address || undefined,
+        phone: parsed.supplier?.phone || undefined,
+      },
+      invoice_number: String(parsed.invoice_number || ''),
+      invoice_date: String(parsed.invoice_date || ''),
+      payment_terms: parsed.payment_terms || undefined,
+      line_items: (parsed.line_items || []).map((item: any) => ({
+        description: String(item.description || ''),
+        quantity: Number(item.quantity) || 0,
+        unit_price: Number(item.unit_price) || 0,
+        total: Number(item.total) || 0,
+        sku_if_visible: item.sku_if_visible || undefined,
+      })),
+      subtotal: Number(parsed.subtotal) || 0,
+      tax_amount: Number(parsed.tax_amount) || 0,
+      total: Number(parsed.total) || 0,
+      confidence: Number(parsed.confidence) || 0,
+    };
   }
 }


### PR DESCRIPTION
## Summary

- **Rewrite invoice_ocr system_prompt** with explicit JSON schema enforcing exact English field names — prevents vision models from translating/renaming fields (e.g., `supplier` instead of `establecimiento`)
- **Add sharp image preprocessing** (resize 1536px max, JPEG 85% quality) before sending to vision model — reduces payload 10-15x for phone photos
- **Add `normalizeOcrResponse()` safety net** for type coercion (`Number()`, `String()`) and field validation after JSON parse
- **Simplify inline user prompt** to single line deferring to system instructions — eliminates schema duplication between seed and service

## Files Changed

| File | Change |
|------|--------|
| `apps/backend/prisma/seeds/ai-engine-apps.seed.ts` | New system_prompt with JSON schema + dynamic config linking |
| `apps/backend/src/.../invoice-scanner.service.ts` | Image preprocessing + prompt simplification + response normalization |

## Test Plan

- [x] Run `npx prisma db seed` to update invoice_ocr prompt in DB
- [x] Upload invoice image via `POST /store/orders/purchase-orders/scan`
- [x] Verify response matches `InvoiceScanResult` interface with English field names
- [x] Verify image preprocessing logs show size reduction
- [x] Verify build with `docker logs --tail 40 vendix_backend`