### PR TITLE
fix: resolver TS18048 en RequestContextInterceptor

### DIFF
--- a/apps/backend/src/common/interceptors/request-context.interceptor.ts
+++ b/apps/backend/src/common/interceptors/request-context.interceptor.ts
@@ -32,13 +32,15 @@ export class RequestContextInterceptor implements NestInterceptor {
       const roles =
         user.user_roles?.map((ur) => ur.roles?.name).filter(Boolean) || [];
 
+      const effectiveRoles: string[] = user.roles || roles;
+
       contextObj.user_id = user.id || user.user_id;
       contextObj.organization_id = user.organization_id;
       contextObj.store_id = user.store_id;
-      contextObj.roles = user.roles || roles;
+      contextObj.roles = effectiveRoles;
       contextObj.permissions = user.permissions || [];
-      contextObj.is_super_admin = user.is_super_admin || contextObj.roles.includes('super_admin');
-      contextObj.is_owner = user.is_owner || contextObj.roles.includes('owner');
+      contextObj.is_super_admin = user.is_super_admin || effectiveRoles.includes('super_admin');
+      contextObj.is_owner = user.is_owner || effectiveRoles.includes('owner');
       contextObj.email = user.email;
     }
 


### PR DESCRIPTION
Usar variable local effectiveRoles para evitar que TS infiera contextObj.roles como posiblemente undefined al leerla tras asignar. Desbloquea el build del backend en Docker.