### PR TITLE
style: apply POS-inspired visual style to app-button component

### DIFF
--- a/apps/frontend/src/app/shared/components/button/button.component.ts
+++ b/apps/frontend/src/app/shared/components/button/button.component.ts
@@ -120,6 +120,40 @@ export type ButtonSize = 'xsm' | 'sm' | 'md' | 'lg';
       .h-13 {
         height: 3.25rem; /* 52px */
       }
+
+      /* Colored glow shadows - POS style */
+      .btn-shadow-primary {
+        box-shadow: 0 4px 12px rgba(var(--color-primary-rgb), 0.3);
+      }
+
+      .btn-shadow-secondary {
+        box-shadow: 0 4px 12px rgba(var(--color-secondary-rgb), 0.3);
+      }
+
+      .btn-shadow-danger {
+        box-shadow: 0 4px 12px rgba(var(--color-destructive-rgb), 0.3);
+      }
+
+      .btn-shadow-success {
+        box-shadow: 0 4px 12px rgba(34, 197, 94, 0.3);
+      }
+
+      /* Outline hover backgrounds */
+      .btn-outline-border {
+        border: 1px solid rgba(var(--color-primary-rgb), 0.5);
+      }
+
+      .btn-outline-border:hover:not(:disabled) {
+        background: rgba(var(--color-primary-rgb), 0.06);
+      }
+
+      .btn-outline-danger-border {
+        border: 1px solid rgba(var(--color-destructive-rgb), 0.5);
+      }
+
+      .btn-outline-danger-border:hover:not(:disabled) {
+        background: rgba(var(--color-destructive-rgb), 0.06);
+      }
     `,
   ],
 })
@@ -143,15 +177,16 @@ export class ButtonComponent {
 
   get buttonClasses(): string {
     const baseClasses = [
-      'font-medium',
+      'font-semibold',
       'rounded-xl',
       'transition-all',
       'duration-200',
       'focus:outline-none',
       'focus:ring-2',
       'focus:ring-offset-2',
-      'disabled:opacity-50',
+      'disabled:opacity-40',
       'disabled:cursor-not-allowed',
+      'active:scale-[0.97]',
       'relative',
       'inline-flex',
       'items-center',
@@ -170,34 +205,30 @@ export class ButtonComponent {
       lg: ['h-12', 'px-4', 'text-base', 'sm:h-13', 'sm:px-6', 'sm:text-lg'], // 48px móvil → 52px desktop
     };
 
-    // Variant classes
+    // Variant classes — POS-inspired style
     const variantClasses = {
       primary: [
         'bg-[var(--color-primary)]',
-        'hover:bg-[var(--color-primary)]/90',
+        'hover:brightness-110',
         'text-[var(--color-text-on-primary)]',
         'focus:ring-[var(--color-primary)]/50',
+        'btn-shadow-primary',
       ],
       secondary: [
         'bg-[var(--color-secondary)]',
-        'hover:bg-[var(--color-secondary)]/90',
+        'hover:brightness-110',
         'text-[var(--color-text-on-primary)]',
         'focus:ring-[var(--color-secondary)]/50',
+        'btn-shadow-secondary',
       ],
       outline: [
-        'border',
-        'border-[var(--color-primary)]',
+        'btn-outline-border',
         'text-[var(--color-primary)]',
-        'hover:bg-[var(--color-primary)]',
-        'hover:text-[var(--color-text-on-primary)]',
         'focus:ring-[var(--color-primary)]/50',
       ],
       'outline-danger': [
-        'border',
-        'border-[var(--color-destructive)]',
+        'btn-outline-danger-border',
         'text-[var(--color-destructive)]',
-        'hover:bg-[var(--color-destructive)]',
-        'hover:text-[var(--color-text-on-primary)]',
         'focus:ring-[var(--color-destructive)]/50',
       ],
       'outline-warning': [
@@ -215,15 +246,17 @@ export class ButtonComponent {
       ],
       danger: [
         'bg-[var(--color-destructive)]',
-        'hover:bg-[var(--color-destructive)]',
+        'hover:brightness-110',
         'text-[var(--color-text-on-primary)]',
         'focus:ring-[var(--color-destructive)]/50',
+        'btn-shadow-danger',
       ],
       success: [
         'bg-green-600',
-        'hover:bg-green-700',
+        'hover:brightness-110',
         'text-white',
         'focus:ring-green-500/50',
+        'btn-shadow-success',
       ],
     };
 

--- a/apps/frontend/src/app/shared/components/button/button.component.ts
+++ b/apps/frontend/src/app/shared/components/button/button.component.ts
@@ -135,7 +135,11 @@ export type ButtonSize = 'xsm' | 'sm' | 'md' | 'lg';
       }
 
       .btn-shadow-success {
-        box-shadow: 0 4px 12px rgba(34, 197, 94, 0.3);
+        box-shadow: 0 4px 12px rgba(var(--color-success-rgb), 0.3);
+      }
+
+      .btn-shadow-warning {
+        box-shadow: 0 4px 12px rgba(var(--color-warning-rgb), 0.3);
       }
 
       /* Outline hover backgrounds */
@@ -153,6 +157,14 @@ export type ButtonSize = 'xsm' | 'sm' | 'md' | 'lg';
 
       .btn-outline-danger-border:hover:not(:disabled) {
         background: rgba(var(--color-destructive-rgb), 0.06);
+      }
+
+      .btn-outline-warning-border {
+        border: 1px solid rgba(var(--color-warning-rgb), 0.5);
+      }
+
+      .btn-outline-warning-border:hover:not(:disabled) {
+        background: rgba(var(--color-warning-rgb), 0.06);
       }
     `,
   ],
