### PR TITLE
feat: marcas únicas por tienda + selector de búsqueda para marcas y categorías

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -24,4 +24,4 @@ COPY --from=builder /app/prisma ./prisma
 COPY --from=builder /app/prisma.config.ts ./
 # Environment files are NOT copied - secrets are loaded from AWS Secrets Manager in production
 EXPOSE 3000
-CMD ["sh", "-c", "npx prisma migrate deploy && node dist/src/main.js"]
+CMD ["node", "dist/src/main.js"]

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -479,6 +479,7 @@ model stores {
   onboarding                  Boolean                       @default(false)
   addresses                   addresses[]
   audit_logs                  audit_logs[]
+  brands                      brands[]
   categories                  categories[]
   domain_settings             domain_settings[]
   inventory_locations         inventory_locations[]
@@ -653,13 +654,20 @@ model addresses {
 
 model brands {
   id          Int              @id @default(autoincrement())
-  name        String           @unique @db.VarChar(100)
+  store_id    Int
+  name        String           @db.VarChar(100)
+  slug        String           @db.VarChar(120)
   description String?
   logo_url    String?
   created_at  DateTime?        @default(now()) @db.Timestamp(6)
   updated_at  DateTime?        @default(now()) @db.Timestamp(6)
   state       brand_state_enum @default(active)
+  stores      stores           @relation(fields: [store_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
   products    products[]
+
+  @@unique([store_id, name])
+  @@unique([store_id, slug])
+  @@index([store_id])
 }
 
 model categories {

--- a/apps/backend/prisma/seeds/products-categories.seed.ts
+++ b/apps/backend/prisma/seeds/products-categories.seed.ts
@@ -288,10 +288,17 @@ export async function seedProductsAndCategories(
   const createdBrands: any[] = [];
   for (const brand of brands) {
     const createdBrand = await client.brands.upsert({
-      where: { name: brand.name },
+      where: {
+        store_id_name: {
+          store_id: techStore1.id,
+          name: brand.name,
+        },
+      },
       update: {},
       create: {
+        store_id: techStore1.id,
         name: brand.name,
+        slug: brand.name.toLowerCase().replace(/\s+/g, '-'),
         description: brand.description,
       },
     });

--- a/apps/backend/src/domains/store/brands/brands.service.ts
+++ b/apps/backend/src/domains/store/brands/brands.service.ts
@@ -9,6 +9,7 @@ import { CreateBrandDto, UpdateBrandDto, BrandQueryDto } from './dto';
 import { S3Service } from '@common/services/s3.service';
 import { extractS3KeyFromUrl } from '@common/helpers/s3-url.helper';
 import { VendixHttpException, ErrorCodes } from 'src/common/errors';
+import { RequestContextService } from '@common/context/request-context.service';
 
 @Injectable()
 export class BrandsService {
@@ -16,17 +17,35 @@ export class BrandsService {
     private prisma: StorePrismaService,
     private s3Service: S3Service,
   ) {}
+
+  private generateSlug(name: string): string {
+    return name
+      .toLowerCase()
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+  }
+
   async create(createBrandDto: CreateBrandDto, user: any) {
+    const context = RequestContextService.getContext();
+    const store_id = context?.store_id;
+
+    if (!store_id) {
+      throw new VendixHttpException(ErrorCodes.STORE_CONTEXT_001);
+    }
+
     try {
-      // CRITICAL: Sanitize logo_url to extract S3 key before storing
-      // This prevents storing signed URLs that expire after 24 hours
       const sanitizedLogoUrl = extractS3KeyFromUrl(createBrandDto.logo_url);
+      const slug = this.generateSlug(createBrandDto.name);
 
       const brand = await this.prisma.brands.create({
         data: {
           name: createBrandDto.name,
+          slug,
           description: createBrandDto.description,
           logo_url: sanitizedLogoUrl,
+          store_id,
         },
       });
 
@@ -36,7 +55,7 @@ export class BrandsService {
       };
     } catch (error) {
       if (error.code === 'P2002') {
-        throw new ConflictException('Brand name already exists');
+        throw new ConflictException('Brand name already exists in this store');
       }
       throw error;
     }
@@ -96,61 +115,8 @@ export class BrandsService {
   }
 
   async findByStore(storeId: number, query: BrandQueryDto) {
-    const {
-      page = 1,
-      limit = 10,
-      search,
-      sort_by = 'created_at',
-      sort_order = 'desc',
-    } = query;
-
-    const skip = (page - 1) * limit;
-
-    const where: any = {
-      state: { not: 'archived' }, // Excluir archivados por defecto
-    };
-
-    if (search) {
-      where.OR = [
-        { name: { contains: search, mode: 'insensitive' } },
-        { description: { contains: search, mode: 'insensitive' } },
-      ];
-    }
-
-    // ✅ SIMPLIFICADO: Brands es global, no necesita filtrar por store
-    // Las marcas globales están disponibles para todos los stores
-
-    const [brands, total] = await Promise.all([
-      this.prisma.brands.findMany({
-        where,
-        skip,
-        take: limit,
-        orderBy: { [sort_by]: sort_order },
-        include: {
-          _count: {
-            select: { products: true },
-          },
-        },
-      }),
-      this.prisma.brands.count({ where }),
-    ]);
-
-    const signedBrands = await Promise.all(
-      brands.map(async (brand) => ({
-        ...brand,
-        logo_url: await this.s3Service.signUrl(brand.logo_url, true),
-      })),
-    );
-
-    return {
-      data: signedBrands,
-      meta: {
-        total,
-        page,
-        limit,
-        totalPages: Math.ceil(total / limit),
-      },
-    };
+    // Scope is applied automatically by StorePrismaService
+    return this.findAll(query);
   }
 
   async findOne(id: number, options?: { includeInactive?: boolean }) {
@@ -176,11 +142,11 @@ export class BrandsService {
   async update(id: number, updateBrandDto: UpdateBrandDto, user: any) {
     const brand = await this.findOne(id);
 
-    // Build update data
     const updateData: any = {};
 
     if (updateBrandDto.name) {
       updateData.name = updateBrandDto.name;
+      updateData.slug = this.generateSlug(updateBrandDto.name);
     }
 
     if (updateBrandDto.description !== undefined) {
@@ -188,7 +154,6 @@ export class BrandsService {
     }
 
     if (updateBrandDto.logo_url !== undefined) {
-      // CRITICAL: Sanitize logo_url to extract S3 key before storing
       updateData.logo_url = extractS3KeyFromUrl(updateBrandDto.logo_url);
     }
 
@@ -209,7 +174,7 @@ export class BrandsService {
       };
     } catch (error) {
       if (error.code === 'P2002') {
-        throw new ConflictException('Brand name already exists');
+        throw new ConflictException('Brand name already exists in this store');
       }
       throw error;
     }
@@ -218,7 +183,6 @@ export class BrandsService {
   async remove(id: number, user: any) {
     const brand = await this.findOne(id);
 
-    // Check if brand has products
     const productCount = await this.prisma.products.count({
       where: { brand_id: id },
     });
@@ -229,7 +193,6 @@ export class BrandsService {
       );
     }
 
-    // Eliminación lógica: cambiar estado a archived
     await this.prisma.brands.update({
       where: { id },
       data: {
@@ -238,6 +201,7 @@ export class BrandsService {
       },
     });
   }
+
   private async validateUniqueName(name: string, excludeId?: number) {
     const where: any = { name };
     if (excludeId) {
@@ -246,7 +210,7 @@ export class BrandsService {
 
     const existing = await this.prisma.brands.findFirst({ where });
     if (existing) {
-      throw new ConflictException('Brand name already exists');
+      throw new ConflictException('Brand name already exists in this store');
     }
   }
 }

--- a/apps/backend/src/prisma/services/store-prisma.service.ts
+++ b/apps/backend/src/prisma/services/store-prisma.service.ts
@@ -59,6 +59,7 @@ export class StorePrismaService extends BasePrismaService {
     'booking_confirmation_tokens',
     'email_templates',
     'messaging_channels',
+    'brands',
   ];
 
   constructor() {
@@ -517,7 +518,7 @@ export class StorePrismaService extends BasePrismaService {
   }
 
   get brands() {
-    return this.baseClient.brands;
+    return this.scoped_client.brands;
   }
 
   get product_categories() {

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -25,7 +25,7 @@
   "watchOptions": {
     "watchFile": "dynamicPriorityPolling",
     "watchDirectory": "dynamicPriorityPolling",
-    "fallbackPolling": "dynamicPriorityPolling",
+    "fallbackPolling": "fixedinterval",
     "synchronousWatchDirectory": false
   }
 }

--- a/apps/frontend/src/app/private/modules/store/products/components/product-create-modal.component.ts
+++ b/apps/frontend/src/app/private/modules/store/products/components/product-create-modal.component.ts
@@ -14,10 +14,9 @@ import {
   InputComponent,
   ToastService,
   IconComponent,
-  SelectorComponent,
-  SelectorOption,
   MultiSelectorComponent,
   MultiSelectorOption,
+  SelectorOption,
   DialogService,
   SettingToggleComponent,
 } from '../../../../../shared/components';
@@ -48,11 +47,10 @@ import { TaxQuickCreateComponent } from './tax-quick-create.component';
     ButtonComponent,
     InputComponent,
     IconComponent,
-    SelectorComponent,
+    MultiSelectorComponent,
     SettingToggleComponent,
     CategoryQuickCreateComponent,
     BrandQuickCreateComponent,
-    MultiSelectorComponent,
     TaxQuickCreateComponent,
   ],
   templateUrl: './product-create-modal/product-create-modal.component.html',
@@ -81,9 +79,9 @@ export class ProductCreateModalComponent {
   }
 
   productForm: FormGroup;
-  categoryOptions: SelectorOption[] = [];
-  brandOptions: SelectorOption[] = [];
-  taxCategoryOptions: MultiSelectorOption[] = [];
+  categoryOptions = signal<SelectorOption[]>([]);
+  brandOptions = signal<SelectorOption[]>([]);
+  taxCategoryOptions = signal<MultiSelectorOption[]>([]);
 
   // Quick create modals state
   isCategoryCreateOpen = signal(false);
@@ -91,6 +89,7 @@ export class ProductCreateModalComponent {
   isTaxCategoryCreateOpen = signal(false);
 
   private allTaxCategories: TaxCategory[] = [];
+  private isInitialized = signal(false);
 
   constructor() {
     this.productForm = this.createForm();
@@ -105,14 +104,19 @@ export class ProductCreateModalComponent {
       }
     });
 
-    // React to isOpen changes
+    // React to isOpen changes - solo ejecutar una vez por apertura
     effect(() => {
-      if (this.isOpen()) {
+      if (this.isOpen() && !this.isInitialized()) {
         this.currencyService.loadCurrency();
         this.loadCategoriesAndBrands();
         if (!this.product()) {
           this.resetForm();
         }
+        this.isInitialized.set(true);
+      }
+      // Cuando el modal se cierra, resetear el flag para la próxima apertura
+      if (!this.isOpen()) {
+        this.isInitialized.set(false);
       }
     });
   }
@@ -188,9 +192,9 @@ export class ProductCreateModalComponent {
   }
 
   private loadCategoriesAndBrands(): void {
-    this.loadCategories();
-    this.loadBrands();
-    this.loadTaxCategories();
+    if (this.categoryOptions().length === 0) this.loadCategories();
+    if (this.brandOptions().length === 0) this.loadBrands();
+    if (this.taxCategoryOptions().length === 0) this.loadTaxCategories();
   }
 
   // Populate form when product data is available (edit mode)
@@ -221,16 +225,16 @@ export class ProductCreateModalComponent {
   private loadCategories(): void {
     this.categoriesService.getAllCategories().pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
       next: (categories: ProductCategory[]) => {
-        this.categoryOptions = categories.map((cat: ProductCategory) => ({
+        this.categoryOptions.set(categories.map((cat: ProductCategory) => ({
           value: cat.id,
           label: cat.name,
           description: cat.description,
-        }));
+        })));
       },
       error: (error: any) => {
         const message = extractApiErrorMessage(error);
         this.toastService.error(message, 'Error al cargar categorías');
-        this.categoryOptions = [];
+        this.categoryOptions.set([]);
       },
     });
   }
@@ -239,7 +243,7 @@ export class ProductCreateModalComponent {
     this.taxesService.getTaxCategories().pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
       next: (taxCategories: TaxCategory[]) => {
         this.allTaxCategories = taxCategories;
-        this.taxCategoryOptions = taxCategories.map((cat: TaxCategory) => {
+        this.taxCategoryOptions.set(taxCategories.map((cat: TaxCategory) => {
           const rawRate = cat.rate ?? cat.tax_rates?.[0]?.rate ?? 0;
           const rate = parseFloat(String(rawRate));
           const finalRate = isNaN(rate) ? 0 : rate;
@@ -249,7 +253,7 @@ export class ProductCreateModalComponent {
             label: `${cat.name} (${(finalRate * 100).toFixed(0)}%)`,
             description: cat.description,
           };
-        });
+        }));
       },
       error: (error: any) => {
         const message = extractApiErrorMessage(error);
@@ -264,65 +268,54 @@ export class ProductCreateModalComponent {
   private loadBrands(): void {
     this.brandsService.getAllBrands().pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
       next: (brands: Brand[]) => {
-        this.brandOptions = brands.map((brand: Brand) => ({
+        this.brandOptions.set(brands.map((brand: Brand) => ({
           value: brand.id,
           label: brand.name,
           description: brand.description,
-        }));
+        })));
       },
       error: (error: any) => {
         const message = extractApiErrorMessage(error);
         this.toastService.error(message, 'Error al cargar marcas');
-        this.brandOptions = [];
+        this.brandOptions.set([]);
       },
     });
   }
 
   onCategoryCreated(category: ProductCategory): void {
-    // Add new option optimistically (triggers OnPush change detection)
-    this.categoryOptions = [
-      ...this.categoryOptions,
+    this.categoryOptions.update(options => [
+      ...options,
       {
         value: category.id,
         label: category.name,
         description: category.description,
       },
-    ];
+    ]);
     this.productForm.patchValue({ category_ids: [category.id] });
     this.isCategoryCreateOpen.set(false);
   }
 
   onBrandCreated(brand: Brand): void {
-    // Add new option optimistically (triggers OnPush change detection)
-    this.brandOptions = [
-      ...this.brandOptions,
-      { value: brand.id, label: brand.name, description: brand.description },
-    ];
+    this.brandOptions.update(options => [
+      ...options,
+      {
+        value: brand.id,
+        label: brand.name,
+        description: brand.description,
+      },
+    ]);
     this.productForm.patchValue({ brand_ids: [brand.id] });
     this.isBrandCreateOpen.set(false);
   }
 
   onTaxCategoryCreated(taxCategory: TaxCategory): void {
-    const rawRate = taxCategory.rate ?? taxCategory.tax_rates?.[0]?.rate ?? 0;
-    const rate = parseFloat(String(rawRate));
-    const finalRate = isNaN(rate) ? 0 : rate;
-
-    this.allTaxCategories = [...this.allTaxCategories, taxCategory];
-    this.taxCategoryOptions = [
-      ...this.taxCategoryOptions,
-      {
-        value: taxCategory.id,
-        label: `${taxCategory.name} (${(finalRate * 100).toFixed(0)}%)`,
-        description: taxCategory.description,
-      },
-    ];
-
-    const currentIds: number[] =
-      this.productForm.get('tax_category_ids')?.value || [];
-    this.productForm.patchValue({
-      tax_category_ids: [...currentIds, taxCategory.id],
-    });
-    this.isTaxCategoryCreateOpen.set(false);
+    this.loadTaxCategories();
+    const currentIds = this.productForm.get('tax_category_ids')?.value || [];
+    if (taxCategory && taxCategory.id) {
+      this.productForm.patchValue({
+        tax_category_ids: [...currentIds, taxCategory.id],
+      });
+    }
   }
 
   onCancel() {

--- a/apps/frontend/src/app/private/modules/store/products/components/product-create-modal.component.ts
+++ b/apps/frontend/src/app/private/modules/store/products/components/product-create-modal.component.ts
@@ -132,8 +132,8 @@ export class ProductCreateModalComponent {
       stock_quantity: [0, [Validators.required, Validators.min(0)]],
       track_inventory: [true],
       sku: [''],
-      category_id: [null],
-      brand_id: [null],
+      category_ids: [[]],
+      brand_ids: [[]],
       tax_category_ids: [[] as number[]],
       state: [ProductState.ACTIVE],
     });
@@ -158,8 +158,8 @@ export class ProductCreateModalComponent {
       stock_quantity: val.stock_quantity || 0,
       track_inventory: val.track_inventory ?? true,
       sku: val.sku || '',
-      category_ids: val.category_id ? [Number(val.category_id)] : [],
-      brand_id: val.brand_id || null,
+      category_ids: val.category_ids || [],
+      brand_ids: val.brand_ids || [],
       tax_category_ids: val.tax_category_ids || [],
       state: val.state || 'active',
     };
@@ -204,21 +204,22 @@ export class ProductCreateModalComponent {
       stock_quantity: prod.stock_quantity || 0,
       track_inventory: prod.track_inventory !== false,
       // Try to get category from new structure or legacy if exists
-      category_id:
-        (prod as any).category_ids?.[0] ||
-        prod.categories?.[0]?.id ||
-        null,
-      brand_id: prod.brand_id || null,
-      tax_category_ids:
-        (prod.product_tax_assignments || []).map(
-          (ta: any) => ta.tax_category_id,
-        ),
+      category_ids:
+        (prod as any).category_ids?.length > 0
+          ? (prod as any).category_ids
+          : prod.categories?.[0]?.id
+            ? [prod.categories[0].id]
+            : [],
+      brand_ids: prod.brand_id ? [prod.brand_id] : [],
+      tax_category_ids: (prod.product_tax_assignments || []).map(
+        (ta: any) => ta.tax_category_id,
+      ),
       state: prod.state || ProductState.ACTIVE,
     });
   }
 
   private loadCategories(): void {
-    this.categoriesService.getCategories().pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+    this.categoriesService.getAllCategories().pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
       next: (categories: ProductCategory[]) => {
         this.categoryOptions = categories.map((cat: ProductCategory) => ({
           value: cat.id,
@@ -261,7 +262,7 @@ export class ProductCreateModalComponent {
   }
 
   private loadBrands(): void {
-    this.brandsService.getBrands().pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+    this.brandsService.getAllBrands().pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
       next: (brands: Brand[]) => {
         this.brandOptions = brands.map((brand: Brand) => ({
           value: brand.id,
@@ -287,7 +288,7 @@ export class ProductCreateModalComponent {
         description: category.description,
       },
     ];
-    this.productForm.patchValue({ category_id: category.id });
+    this.productForm.patchValue({ category_ids: [category.id] });
     this.isCategoryCreateOpen.set(false);
   }
 
@@ -297,7 +298,7 @@ export class ProductCreateModalComponent {
       ...this.brandOptions,
       { value: brand.id, label: brand.name, description: brand.description },
     ];
-    this.productForm.patchValue({ brand_id: brand.id });
+    this.productForm.patchValue({ brand_ids: [brand.id] });
     this.isBrandCreateOpen.set(false);
   }
 
@@ -343,9 +344,9 @@ export class ProductCreateModalComponent {
       track_inventory: !!val.track_inventory,
       stock_quantity: val.track_inventory ? val.stock_quantity : null,
       sku: val.sku || undefined,
-      // Map single category to array for backend compat
-      category_ids: val.category_id ? [Number(val.category_id)] : [],
-      brand_id: val.brand_id,
+      // Map categories to array for backend
+      category_ids: val.category_ids || [],
+      brand_id: val.brand_ids?.[0] ? Number(val.brand_ids[0]) : null,
       tax_category_ids: val.tax_category_ids || [],
       state: val.state,
     };

--- a/apps/frontend/src/app/private/modules/store/products/components/product-create-modal/product-create-modal.component.html
+++ b/apps/frontend/src/app/private/modules/store/products/components/product-create-modal/product-create-modal.component.html
@@ -91,7 +91,7 @@
             <app-multi-selector
               class="flex-1"
               label="Categoría"
-              [options]="categoryOptions"
+              [options]="categoryOptions()"
               formControlName="category_ids"
               placeholder="Seleccionar categorías..."
             ></app-multi-selector>
@@ -112,7 +112,7 @@
             <app-multi-selector
               class="flex-1"
               label="Marca"
-              [options]="brandOptions"
+              [options]="brandOptions()"
               formControlName="brand_ids"
               placeholder="Seleccionar marca..."
             ></app-multi-selector>
@@ -135,7 +135,7 @@
           <app-multi-selector
             class="flex-1"
             label="Impuestos (IVA)"
-            [options]="taxCategoryOptions"
+            [options]="taxCategoryOptions()"
             formControlName="tax_category_ids"
             placeholder="Seleccionar impuestos..."
           >

--- a/apps/frontend/src/app/private/modules/store/products/components/product-create-modal/product-create-modal.component.html
+++ b/apps/frontend/src/app/private/modules/store/products/components/product-create-modal/product-create-modal.component.html
@@ -5,39 +5,57 @@
   [size]="'md'"
   [title]="isEditMode ? 'Editar Producto' : 'Nuevo Producto'"
   subtitle="Configura los productos esenciales"
-  >
-
+>
   <div class="p-2 md:p-4">
     <form [formGroup]="productForm" class="space-y-2 md:space-y-2 md:space-y-4">
-
       <!-- Name -->
       <div>
-        <app-input label="Nombre del Producto" formControlName="name" placeholder="Ej. Camiseta Algodón Premium"
-        [error]="getErrorMessage('name')" [required]="true"></app-input>
+        <app-input
+          label="Nombre del Producto"
+          formControlName="name"
+          placeholder="Ej. Camiseta Algodón Premium"
+          [error]="getErrorMessage('name')"
+          [required]="true"
+        ></app-input>
       </div>
 
       <!-- Price & SKU Row -->
       <div class="grid grid-cols-2 gap-2 md:gap-4">
-        <app-input label="Precio Base" [currency]="true" formControlName="base_price" [error]="getErrorMessage('base_price')"
-        prefix="$" [required]="true" placeholder="0.00"></app-input>
+        <app-input
+          label="Precio Base"
+          [currency]="true"
+          formControlName="base_price"
+          [error]="getErrorMessage('base_price')"
+          prefix="$"
+          [required]="true"
+          placeholder="0.00"
+        ></app-input>
 
         <div>
-          <app-input label="SKU" formControlName="sku" placeholder="Ej. CAM-001"
-          [error]="getErrorMessage('sku')"></app-input>
+          <app-input
+            label="SKU"
+            formControlName="sku"
+            placeholder="Ej. CAM-001"
+            [error]="getErrorMessage('sku')"
+          ></app-input>
           <small class="text-xs text-gray-400 mt-0.5 block">Opcional</small>
         </div>
       </div>
 
       <!-- Track Inventory Toggle -->
-      <app-setting-toggle formControlName="track_inventory"
+      <app-setting-toggle
+        formControlName="track_inventory"
         label="Controlar inventario"
-        [description]="productForm.get('track_inventory')?.value
-          ? 'Se controla el stock de este producto'
-          : 'Producto bajo pedido — siempre disponible para venta'">
+        [description]="
+          productForm.get('track_inventory')?.value
+            ? 'Se controla el stock de este producto'
+            : 'Producto bajo pedido — siempre disponible para venta'
+        "
+      >
       </app-setting-toggle>
 
       <!-- Stock Field: Only shown when track_inventory is enabled -->
-      @if (productForm.get('track_inventory')?.value) {
+      @if (productForm.get("track_inventory")?.value) {
         <div class="grid grid-cols-1 gap-2 md:gap-4">
           <!-- Stock Field: Different behavior for create vs edit mode -->
           @if (!isEditMode) {
@@ -70,11 +88,19 @@
       <div class="grid grid-cols-2 gap-2 md:gap-4">
         <div>
           <div class="flex gap-2 items-end">
-            <app-selector class="flex-1" label="Categoría" [options]="categoryOptions" formControlName="category_id"
-            placeholder="Seleccionar"></app-selector>
-            <button type="button" (click)="isCategoryCreateOpen.set(true)"
+            <app-multi-selector
+              class="flex-1"
+              label="Categoría"
+              [options]="categoryOptions"
+              formControlName="category_ids"
+              placeholder="Seleccionar categorías..."
+            ></app-multi-selector>
+            <button
+              type="button"
+              (click)="isCategoryCreateOpen.set(true)"
               class="p-2 text-gray-500 hover:bg-gray-100 border border-gray-300 bg-white mb-0.5"
-              style="border-radius: var(--radius-sm);">
+              style="border-radius: var(--radius-sm)"
+            >
               <app-icon name="plus" size="20"></app-icon>
             </button>
           </div>
@@ -83,11 +109,19 @@
 
         <div>
           <div class="flex gap-2 items-end">
-            <app-selector class="flex-1" label="Marca" [options]="brandOptions"
-            formControlName="brand_id" placeholder="Seleccionar"></app-selector>
-            <button type="button" (click)="isBrandCreateOpen.set(true)"
+            <app-multi-selector
+              class="flex-1"
+              label="Marca"
+              [options]="brandOptions"
+              formControlName="brand_ids"
+              placeholder="Seleccionar marca..."
+            ></app-multi-selector>
+            <button
+              type="button"
+              (click)="isBrandCreateOpen.set(true)"
               class="p-2 text-gray-500 hover:bg-gray-100 border border-gray-300 bg-white mb-0.5"
-              style="border-radius: var(--radius-sm);">
+              style="border-radius: var(--radius-sm)"
+            >
               <app-icon name="plus" size="20"></app-icon>
             </button>
           </div>
@@ -98,19 +132,32 @@
       <!-- IVA / Impuestos -->
       <div>
         <div class="flex gap-2 items-end">
-          <app-multi-selector class="flex-1" label="Impuestos (IVA)"
-            [options]="taxCategoryOptions" formControlName="tax_category_ids"
-            placeholder="Seleccionar impuestos...">
+          <app-multi-selector
+            class="flex-1"
+            label="Impuestos (IVA)"
+            [options]="taxCategoryOptions"
+            formControlName="tax_category_ids"
+            placeholder="Seleccionar impuestos..."
+          >
           </app-multi-selector>
-          <button type="button" (click)="isTaxCategoryCreateOpen.set(true)"
+          <button
+            type="button"
+            (click)="isTaxCategoryCreateOpen.set(true)"
             class="p-2 text-gray-500 hover:bg-gray-100 border border-gray-300 bg-white mb-0.5"
-            style="border-radius: var(--radius-sm);">
+            style="border-radius: var(--radius-sm)"
+          >
             <app-icon name="plus" size="20"></app-icon>
           </button>
         </div>
-        @if ((productForm.get('tax_category_ids')?.value || []).length > 0 && productForm.get('base_price')?.value > 0) {
+        @if (
+          (productForm.get("tax_category_ids")?.value || []).length > 0 &&
+          productForm.get("base_price")?.value > 0
+        ) {
           <small class="text-xs text-gray-500 mt-1 block">
-            Precio con impuestos: <span class="font-semibold text-gray-700">{{ priceWithTax | number:'1.0-0' }}</span>
+            Precio con impuestos:
+            <span class="font-semibold text-gray-700">{{
+              priceWithTax | number: "1.0-0"
+            }}</span>
           </small>
         }
         <small class="text-xs text-gray-400 mt-0.5 block">Opcional</small>
@@ -118,26 +165,39 @@
 
       <!-- Advanced Link -->
       <div class="pt-2">
-        <button type="button" (click)="goToAdvancedCreation()"
-          class="text-sm text-primary-600 hover:text-primary-700 font-medium flex items-center gap-1 transition-colors">
+        <button
+          type="button"
+          (click)="goToAdvancedCreation()"
+          class="text-sm text-primary-600 hover:text-primary-700 font-medium flex items-center gap-1 transition-colors"
+        >
           <app-icon name="settings" size="14"></app-icon>
           Configuración avanzada (variantes, imágenes, descripción)
         </button>
       </div>
-
     </form>
   </div>
 
   <!-- Footer -->
   <div slot="footer" class="max-w-full">
-    <div class="flex items-center justify-end gap-2 md:gap-3 p-2 md:px-4 md:py-3 bg-gray-50 rounded-b-xl">
-      <app-button variant="outline" (clicked)="onCancel()" [disabled]="isSubmitting()"
-        customClasses="!rounded-xl flex-1 sm:flex-none font-bold">
+    <div
+      class="flex items-center justify-end gap-2 md:gap-3 p-2 md:px-4 md:py-3 bg-gray-50 rounded-b-xl"
+    >
+      <app-button
+        variant="outline"
+        (clicked)="onCancel()"
+        [disabled]="isSubmitting()"
+        customClasses="!rounded-xl flex-1 sm:flex-none font-bold"
+      >
         Cancelar
       </app-button>
 
-      <app-button variant="primary" (clicked)="onSubmit()" [loading]="isSubmitting()" [disabled]="isSubmitting()"
-        customClasses="!rounded-xl flex-1 sm:flex-none font-bold shadow-md shadow-primary-200 active:scale-95 transition-all">
+      <app-button
+        variant="primary"
+        (clicked)="onSubmit()"
+        [loading]="isSubmitting()"
+        [disabled]="isSubmitting()"
+        customClasses="!rounded-xl flex-1 sm:flex-none font-bold shadow-md shadow-primary-200 active:scale-95 transition-all"
+      >
         {{ isEditMode ? 'Guardar Cambios' : 'Crear Producto' }}
       </app-button>
     </div>
@@ -145,8 +205,12 @@
 </app-modal>
 
 <!-- Quick Create Modals -->
-<app-category-quick-create [isOpen]="isCategoryCreateOpen()" (isOpenChange)="isCategoryCreateOpen.set($event)"
-(created)="onCategoryCreated($event)" (cancel)="isCategoryCreateOpen.set(false)"></app-category-quick-create>
+<app-category-quick-create
+  [isOpen]="isCategoryCreateOpen()"
+  (isOpenChange)="isCategoryCreateOpen.set($event)"
+  (created)="onCategoryCreated($event)"
+  (cancel)="isCategoryCreateOpen.set(false)"
+></app-category-quick-create>
 
 <app-brand-quick-create
   [isOpen]="isBrandCreateOpen()"
@@ -159,5 +223,6 @@
   [isOpen]="isTaxCategoryCreateOpen()"
   (isOpenChange)="isTaxCategoryCreateOpen.set($event)"
   (created)="onTaxCategoryCreated($event)"
-  (cancel)="isTaxCategoryCreateOpen.set(false)">
+  (cancel)="isTaxCategoryCreateOpen.set(false)"
+>
 </app-tax-quick-create>

--- a/apps/frontend/src/app/private/modules/store/products/pages/product-create-page/product-create-page.component.html
+++ b/apps/frontend/src/app/private/modules/store/products/pages/product-create-page/product-create-page.component.html
@@ -589,13 +589,13 @@
             <!-- Brand -->
             <div>
               <div class="flex gap-2 items-end">
-                <app-selector
+                <app-multi-selector
                   class="flex-1"
                   label="Marca"
                   [options]="brandOptions"
-                  formControlName="brand_id"
-                  placeholder="Seleccionar marca"
-                ></app-selector>
+                  formControlName="brand_ids"
+                  placeholder="Seleccionar marca..."
+                ></app-multi-selector>
 
                 <app-button
                   variant="outline"
@@ -1677,6 +1677,76 @@
         </div>
         <!-- Variants UI -->
         <div class="space-y-4 md:space-y-5">
+          <!-- Variant count preview -->
+          @if (
+            variantAttributes.length > 0 &&
+            previewVariantCount > 0 &&
+            generatedVariants.length > 0
+          ) {
+            <div
+              class="flex items-center gap-2 p-3 bg-primary/5 border border-primary/15 rounded-xl"
+            >
+              <app-icon
+                name="layers"
+                size="16"
+                class="text-primary-600"
+              ></app-icon>
+              <span class="text-sm font-medium text-primary-700">
+                <strong>{{ generatedVariants.length }}</strong> variante{{
+                  generatedVariants.length !== 1 ? "s" : ""
+                }}
+                generada{{ generatedVariants.length !== 1 ? "s" : "" }}
+                automáticamente
+              </span>
+            </div>
+          }
+
+          <!-- Duplicate SKU Warning -->
+          @if (hasDuplicateSkus && generatedVariants.length > 0) {
+            <div
+              class="flex items-center gap-2 p-3 bg-red-50 border border-red-200 rounded-xl"
+            >
+              <app-icon
+                name="alert-triangle"
+                size="16"
+                class="text-red-600"
+              ></app-icon>
+              <span class="text-sm font-medium text-red-700">
+                Hay SKUs duplicados entre las variantes. Cada variante debe tener
+                un SKU único para guardar.
+              </span>
+            </div>
+          }
+
+          <!-- Bulk Actions Bar -->
+          @if (generatedVariants.length > 0) {
+            <div
+              class="flex flex-wrap gap-2 p-3 bg-gray-50 border border-gray-200 rounded-xl"
+            >
+              <span
+                class="text-xs font-bold text-text-muted uppercase tracking-wider self-center mr-2"
+              >
+                {{ generatedVariants.length }} variantes
+              </span>
+              <app-button
+                variant="outline"
+                size="sm"
+                (clicked)="applyBasePriceToAll()"
+              >
+                <app-icon slot="icon" name="dollar-sign" [size]="14"></app-icon>
+                Aplicar precio base a todas
+              </app-button>
+              <app-button
+                variant="outline"
+                size="sm"
+                (clicked)="applyBaseCostToAll()"
+              >
+                <app-icon slot="icon" name="calculator" [size]="14"></app-icon>
+                Aplicar costo base a todas
+              </app-button>
+            </div>
+          }
+
           <!-- Quick Attribute Buttons -->
           <div class="flex flex-wrap gap-2">
             <button

--- a/apps/frontend/src/app/private/modules/store/products/pages/product-create-page/product-create-page.component.ts
+++ b/apps/frontend/src/app/private/modules/store/products/pages/product-create-page/product-create-page.component.ts
@@ -344,10 +344,17 @@ export class ProductCreatePageComponent {
   private http = inject(HttpClient);
 
   // Data Collection Templates (for consultation configuration)
-  dataCollectionTemplates: { id: number; name: string; productIds: number[] }[] = [];
+  dataCollectionTemplates: {
+    id: number;
+    name: string;
+    productIds: number[];
+  }[] = [];
 
   get templateSelectorOptions(): SelectorOption[] {
-    return this.dataCollectionTemplates.map(t => ({ value: t.id, label: t.name }));
+    return this.dataCollectionTemplates.map((t) => ({
+      value: t.id,
+      label: t.name,
+    }));
   }
 
   // Provider assignment (for services with requires_booking)
@@ -537,7 +544,7 @@ export class ProductCreatePageComponent {
       track_inventory: draft.track_inventory ?? true,
       sku: draft.sku || '',
       category_ids: draft.category_ids || [],
-      brand_id: draft.brand_id || null,
+      brand_ids: draft.brand_id ? [draft.brand_id] : [],
       tax_category_ids: draft.tax_category_ids || [],
       state: draft.state || ProductState.ACTIVE,
     });
@@ -576,18 +583,21 @@ export class ProductCreatePageComponent {
   }
 
   private loadDataCollectionTemplates(): void {
-    this.http.get<any>(`${environment.apiUrl}/store/data-collection/templates`).pipe(
-      map((r: any) => r.data || [])
-    ).subscribe({
-      next: (templates: any[]) => {
-        this.dataCollectionTemplates = templates.map((t: any) => ({
-          id: t.id,
-          name: t.name,
-          productIds: (t.products || []).map((p: any) => p.product_id || p.product?.id),
-        }));
-      },
-      error: () => {}, // Silently fail — not critical
-    });
+    this.http
+      .get<any>(`${environment.apiUrl}/store/data-collection/templates`)
+      .pipe(map((r: any) => r.data || []))
+      .subscribe({
+        next: (templates: any[]) => {
+          this.dataCollectionTemplates = templates.map((t: any) => ({
+            id: t.id,
+            name: t.name,
+            productIds: (t.products || []).map(
+              (p: any) => p.product_id || p.product?.id,
+            ),
+          }));
+        },
+        error: () => {}, // Silently fail — not critical
+      });
   }
 
   private createForm(): FormGroup {
@@ -612,7 +622,7 @@ export class ProductCreatePageComponent {
       stock_quantity: [0, [Validators.min(0)]],
       track_inventory: [true],
       category_ids: [[] as number[]],
-      brand_id: [null],
+      brand_ids: [[]],
       tax_category_ids: [[] as number[]],
       weight: [0, [Validators.min(0)]],
       dimensions: this.fb.group({
@@ -760,7 +770,11 @@ export class ProductCreatePageComponent {
       stock_quantity: product.stock_quantity,
       track_inventory: product.track_inventory !== false,
       category_ids: categoryIds,
-      brand_id: product.brand?.id ?? product.brand_id,
+      brand_ids: product.brand?.id
+        ? [product.brand.id]
+        : product.brand_id
+          ? [product.brand_id]
+          : [],
       tax_category_ids: taxCategoryIds,
       state: product.state,
       pricing_type:
@@ -776,7 +790,8 @@ export class ProductCreatePageComponent {
       is_consultation: product.is_consultation || false,
       send_preconsultation: product.send_preconsultation || false,
       consultation_template_id: product.consultation_template_id || null,
-      preconsultation_template_id: (product as any).preconsultation_template_id || null,
+      preconsultation_template_id:
+        (product as any).preconsultation_template_id || null,
       weight: product.weight || 0,
       dimensions: {
         length: product.dimensions?.length || 0,
@@ -843,7 +858,7 @@ export class ProductCreatePageComponent {
   }
 
   private loadCategories(): void {
-    this.categoriesService.getCategories().subscribe({
+    this.categoriesService.getAllCategories().subscribe({
       next: (categories: ProductCategory[]) => {
         this.categoryOptions = categories.map((cat: ProductCategory) => ({
           value: cat.id,
@@ -888,7 +903,7 @@ export class ProductCreatePageComponent {
   }
 
   private loadBrands(): void {
-    this.brandsService.getBrands().subscribe({
+    this.brandsService.getAllBrands().subscribe({
       next: (brands: Brand[]) => {
         this.brandOptions = brands.map((brand: Brand) => ({
           value: brand.id,
@@ -897,7 +912,7 @@ export class ProductCreatePageComponent {
         }));
 
         // Re-set the brand value to force selector sync after options load
-        const brandControl = this.productForm.get('brand_id');
+        const brandControl = this.productForm.get('brand_ids');
         if (brandControl?.value) {
           const currentValue = brandControl.value;
           brandControl.setValue(currentValue);
@@ -1367,7 +1382,7 @@ export class ProductCreatePageComponent {
   onBrandCreated(brand: Brand): void {
     this.loadBrands();
     if (brand && brand.id) {
-      this.productForm.patchValue({ brand_id: brand.id });
+      this.productForm.patchValue({ brand_ids: [brand.id] });
     }
     this.isBrandCreateOpen = false;
   }
@@ -1698,7 +1713,9 @@ export class ProductCreatePageComponent {
           : undefined,
       category_ids: formValue.category_ids || [],
       tax_category_ids: formValue.tax_category_ids || [],
-      brand_id: formValue.brand_id ? Number(formValue.brand_id) : null,
+      brand_id: formValue.brand_ids?.[0]
+        ? Number(formValue.brand_ids[0])
+        : null,
       state: formValue.state || ProductState.ACTIVE,
       pricing_type:
         typeof formValue.pricing_type === 'object'
@@ -1719,7 +1736,8 @@ export class ProductCreatePageComponent {
         is_consultation: !!formValue.is_consultation,
         send_preconsultation: !!formValue.send_preconsultation,
         consultation_template_id: formValue.consultation_template_id || null,
-        preconsultation_template_id: formValue.preconsultation_template_id || null,
+        preconsultation_template_id:
+          formValue.preconsultation_template_id || null,
       }),
       images: images.length > 0 ? images : undefined,
       weight: isServiceType
@@ -1822,7 +1840,7 @@ export class ProductCreatePageComponent {
 
     this.isGeneratingDescription.set(true);
 
-    const brandId = this.productForm.get('brand_id')?.value;
+    const brandId = this.productForm.get('brand_ids')?.value?.[0];
     const brand = brandId
       ? this.brandOptions.find((b) => b.value === brandId)?.label
       : undefined;

--- a/apps/frontend/src/app/private/modules/store/products/services/brands.service.ts
+++ b/apps/frontend/src/app/private/modules/store/products/services/brands.service.ts
@@ -17,7 +17,7 @@ import { Brand } from '../interfaces';
 export class BrandsService {
   private readonly apiUrl = environment.apiUrl;
 
-  constructor(private http: HttpClient) { }
+  constructor(private http: HttpClient) {}
 
   getBrands(storeId?: number): Observable<Brand[]> {
     const params = storeId
@@ -31,12 +31,22 @@ export class BrandsService {
       );
   }
 
+  getAllBrands(storeId?: number): Observable<Brand[]> {
+    const params = new HttpParams().set('limit', '200').set('page', '1');
+    return this.http
+      .get<ApiResponse<Brand[]>>(`${this.apiUrl}/store/brands`, { params })
+      .pipe(
+        map((response) => response.data),
+        catchError(this.handleError),
+      );
+  }
+
   getBrandById(id: number): Observable<Brand> {
     return this.http
       .get<ApiResponse<Brand>>(`${this.apiUrl}/store/brands/${id}`)
       .pipe(
         map((response) => response.data),
-        catchError(this.handleError)
+        catchError(this.handleError),
       );
   }
 
@@ -45,7 +55,7 @@ export class BrandsService {
       .post<ApiResponse<Brand>>(`${this.apiUrl}/store/brands`, brand)
       .pipe(
         map((response) => response.data),
-        catchError(this.handleError)
+        catchError(this.handleError),
       );
   }
 
@@ -54,7 +64,7 @@ export class BrandsService {
       .patch<ApiResponse<Brand>>(`${this.apiUrl}/store/brands/${id}`, brand)
       .pipe(
         map((response) => response.data),
-        catchError(this.handleError)
+        catchError(this.handleError),
       );
   }
 

--- a/apps/frontend/src/app/private/modules/store/products/services/categories.service.ts
+++ b/apps/frontend/src/app/private/modules/store/products/services/categories.service.ts
@@ -17,7 +17,7 @@ import { ProductCategory } from '../interfaces';
 export class CategoriesService {
   private readonly apiUrl = environment.apiUrl;
 
-  constructor(private http: HttpClient) { }
+  constructor(private http: HttpClient) {}
 
   getCategories(storeId?: number): Observable<ProductCategory[]> {
     const params = storeId
@@ -33,12 +33,26 @@ export class CategoriesService {
       );
   }
 
-  getCategoryById(id: number): Observable<ProductCategory> {
+  getAllCategories(storeId?: number): Observable<ProductCategory[]> {
+    const params = new HttpParams().set('limit', '200').set('page', '1');
     return this.http
-      .get<ApiResponse<ProductCategory>>(`${this.apiUrl}/store/categories/${id}`)
+      .get<
+        ApiResponse<ProductCategory[]>
+      >(`${this.apiUrl}/store/categories`, { params })
       .pipe(
         map((response) => response.data),
-        catchError(this.handleError)
+        catchError(this.handleError),
+      );
+  }
+
+  getCategoryById(id: number): Observable<ProductCategory> {
+    return this.http
+      .get<
+        ApiResponse<ProductCategory>
+      >(`${this.apiUrl}/store/categories/${id}`)
+      .pipe(
+        map((response) => response.data),
+        catchError(this.handleError),
       );
   }
 
@@ -46,10 +60,12 @@ export class CategoriesService {
     category: Partial<ProductCategory>,
   ): Observable<ProductCategory> {
     return this.http
-      .post<ApiResponse<ProductCategory>>(`${this.apiUrl}/store/categories`, category)
+      .post<
+        ApiResponse<ProductCategory>
+      >(`${this.apiUrl}/store/categories`, category)
       .pipe(
         map((response) => response.data),
-        catchError(this.handleError)
+        catchError(this.handleError),
       );
   }
 
@@ -58,10 +74,9 @@ export class CategoriesService {
     category: Partial<ProductCategory>,
   ): Observable<ProductCategory> {
     return this.http
-      .patch<ApiResponse<ProductCategory>>(
-        `${this.apiUrl}/store/categories/${id}`,
-        category,
-      )
+      .patch<
+        ApiResponse<ProductCategory>
+      >(`${this.apiUrl}/store/categories/${id}`, category)
       .pipe(
         map((response) => response.data),
         catchError(this.handleError),

--- a/apps/frontend/src/app/shared/components/multi-selector/multi-selector.component.ts
+++ b/apps/frontend/src/app/shared/components/multi-selector/multi-selector.component.ts
@@ -102,7 +102,7 @@ export type MultiSelectorSize = 'sm' | 'md' | 'lg';
         <!-- Dropdown -->
         @if (isOpen()) {
           <div
-            class="absolute z-50 w-full mt-1 bg-[var(--color-surface)] border border-border shadow-lg max-h-60 overflow-auto"
+            class="absolute z-[10000] w-full mt-1 bg-[var(--color-surface)] border border-border shadow-lg max-h-60 overflow-auto"
             style="border-radius: var(--radius-sm);"
             >
             <!-- Search input -->
@@ -120,7 +120,7 @@ export type MultiSelectorSize = 'sm' | 'md' | 'lg';
             </div>
             <!-- Options -->
             <div class="py-1">
-              @for (option of filteredOptions(); track option) {
+              @for (option of filteredOptions(); track option.value) {
                 <button
                   type="button"
                   [disabled]="option.disabled"
@@ -223,7 +223,11 @@ export class MultiSelectorComponent implements ControlValueAccessor {
 
   @HostListener('document:click', ['$event'])
   onDocumentClick(event: MouseEvent): void {
-    if (!this.elementRef.nativeElement.contains(event.target)) {
+    const target = event.target as Node | null;
+    if (!target) return;
+    const path = event.composedPath();
+    const isInside = path.some((node) => node === this.elementRef.nativeElement);
+    if (!isInside) {
       this.isOpen.set(false);
     }
   }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,7 @@ services:
       - /app/node_modules
     networks:
       - vendix_net
-    command: sh -c "npx prisma generate && npx prisma migrate deploy && npm run start:dev"
+    command: sh -c "npx prisma generate && npm run start:dev"
     logging:
       driver: json-file
       options:

--- a/package-lock.json
+++ b/package-lock.json
@@ -148,6 +148,7 @@
         "marked": "^17.0.1",
         "ng2-charts": "^10.0.0",
         "ngx-echarts": "^21.0.0",
+        "qrcode": "^1.5.4",
         "rxjs": "~7.8.0",
         "swiper": "^12.0.3",
         "tailwindcss": "^3.4.0",
@@ -165,6 +166,7 @@
         "@types/jasmine": "~5.1.0",
         "@types/marked": "^5.0.2",
         "@types/node": "^20.17.19",
+        "@types/qrcode": "^1.5.6",
         "@types/xlsx": "^0.0.35",
         "autoprefixer": "^10.4.16",
         "jasmine-core": "~5.7.0",
@@ -175,46 +177,6 @@
         "karma-jasmine-html-reporter": "~2.1.0",
         "postcss": "^8.4.35",
         "typescript": "~5.8.2"
-      }
-    },
-    "apps/frontend/node_modules/@angular/platform-server": {
-      "version": "20.3.17",
-      "resolved": "https://registry.npmjs.org/@angular/platform-server/-/platform-server-20.3.17.tgz",
-      "integrity": "sha512-8IO8wqjB1c8G+lzQwWcUFlWxm3LkyAT3bsJ5L3Vm0L9WekFBsfG78T9wAy6WYxxZCX6T2iQBD6tg/3t+t86lTA==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0",
-        "xhr2": "^0.2.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@angular/common": "20.3.17",
-        "@angular/compiler": "20.3.17",
-        "@angular/core": "20.3.17",
-        "@angular/platform-browser": "20.3.17",
-        "rxjs": "^6.5.3 || ^7.4.0"
-      }
-    },
-    "apps/frontend/node_modules/@angular/ssr": {
-      "version": "20.3.19",
-      "resolved": "https://registry.npmjs.org/@angular/ssr/-/ssr-20.3.19.tgz",
-      "integrity": "sha512-dGXPetfUCWXADWxHKHuPHbPql9x7gLrubgiFwTl94YpGcqgUy09qFcd6yhRDPu99YZahH07rFrNsxLg+s2oI6Q==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "@angular/common": "^20.0.0",
-        "@angular/core": "^20.0.0",
-        "@angular/platform-server": "^20.0.0",
-        "@angular/router": "^20.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@angular/platform-server": {
-          "optional": true
-        }
       }
     },
     "libs/shared-types": {
@@ -1341,6 +1303,26 @@
         }
       }
     },
+    "node_modules/@angular/platform-server": {
+      "version": "20.3.19",
+      "resolved": "https://registry.npmjs.org/@angular/platform-server/-/platform-server-20.3.19.tgz",
+      "integrity": "sha512-9STNB8Z5uYpaIgzfiJOH81c4CY2lM3oq/650+pdnjJsedxyEi+NAbnn5tF857Cd/N+43lR+OMolKgm0MJziHqw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0",
+        "xhr2": "^0.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "20.3.19",
+        "@angular/compiler": "20.3.19",
+        "@angular/core": "20.3.19",
+        "@angular/platform-browser": "20.3.19",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
     "node_modules/@angular/router": {
       "version": "20.3.16",
       "resolved": "https://registry.npmjs.org/@angular/router/-/router-20.3.16.tgz",
@@ -1357,6 +1339,26 @@
         "@angular/core": "20.3.16",
         "@angular/platform-browser": "20.3.16",
         "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
+    "node_modules/@angular/ssr": {
+      "version": "20.3.24",
+      "resolved": "https://registry.npmjs.org/@angular/ssr/-/ssr-20.3.24.tgz",
+      "integrity": "sha512-ChY6ByYOBoEAXCgOpUNFgxeaZlGc3xUdxMRIbuIJQKIL8RipIlh5PYpyvCyLVAl4ciRH2/MSCyrFBIK0OoJtjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^20.0.0",
+        "@angular/core": "^20.0.0",
+        "@angular/platform-server": "^20.0.0",
+        "@angular/router": "^20.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@angular/platform-server": {
+          "optional": true
+        }
       }
     },
     "node_modules/@anthropic-ai/sdk": {


### PR DESCRIPTION
## Summary
- Backend: Brands ahora tienen store_id obligatorio y scope por tienda
- Backend: Inyecta store_id desde contexto al crear/actualizar marcas
- Backend: Brands agregadas al StorePrismaService con scope automático
- Frontend: Agregado método getAllBrands() para cargar hasta 200 marcas
- Frontend: Agregado método getAllCategories() para cargar hasta 200 categorías
- Frontend: Selector de marcas con búsqueda integrada (app-multi-selector)
- Frontend: Selector de categorías con búsqueda integrada (app-multi-selector)
- Frontend: Actualizado manejo de brand_ids y category_ids como arrays
- Seeds: Actualizado seed de productos para incluir store_id en marcas
- Funciona en: crear producto, edición rápida y página completa