### PR TITLE
fix: move Wompi prepare endpoint to eCommerce checkout context

### DIFF
--- a/apps/backend/src/domains/ecommerce/checkout/checkout.controller.ts
+++ b/apps/backend/src/domains/ecommerce/checkout/checkout.controller.ts
@@ -34,6 +34,14 @@ export class CheckoutController {
         return { success: true, data };
     }
 
+    @Post('prepare-wompi')
+    async prepareWompiPayment(
+        @Body() dto: { order_id: number; amount: number; currency?: string; customer_email?: string; redirect_url?: string },
+    ) {
+        const data = await this.checkout_service.prepareWompiPayment(dto);
+        return { success: true, data };
+    }
+
     @OptionalAuth()
     @Post('whatsapp')
     async whatsappCheckout(@Body() dto: WhatsappCheckoutDto) {

--- a/apps/backend/src/domains/ecommerce/checkout/checkout.module.ts
+++ b/apps/backend/src/domains/ecommerce/checkout/checkout.module.ts
@@ -8,11 +8,13 @@ import { TaxesModule } from '../../store/taxes/taxes.module';
 import { SettingsModule } from '../../store/settings/settings.module';
 import { StockLevelManager } from '../../store/inventory/shared/services/stock-level-manager.service';
 import { InventoryTransactionsService } from '../../store/inventory/transactions/inventory-transactions.service';
+import { WompiModule } from '../../store/payments/processors/wompi/wompi.module';
+import { PaymentEncryptionService } from '../../store/payments/services/payment-encryption.service';
 
 @Module({
-    imports: [PrismaModule, CartModule, ShippingModule, TaxesModule, SettingsModule],
+    imports: [PrismaModule, CartModule, ShippingModule, TaxesModule, SettingsModule, WompiModule],
     controllers: [CheckoutController],
-    providers: [CheckoutService, StockLevelManager, InventoryTransactionsService],
+    providers: [CheckoutService, StockLevelManager, InventoryTransactionsService, PaymentEncryptionService],
     exports: [CheckoutService],
 })
 export class CheckoutModule { }

--- a/apps/backend/src/domains/ecommerce/checkout/checkout.service.ts
+++ b/apps/backend/src/domains/ecommerce/checkout/checkout.service.ts
@@ -11,7 +11,11 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { SettingsService } from '../../store/settings/settings.service';
 import { VendixHttpException, ErrorCodes } from 'src/common/errors';
 import { StockLevelManager } from '../../store/inventory/shared/services/stock-level-manager.service';
-import { Logger } from '@nestjs/common';
+import { Logger, BadRequestException } from '@nestjs/common';
+import { WompiClient } from '../../store/payments/processors/wompi/wompi.client';
+import { WompiEnvironment } from '../../store/payments/processors/wompi/wompi.types';
+import { PaymentEncryptionService } from '../../store/payments/services/payment-encryption.service';
+import * as crypto from 'crypto';
 
 @Injectable()
 export class CheckoutService {
@@ -25,6 +29,8 @@ export class CheckoutService {
     private readonly eventEmitter: EventEmitter2,
     private readonly settingsService: SettingsService,
     private readonly stockLevelManager: StockLevelManager,
+    private readonly wompiClient: WompiClient,
+    private readonly paymentEncryption: PaymentEncryptionService,
   ) {}
 
   async getPaymentMethods(shippingMethodType?: string) {
@@ -780,5 +786,68 @@ export class CheckoutService {
 
     const sequence = String(count + 1).padStart(4, '0');
     return `${store_code}-${date_str}-${sequence}`;
+  }
+
+  /**
+   * Prepare Wompi payment data for the frontend Widget.
+   * This endpoint is accessible from eCommerce context (customer JWT + x-store-id header).
+   */
+  async prepareWompiPayment(dto: {
+    order_id: number;
+    amount: number;
+    currency?: string;
+    customer_email?: string;
+    redirect_url?: string;
+  }) {
+    // Find Wompi payment method for this store
+    const wompiMethod = await this.store_prisma.store_payment_methods.findFirst({
+      where: {
+        state: 'enabled',
+        system_payment_method: { type: 'wompi' },
+      },
+      include: { system_payment_method: true },
+    });
+
+    if (!wompiMethod?.custom_config) {
+      throw new BadRequestException('Wompi no está configurado para esta tienda');
+    }
+
+    const config = this.paymentEncryption.decryptConfig(
+      wompiMethod.custom_config as Record<string, any>,
+      'wompi',
+    );
+
+    this.wompiClient.configure({
+      public_key: config.public_key,
+      private_key: config.private_key,
+      events_secret: config.events_secret || '',
+      integrity_secret: config.integrity_secret || '',
+      environment: (config.environment as WompiEnvironment) || WompiEnvironment.SANDBOX,
+    });
+
+    const storeId = RequestContextService.getStoreId();
+    const reference = `vendix_${storeId}_${dto.order_id}_${Date.now()}`;
+    const amountInCents = Math.round(dto.amount * 100);
+    const currency = dto.currency || 'COP';
+
+    const integritySignature = this.wompiClient.generateIntegritySignature(
+      reference,
+      amountInCents,
+      currency,
+    );
+
+    const tokens = await this.wompiClient.getAcceptanceTokens();
+
+    return {
+      public_key: config.public_key,
+      currency,
+      amount_in_cents: amountInCents,
+      reference,
+      signature_integrity: integritySignature,
+      redirect_url: dto.redirect_url || '',
+      acceptance_token: tokens.acceptance_token,
+      accept_personal_auth: tokens.personal_auth_token,
+      customer_email: dto.customer_email || '',
+    };
   }
 }

--- a/apps/frontend/src/app/private/modules/ecommerce/services/checkout.service.ts
+++ b/apps/frontend/src/app/private/modules/ecommerce/services/checkout.service.ts
@@ -133,7 +133,7 @@ export class CheckoutService {
         redirectUrl?: string,
     ): Observable<{ success: boolean; data: WompiWidgetConfig }> {
         return this.http.post<{ success: boolean; data: WompiWidgetConfig }>(
-            `${environment.apiUrl}/store/payments/wompi/prepare`,
+            `${this.api_url}/prepare-wompi`,
             {
                 order_id: orderId,
                 amount,


### PR DESCRIPTION
## Summary

Arregla "Access denied - store context required" al pagar con Wompi en eCommerce.

**Causa raíz**: El endpoint `/store/payments/wompi/prepare` requería `StorePrismaService` con contexto de admin, pero el eCommerce usa JWT de customer + `x-store-id` header que solo resuelve contexto para rutas `/ecommerce/`.

**Fix**: Nuevo endpoint `POST /ecommerce/checkout/prepare-wompi` dentro del checkout controller que ya tiene el contexto correcto de eCommerce.

## Test plan

- [ ] eCommerce: seleccionar Wompi → click "Pagar con Wompi" → Widget debe abrirse
- [ ] POS: flujo Wompi no afectado (sigue usando `/store/payments/wompi/prepare`)