@@ -232,11 +244,8 @@ export class ButtonComponent {
         'focus:ring-[var(--color-destructive)]/50',
       ],
       'outline-warning': [
-        'border',
-        'border-orange-300',
-        'bg-white',
-        'text-orange-600',
-        'hover:bg-orange-50',
+        'btn-outline-warning-border',
+        'text-[var(--color-warning)]',
         'focus:ring-orange-500/50',
       ],
       ghost: [
@@ -252,10 +261,10 @@ export class ButtonComponent {
         'btn-shadow-danger',
       ],
       success: [
-        'bg-green-600',
+        'bg-[var(--color-success)]',
         'hover:brightness-110',
-        'text-white',
-        'focus:ring-green-500/50',
+        'text-[var(--color-text-on-primary)]',
+        'focus:ring-[var(--color-success)]/50',
         'btn-shadow-success',
       ],
     };

--- a/apps/frontend/src/styles.scss
+++ b/apps/frontend/src/styles.scss
@@ -72,6 +72,7 @@
   --color-primary-rgb: 126, 215, 165;
   --color-secondary-rgb: 47, 111, 78;
   --color-accent-rgb: 255, 255, 255;
+  --color-destructive-rgb: 196, 99, 99;
 
   /* Light variants for backgrounds */
   --color-primary-light: rgba(126, 215, 165, 0.1);
@@ -191,6 +192,7 @@
   --color-primary-rgb: 126, 215, 165;
   --color-secondary-rgb: 47, 111, 78;
   --color-accent-rgb: 6, 182, 212;
+  --color-destructive-rgb: 239, 68, 68;
 
   /* Light variants for backgrounds (Dark theme) */
   --color-primary-light: rgba(126, 215, 165, 0.15);

--- a/apps/frontend/src/styles.scss
+++ b/apps/frontend/src/styles.scss
@@ -73,6 +73,8 @@
   --color-secondary-rgb: 47, 111, 78;
   --color-accent-rgb: 255, 255, 255;
   --color-destructive-rgb: 196, 99, 99;
+  --color-success-rgb: 34, 197, 94;
+  --color-warning-rgb: 251, 146, 60;
 
   /* Light variants for backgrounds */
   --color-primary-light: rgba(126, 215, 165, 0.1);
@@ -193,6 +195,8 @@
   --color-secondary-rgb: 47, 111, 78;
   --color-accent-rgb: 6, 182, 212;
   --color-destructive-rgb: 239, 68, 68;
+  --color-success-rgb: 34, 197, 94;
+  --color-warning-rgb: 251, 146, 60;
 
   /* Light variants for backgrounds (Dark theme) */
   --color-primary-light: rgba(126, 215, 165, 0.15);


### PR DESCRIPTION
## Summary
- Apply premium button style from POS mobile footer to the shared `app-button` component
- Colored glow shadows on solid variants, brightness hover, press effect, refined outlines
- Add `--color-destructive-rgb` CSS variable for consistent shadow colors across themes

## Changes
| Variant | Before | After |
|---------|--------|-------|
| Solid (primary, secondary, danger, success) | Opacity hover, no shadow | `brightness(1.1)` hover + colored glow shadow |
| Outline / Outline-danger | Color flip on hover | Semi-transparent border + subtle 6% tint hover |
| All variants | No press feedback | `scale(0.97)` active effect |
| All variants | `font-medium`, `opacity-50` disabled | `font-semibold`, `opacity-40` disabled |

**Sizes remain unchanged** — only visual style is affected.

## Files
- `apps/frontend/src/styles.scss` — Added `--color-destructive-rgb` variable
- `apps/frontend/src/app/shared/components/button/button.component.ts` — POS-style classes

## Test plan
- [ ] Verify all 8 button variants render correctly (primary, secondary, outline, outline-danger, outline-warning, ghost, danger, success)
- [ ] Verify hover, active, and disabled states work as expected
- [ ] Verify sizes (xsm, sm, md, lg) are unchanged
- [ ] Check that existing pages using `app-button` look correct

🤖 Generated with [OpenClaude](https://github.com/Gitlawb/openclaude)