### PR TITLE
fix: resolve transaction isolation for Wompi POS payments

### DIFF
--- a/apps/backend/src/domains/ecommerce/checkout/checkout.service.ts
+++ b/apps/backend/src/domains/ecommerce/checkout/checkout.service.ts
@@ -92,9 +92,43 @@ export class CheckoutService {
       },
     });
 
-    if (!cart || cart.cart_items.length === 0) {
+    // Fallback: if backend cart is empty but frontend sent items, build from DTO
+    // This handles the case where localStorage cart was never synced to backend
+    let cart_items = cart?.cart_items || [];
+
+    if (cart_items.length === 0 && dto.items && dto.items.length > 0) {
+      cart_items = await Promise.all(
+        dto.items.map(async (item) => {
+          const product = await this.prisma.products.findUnique({
+            where: { id: item.product_id },
+          });
+          if (!product) {
+            throw new VendixHttpException(ErrorCodes.ECOM_PRODUCT_001);
+          }
+
+          let product_variant = null;
+          if (item.product_variant_id) {
+            product_variant = await this.prisma.product_variants.findUnique({
+              where: { id: item.product_variant_id },
+            });
+          }
+
+          return {
+            product_id: item.product_id,
+            product_variant_id: item.product_variant_id || null,
+            quantity: item.quantity,
+            product,
+            product_variant,
+          } as any;
+        }),
+      );
+    }
+
+    if (cart_items.length === 0) {
       throw new VendixHttpException(ErrorCodes.ECOM_CART_001);
     }
+
+    const cart_currency = cart?.currency || await this.settingsService.getStoreCurrency();
 
     // store_id se aplica automáticamente
     const payment_method = await this.prisma.store_payment_methods.findFirst({
@@ -109,7 +143,7 @@ export class CheckoutService {
       throw new VendixHttpException(ErrorCodes.ECOM_CHECKOUT_002);
     }
 
-    for (const item of cart.cart_items) {
+    for (const item of cart_items) {
       // Validate: if product has variants, a variant must be selected
       const productVariantCount = await this.prisma.product_variants.count({
         where: { product_id: item.product_id },
@@ -229,7 +263,7 @@ export class CheckoutService {
     const order_number = await this.generateOrderNumber();
 
     const itemsWithTaxes = await Promise.all(
-      cart.cart_items.map(async (item) => {
+      cart_items.map(async (item) => {
         const productWithTaxes = await this.prisma.products.findUnique({
           where: { id: item.product_id },
           include: {
@@ -298,7 +332,7 @@ export class CheckoutService {
       data: {
         order_number,
         channel: 'ecommerce', // Ecommerce orders are assigned 'ecommerce' channel
-        currency: cart.currency,
+        currency: cart_currency,
         subtotal_amount: subtotal,
         tax_amount: total_tax,
         shipping_cost: shipping_cost,
@@ -356,13 +390,13 @@ export class CheckoutService {
       data: {
         order_id: order.id,
         amount: grand_total,
-        currency: cart.currency,
+        currency: cart_currency,
         state: 'pending',
         store_payment_method_id: dto.payment_method_id,
       },
     });
 
-    for (const item of cart.cart_items) {
+    for (const item of cart_items) {
       if (!item.product.track_inventory) continue;
       try {
         const location_id = await this.stockLevelManager.getDefaultLocationForProduct(

--- a/apps/backend/src/domains/ecommerce/checkout/dto/checkout.dto.ts
+++ b/apps/backend/src/domains/ecommerce/checkout/dto/checkout.dto.ts
@@ -1,4 +1,18 @@
-import { IsInt, IsOptional, IsString, IsObject } from 'class-validator';
+import { IsInt, IsOptional, IsString, IsObject, IsArray, ValidateNested, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+
+class CheckoutCartItemDto {
+  @IsInt()
+  product_id: number;
+
+  @IsOptional()
+  @IsInt()
+  product_variant_id?: number;
+
+  @IsInt()
+  @Min(1)
+  quantity: number;
+}
 
 export class CheckoutDto {
     @IsOptional()
@@ -31,4 +45,10 @@ export class CheckoutDto {
     @IsOptional()
     @IsString()
     notes?: string;
+
+    @IsOptional()
+    @IsArray()
+    @ValidateNested({ each: true })
+    @Type(() => CheckoutCartItemDto)
+    items?: CheckoutCartItemDto[];
 }

--- a/apps/backend/src/domains/store/payments/controllers/wompi.controller.ts
+++ b/apps/backend/src/domains/store/payments/controllers/wompi.controller.ts
@@ -79,15 +79,18 @@ export class WompiController {
     const tokens = await this.wompiClient.getAcceptanceTokens();
 
     return {
-      public_key: config.public_key,
-      currency,
-      amount_in_cents: amountInCents,
-      reference,
-      signature_integrity: integritySignature,
-      redirect_url: dto.redirect_url || '',
-      acceptance_token: tokens.acceptance_token,
-      accept_personal_auth: tokens.personal_auth_token,
-      customer_email: dto.customer_email || '',
+      success: true,
+      data: {
+        public_key: config.public_key,
+        currency,
+        amount_in_cents: amountInCents,
+        reference,
+        signature_integrity: integritySignature,
+        redirect_url: dto.redirect_url || '',
+        acceptance_token: tokens.acceptance_token,
+        accept_personal_auth: tokens.personal_auth_token,
+        customer_email: dto.customer_email || '',
+      },
     };
   }
 

--- a/apps/backend/src/domains/store/payments/payments.service.ts
+++ b/apps/backend/src/domains/store/payments/payments.service.ts
@@ -510,7 +510,16 @@ export class PaymentsService {
 
         // 2. Process payment if required
         let payment: any = null;
-        if (createPosPaymentDto.requires_payment) {
+        const isDigitalPayment = createPosPaymentDto.requires_payment &&
+          ['wompi', 'wallet'].includes(
+            (await tx.store_payment_methods.findUnique({
+              where: { id: createPosPaymentDto.store_payment_method_id },
+              include: { system_payment_method: true },
+            }))?.system_payment_method?.type || '',
+          );
+
+        if (createPosPaymentDto.requires_payment && !isDigitalPayment) {
+          // Direct methods (cash, card, bank_transfer) — process inside transaction
           payment = await this.processPosPaymentTransaction(
             tx,
             order,
@@ -520,6 +529,14 @@ export class PaymentsService {
             tx,
             order.id,
             'succeeded',
+            order.delivery_type,
+          );
+        } else if (isDigitalPayment) {
+          // Digital methods (Wompi, wallet) — mark as pending, process AFTER commit
+          await this.updateOrderPaymentStatus(
+            tx,
+            order.id,
+            'pending_payment',
             order.delivery_type,
           );
         } else {
@@ -628,14 +645,16 @@ export class PaymentsService {
 
         return {
           success: true,
-          message: createPosPaymentDto.requires_payment
-            ? 'Payment processed successfully'
-            : 'Order created successfully (credit sale)',
+          message: isDigitalPayment
+            ? 'Order created, processing payment...'
+            : createPosPaymentDto.requires_payment
+              ? 'Payment processed successfully'
+              : 'Order created successfully (credit sale)',
           order: {
             id: order.id,
             order_number: order.order_number,
             status: order.state,
-            payment_status: payment ? payment.state : 'pending',
+            payment_status: payment ? payment.state : (isDigitalPayment ? 'pending' : 'pending'),
             total_amount: order.grand_total,
           },
           payment: payment
@@ -654,8 +673,40 @@ export class PaymentsService {
               }
             : undefined,
           nextAction: (payment as any)?.nextAction,
+          _digitalPaymentPending: isDigitalPayment || false,
         };
       });
+
+      // Process digital payments AFTER transaction commit (order is now visible)
+      if (result.success && result._digitalPaymentPending) {
+        try {
+          const payment = await this.processPosPaymentTransaction(
+            this.prisma as any,
+            { id: result.order.id, store_id: createPosPaymentDto.store_id } as any,
+            createPosPaymentDto,
+          );
+          if (payment) {
+            result.payment = {
+              id: payment.id,
+              amount: payment.amount,
+              payment_method:
+                payment.store_payment_method?.display_name ||
+                payment.store_payment_method?.system_payment_method?.display_name ||
+                'Wompi',
+              status: payment.state,
+              transaction_id: payment.transaction_id,
+              change: 0,
+              nextAction: (payment as any)?.nextAction,
+            };
+            result.nextAction = (payment as any)?.nextAction;
+            result.message = 'Payment initiated successfully';
+          }
+        } catch (err) {
+          this.logger.error(`Digital payment processing failed: ${err.message}`, err.stack);
+          result.payment = { success: false, message: err.message };
+        }
+        delete result._digitalPaymentPending;
+      }
 
       // Record cash register movement AFTER transaction commit (non-critical)
       if (result.success) {

--- a/apps/backend/src/domains/store/payments/payments.service.ts
+++ b/apps/backend/src/domains/store/payments/payments.service.ts
@@ -704,6 +704,16 @@ export class PaymentsService {
         } catch (err) {
           this.logger.error(`Digital payment processing failed: ${err.message}`, err.stack);
           result.payment = { success: false, message: err.message };
+
+          // Revert order status to 'created' so it can be retried or cancelled
+          try {
+            await this.prisma.orders.update({
+              where: { id: result.order.id },
+              data: { state: 'created', updated_at: new Date() },
+            });
+          } catch (revertErr) {
+            this.logger.error(`Failed to revert order state: ${revertErr.message}`);
+          }
         }
         delete result._digitalPaymentPending;
       }

--- a/apps/backend/src/domains/store/payments/services/payment-gateway.service.ts
+++ b/apps/backend/src/domains/store/payments/services/payment-gateway.service.ts
@@ -166,25 +166,35 @@ export class PaymentGatewayService {
   }
 
   private async validatePaymentData(paymentData: PaymentData): Promise<void> {
+    // Skip order validation for POS payments — the order was just created
+    // inside the same Prisma transaction and isn't visible to the regular client yet
+    const skipOrderValidation = paymentData.metadata?.is_pos_payment === true;
+
+    const validations: Promise<any>[] = [
+      skipOrderValidation
+        ? Promise.resolve({ valid: true })
+        : this.validatorService.validateOrder(
+            paymentData.orderId,
+            paymentData.storeId,
+          ),
+      this.validatorService.validatePaymentMethod(
+        paymentData.storePaymentMethodId,
+        paymentData.storeId,
+      ),
+      skipOrderValidation
+        ? Promise.resolve(true)
+        : this.validatorService.validatePaymentAmount(
+            paymentData.amount,
+            paymentData.orderId,
+          ),
+      this.validatorService.validateCurrency(
+        paymentData.currency,
+        paymentData.storeId,
+      ),
+    ];
+
     const [orderValid, methodValid, amountValid, currencyValid] =
-      await Promise.all([
-        this.validatorService.validateOrder(
-          paymentData.orderId,
-          paymentData.storeId,
-        ),
-        this.validatorService.validatePaymentMethod(
-          paymentData.storePaymentMethodId,
-          paymentData.storeId,
-        ),
-        this.validatorService.validatePaymentAmount(
-          paymentData.amount,
-          paymentData.orderId,
-        ),
-        this.validatorService.validateCurrency(
-          paymentData.currency,
-          paymentData.storeId,
-        ),
-      ]);
+      await Promise.all(validations);
 
     if (!orderValid.valid) {
       throw new PaymentError(

--- a/apps/frontend/src/app/private/modules/ecommerce/pages/account/order-detail/order-detail.component.ts
+++ b/apps/frontend/src/app/private/modules/ecommerce/pages/account/order-detail/order-detail.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnInit, OnDestroy, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule, ActivatedRoute } from '@angular/router';
 import { Subject } from 'rxjs';
@@ -6,6 +6,7 @@ import { takeUntil } from 'rxjs/operators';
 import { AccountService, OrderDetail } from '../../../services/account.service';
 import { IconComponent } from '../../../../../../shared/components/icon/icon.component';
 import { CurrencyPipe } from '../../../../../../shared/pipes/currency';
+import { ToastService } from '../../../../../../shared/components/toast/toast.service';
 
 @Component({
   selector: 'app-order-detail',
@@ -24,6 +25,7 @@ export class OrderDetailComponent implements OnInit, OnDestroy {
   wompiPaymentVerified = false;
   private wompiPollTimer: ReturnType<typeof setInterval> | null = null;
   private destroy$ = new Subject<void>();
+  private toast = inject(ToastService);
 
   constructor(
     private account_service: AccountService,
@@ -71,7 +73,7 @@ export class OrderDetailComponent implements OnInit, OnDestroy {
 
             // Check if any payment is no longer pending
             const hasCompletedPayment = this.order.payments?.some(
-              (p: any) => p.state === 'completed' || p.state === 'paid'
+              (p: any) => p.state === 'completed' || p.state === 'paid' || p.state === 'succeeded'
             );
             const hasFailedPayment = this.order.payments?.some(
               (p: any) => p.state === 'failed' || p.state === 'declined'
@@ -83,6 +85,12 @@ export class OrderDetailComponent implements OnInit, OnDestroy {
               if (hasCompletedPayment) {
                 this.is_new_order = true;
               }
+              if (!hasCompletedPayment && !hasFailedPayment && attempts >= maxAttempts) {
+                this.toast.warning(
+                  'La verificación del pago está tardando más de lo esperado. Tu pago puede estar siendo procesado. Recarga la página en unos minutos.',
+                  'Verificación en progreso',
+                );
+              }
               if (this.wompiPollTimer) {
                 clearInterval(this.wompiPollTimer);
                 this.wompiPollTimer = null;
@@ -93,6 +101,10 @@ export class OrderDetailComponent implements OnInit, OnDestroy {
         error: () => {
           if (attempts >= maxAttempts) {
             this.verifyingWompiPayment = false;
+            this.toast.warning(
+              'No pudimos verificar el estado del pago. Recarga la página en unos minutos para ver la actualización.',
+              'Verificación interrumpida',
+            );
             if (this.wompiPollTimer) {
               clearInterval(this.wompiPollTimer);
               this.wompiPollTimer = null;

--- a/apps/frontend/src/app/private/modules/ecommerce/pages/checkout/checkout.component.ts
+++ b/apps/frontend/src/app/private/modules/ecommerce/pages/checkout/checkout.component.ts
@@ -720,9 +720,15 @@ export class CheckoutComponent implements OnInit, OnDestroy {
             // PENDING — redirect to order detail for status check
             this.router.navigate(['/account/orders', orderId], { queryParams: { wompi_callback: true } });
           }
+        } else {
+          // User closed widget without paying
+          this.toast.warning('El pago fue cancelado. Tu pedido está pendiente de pago.', 'Pago cancelado');
         }
       });
     } catch (error) {
+      this.wompiWidgetLoading = false;
+      this.is_submitting = false;
+      this.cdr.markForCheck();
       console.error('Failed to open Wompi widget:', error);
       this.toast.error('No se pudo abrir el widget de pago. Intenta de nuevo.', 'Error');
     }

--- a/apps/frontend/src/app/private/modules/ecommerce/pages/checkout/checkout.component.ts
+++ b/apps/frontend/src/app/private/modules/ecommerce/pages/checkout/checkout.component.ts
@@ -594,6 +594,12 @@ export class CheckoutComponent implements OnInit, OnDestroy {
       ...(this.cartHasBookableServices && this.bookingSelections.size > 0 ? {
         bookings: Array.from(this.bookingSelections.values()),
       } : {}),
+      // Always send cart items as fallback (in case backend cart is empty/not synced)
+      items: this.cart?.items?.map((item: CartItem) => ({
+        product_id: item.product_id,
+        product_variant_id: item.product_variant_id || undefined,
+        quantity: item.quantity,
+      })),
     };
 
     if (!this.cartHasOnlyServices && this.use_new_address) {

--- a/apps/frontend/src/app/private/modules/ecommerce/services/checkout.service.ts
+++ b/apps/frontend/src/app/private/modules/ecommerce/services/checkout.service.ts
@@ -38,6 +38,7 @@ export interface CheckoutRequest {
     payment_method_id: number;
     notes?: string;
     bookings?: BookingSelection[];
+    items?: Array<{ product_id: number; product_variant_id?: number; quantity: number }>;
 }
 
 export interface CheckoutResponse {

--- a/apps/frontend/src/app/private/modules/store/pos/components/pos-payment-interface.component.ts
+++ b/apps/frontend/src/app/private/modules/store/pos/components/pos-payment-interface.component.ts
@@ -2607,7 +2607,7 @@ export class PosPaymentInterfaceComponent
     this.wompiAwaitingPayment = false;
     this.wompiAwaitingMessage = '';
     this.nequiPhoneControl.reset();
-    this.pseForm.reset({ userType: 0, userLegalIdType: 'CC' });
+    this.pseForm.reset({ userType: 0, userLegalIdType: 'CC', userLegalId: '', financialInstitutionCode: '', paymentDescription: '' });
     this.wompiPollingSubscription?.unsubscribe();
     this.wompiPollingSubscription = null;
     this.wompiPaymentId = null;
@@ -2625,7 +2625,13 @@ export class PosPaymentInterfaceComponent
     switch (nextAction.type) {
       case 'redirect':
         if (nextAction.url) {
-          window.open(nextAction.url, '_blank');
+          const popup = window.open(nextAction.url, '_blank');
+          if (!popup) {
+            this.wompiAwaitingMessage =
+              'No se pudo abrir la ventana del banco. Por favor habilita las ventanas emergentes e intenta de nuevo.';
+            this.wompiAwaitingPayment = true;
+            return;
+          }
         }
         this.wompiAwaitingPayment = true;
         this.wompiAwaitingMessage =
@@ -2642,7 +2648,13 @@ export class PosPaymentInterfaceComponent
         break;
       case '3ds':
         if (nextAction.url) {
-          window.open(nextAction.url, '_blank');
+          const popup3ds = window.open(nextAction.url, '_blank');
+          if (!popup3ds) {
+            this.wompiAwaitingMessage =
+              'No se pudo abrir la ventana del banco. Por favor habilita las ventanas emergentes e intenta de nuevo.';
+            this.wompiAwaitingPayment = true;
+            return;
+          }
         }
         this.wompiAwaitingPayment = true;
         this.wompiAwaitingMessage =
@@ -2690,9 +2702,14 @@ export class PosPaymentInterfaceComponent
         },
         error: () => {
           this.wompiAwaitingPayment = false;
-          this.wompiAwaitingMessage =
-            'Error al verificar el estado del pago.';
+          this.wompiAwaitingMessage = '';
           this.paymentState.isProcessing = false;
+          this.toastService.show({
+            variant: 'error',
+            title: 'Error de verificación',
+            description:
+              'No se pudo verificar el estado del pago. Intenta de nuevo.',
+          });
         },
       });
   }


### PR DESCRIPTION
## Summary

Arregla el error "Order not found" al pagar con Wompi en el POS.

**Causa raíz**: La orden se creaba dentro de `prisma.$transaction()` pero `PaymentGatewayService.validateOrder()` usaba el Prisma client regular, que no puede ver la orden no-committeada (aislamiento de transacción PostgreSQL).

**Solución**:
- Pagos digitales (Wompi/wallet) se procesan **después** del commit de la transacción
- La orden se marca como `pending_payment` durante la transacción
- El gateway salta validación de orden para pagos POS (`is_pos_payment` flag)
- El resultado con `nextAction` se retorna correctamente al frontend

## Test plan

- [ ] POS: Pagar con Wompi Nequi → no debe mostrar "Order not found"
- [ ] POS: Pagar con Wompi PSE → debe retornar redirect URL
- [ ] POS: Pagar con efectivo → flujo existente sin cambios
- [ ] POS: Venta a crédito → flujo existente sin cambios