### PR TITLE
fix: eliminar item del cart cuando quantity es 0

### DIFF
--- a/apps/backend/src/domains/ecommerce/cart/cart.service.ts
+++ b/apps/backend/src/domains/ecommerce/cart/cart.service.ts
@@ -169,6 +169,10 @@ export class CartService {
   }
 
   async updateItem(item_id: number, dto: UpdateCartItemDto) {
+    if (dto.quantity === 0) {
+      return this.removeItem(item_id);
+    }
+
     const cart = await this.prisma.carts.findFirst({});
 
     if (!cart) {

--- a/apps/backend/src/domains/ecommerce/cart/dto/cart.dto.ts
+++ b/apps/backend/src/domains/ecommerce/cart/dto/cart.dto.ts
@@ -1,43 +1,49 @@
-import { IsInt, IsOptional, IsArray, ValidateNested, Min } from 'class-validator';
+import {
+  IsInt,
+  IsOptional,
+  IsArray,
+  ValidateNested,
+  Min,
+} from 'class-validator';
 import { Type } from 'class-transformer';
 
 export class AddToCartDto {
-    @IsInt()
-    @Min(1)
-    product_id: number;
+  @IsInt()
+  @Min(1)
+  product_id: number;
 
-    @IsOptional()
-    @IsInt()
-    product_variant_id?: number;
+  @IsOptional()
+  @IsInt()
+  product_variant_id?: number;
 
-    @IsInt()
-    @Min(1)
-    quantity: number;
+  @IsInt()
+  @Min(1)
+  quantity: number;
 }
 
 export class UpdateCartItemDto {
-    @IsInt()
-    @Min(1)
-    quantity: number;
+  @IsInt()
+  @Min(0)
+  quantity: number;
 }
 
 export class SyncCartItemDto {
-    @IsInt()
-    @Min(1)
-    product_id: number;
+  @IsInt()
+  @Min(1)
+  product_id: number;
 
-    @IsOptional()
-    @IsInt()
-    product_variant_id?: number;
+  @IsOptional()
+  @IsInt()
+  product_variant_id?: number;
 
-    @IsInt()
-    @Min(1)
-    quantity: number;
+  @IsInt()
+  @Min(1)
+  quantity: number;
 }
 
 export class SyncCartDto {
-    @IsArray()
-    @ValidateNested({ each: true })
-    @Type(() => SyncCartItemDto)
-    items: SyncCartItemDto[];
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => SyncCartItemDto)
+  items: SyncCartItemDto[];
 }

--- a/bruno/Vendix/Store/Cart/Update Cart Item - quantity zero removes item.bru
+++ b/bruno/Vendix/Store/Cart/Update Cart Item - quantity zero removes item.bru
@@ -1,0 +1,32 @@
+meta {
+  name: Update Cart Item - quantity zero removes item
+  type: http
+  seq: 1
+}
+
+put {
+  url: http://{{baseUrl}}/ecommerce/cart/items/{{cartItemId}}
+  body: json
+  headers: {
+    Authorization: Bearer {{customerToken}}
+    Content-Type: application/json
+  }
+}
+
+body:json {
+  {
+    "quantity": 0
+  }
+}
+
+tests {
+  test("update with quantity 0 removes item", function() {
+    expect(res.status).to.equal(200);
+    expect(res.body.success).to.equal(true);
+  });
+
+  test("removed item is not in cart", function() {
+    const itemIds = res.body.data.items.map(i => i.id);
+    expect(itemIds).to.not.include(parseInt(vars.get("cartItemId")));
+  });
+}


### PR DESCRIPTION
## Summary
- Agregar validación en `updateItem` para eliminar item cuando `quantity=0`
- Actualizar `UpdateCartItemDto` para permitir `quantity=0` (cambiar `@Min(1)` a `@Min(0)`)
- Agregar test de Bruno para verificar el comportamiento

## Changes
- `apps/backend/src/domains/ecommerce/cart/cart.service.ts`
- `apps/backend/src/domains/ecommerce/cart/dto/cart.dto.ts`
- `bruno/Vendix/Store/Cart/Update Cart Item - quantity zero removes item.bru`