### PR TITLE
fix: agregar logging de errores en syncFromLocalStorage

### DIFF
--- a/apps/backend/src/domains/ecommerce/cart/cart.service.ts
+++ b/apps/backend/src/domains/ecommerce/cart/cart.service.ts
@@ -1,5 +1,6 @@
 import {
   Injectable,
+  Logger,
   NotFoundException,
   BadRequestException,
 } from '@nestjs/common';
@@ -11,6 +12,8 @@ import { VendixHttpException, ErrorCodes } from 'src/common/errors';
 
 @Injectable()
 export class CartService {
+  private readonly logger = new Logger(CartService.name);
+
   constructor(
     private readonly prisma: EcommercePrismaService,
     private readonly s3Service: S3Service,
@@ -253,8 +256,8 @@ export class CartService {
           product_variant_id: item.product_variant_id,
           quantity: item.quantity,
         });
-      } catch {
-        // Skip invalid items during sync
+      } catch (error) {
+        this.logger.warn(`Skipping invalid cart item during sync: product_id=${item.product_id}, error=${error.message}`);
       }
     }
 


### PR DESCRIPTION
## Summary
- Agregar `Logger` a `CartService` para registrar errores durante la sincronización del carrito
- El catch vacío en `syncFromLocalStorage` ahora loguea un `warn` con el `product_id` y el mensaje de error
- Permite detectar problemas de sincronización sin interrumpir el flujo (invalid items se siguen saltando)

## Archivo afectado
- `apps/backend/src/domains/ecommerce/cart/cart.service.ts`

## Test plan
- [x] Verificar que el backend compila sin errores
- [x] Probar sync con items inválidos y verificar que aparecen logs warn
- [x] Confirmar que los items válidos se sincronizan correctamente