### PR TITLE
fix: TS error in employee code generation

### DIFF
--- a/apps/backend/src/domains/store/payroll/employees/employees.service.ts
+++ b/apps/backend/src/domains/store/payroll/employees/employees.service.ts
@@ -94,7 +94,7 @@ export class EmployeesService {
 
     // Auto-generate employee_code if not provided
     if (!dto.employee_code) {
-      dto.employee_code = await this.generateNextEmployeeCode(context.organization_id);
+      dto.employee_code = await this.generateNextEmployeeCode(context.organization_id!);
     }
 
     // Check for duplicate employee_code (org-level unique constraint)


### PR DESCRIPTION
## Summary
- Fix TS2345 error: `context.organization_id` is `number | undefined` but `generateNextEmployeeCode` expects `number`
- Added non-null assertion since this code runs in a scoped context where `organization_id` is always present

## Test plan
- [ ] Verify backend builds without TS errors
- [ ] Test employee creation with auto-generated code