### PR TITLE
fix: Wompi config binding and test-connection with form credentials

### DIFF
--- a/apps/backend/src/domains/store/payments/controllers/wompi.controller.ts
+++ b/apps/backend/src/domains/store/payments/controllers/wompi.controller.ts
@@ -104,9 +104,23 @@ export class WompiController {
   @Post('test-connection')
   @ApiOperation({ summary: 'Test Wompi credentials by fetching merchant data' })
   @ApiResponse({ status: 200, description: 'Connection test result' })
-  async testConnection() {
+  async testConnection(
+    @Body() body?: { public_key?: string; private_key?: string; environment?: string },
+  ) {
     try {
-      const config = await this.resolveWompiConfig();
+      // Use credentials from request body (modal pre-save) or from stored config (post-save)
+      let config: Record<string, any>;
+
+      if (body?.public_key && body?.private_key) {
+        config = {
+          public_key: body.public_key,
+          private_key: body.private_key,
+          environment: body.environment || 'SANDBOX',
+        };
+      } else {
+        config = await this.resolveWompiConfig();
+      }
+
       this.configureClient(config);
       await this.wompiClient.getAcceptanceTokens();
 

--- a/apps/frontend/src/app/private/modules/store/settings/payments/payments-settings.component.ts
+++ b/apps/frontend/src/app/private/modules/store/settings/payments/payments-settings.component.ts
@@ -1064,7 +1064,7 @@ export class PaymentsSettingsComponent implements OnInit, OnDestroy {
     this.http
       .post<{ success: boolean; message?: string; environment?: string }>(
         `${environment.apiUrl}/store/payments/wompi/test-connection`,
-        {},
+        this.config_form.value,
       )
       .pipe(takeUntil(this.destroy$))
       .subscribe({

--- a/apps/frontend/src/app/private/modules/store/settings/payments/payments-settings.component.ts
+++ b/apps/frontend/src/app/private/modules/store/settings/payments/payments-settings.component.ts
@@ -279,27 +279,27 @@ import {
       <form [formGroup]="config_form" class="cfg-form">
         @if (isWompiConfig()) {
           <!-- Wompi: explicit layout matching Pencil design -->
-          <div class="cfg-grid">
+          <div class="cfg-grid" [formGroup]="config_form">
             <!-- Row 1: Public Key + Private Key -->
             <div class="cfg-cell">
               <app-input label="Public Key" type="text" placeholder="pub_test_ o pub_prod_"
-                [control]="config_form.get('public_key')!" [required]="true" size="sm">
+                formControlName="public_key" [required]="true" size="sm">
               </app-input>
             </div>
             <div class="cfg-cell">
               <app-input label="Private Key" type="password" placeholder="prv_test_ o prv_prod_"
-                [control]="config_form.get('private_key')!" [required]="true" size="sm">
+                formControlName="private_key" [required]="true" size="sm">
               </app-input>
             </div>
             <!-- Row 2: Events Secret + Integrity Secret -->
             <div class="cfg-cell">
               <app-input label="Events Secret" type="password" placeholder="Secret de eventos"
-                [control]="config_form.get('events_secret')!" [required]="true" size="sm">
+                formControlName="events_secret" [required]="true" size="sm">
               </app-input>
             </div>
             <div class="cfg-cell">
               <app-input label="Integrity Secret" type="password" placeholder="Secret de integridad"
-                [control]="config_form.get('integrity_secret')!" [required]="true" size="sm">
+                formControlName="integrity_secret" [required]="true" size="sm">
               </app-input>
             </div>
             <!-- Row 3: Ambiente + Badge -->
@@ -361,7 +361,7 @@ import {
           </div>
         } @else {
           <!-- Generic: other payment methods use dynamic grid -->
-          <div class="cfg-grid">
+          <div class="cfg-grid" [formGroup]="config_form">
             @for (field of config_fields; track field.key) {
               @if (field.enum_values) {
                 <div class="cfg-cell" style="grid-column: 1 / -1">
@@ -373,7 +373,7 @@ import {
                 <div class="cfg-cell">
                   <app-input [label]="field.title"
                     [type]="field.key.includes('secret') || field.key.includes('private') ? 'password' : 'text'"
-                    [placeholder]="field.title" [control]="config_form.get(field.key)!"
+                    [placeholder]="field.title" [formControlName]="field.key"
                     [required]="field.required" size="sm">
                   </app-input>
                 </div>


### PR DESCRIPTION
## Summary

Dos fixes críticos para la configuración de Wompi que no entraron en el merge anterior:

- **test-connection acepta credenciales del formulario**: El endpoint ahora funciona tanto pre-save (credenciales del modal) como post-save (credenciales de DB). Antes fallaba con "Wompi no está configurado" porque buscaba en DB antes de guardar.
- **formControlName en lugar de [control]**: El input `[control]` de app-input solo conecta validación visual, NO el two-way binding del ControlValueAccessor. Cambio a `formControlName` que sí sincroniza valores con el FormGroup, arreglando el error "campo requerido" al guardar.

## Test plan

- [ ] Abrir modal Wompi, llenar credenciales, click "Probar" → debe conectar
- [ ] Llenar todos los campos y click "Configurar y Agregar" → debe guardar sin error de campo requerido