### PR TITLE
dev → main: inventory_locations unique por store

### DIFF
--- a/apps/backend/prisma/migrations/20260418040000_move_location_uniqueness_to_store/migration.sql
+++ b/apps/backend/prisma/migrations/20260418040000_move_location_uniqueness_to_store/migration.sql
@@ -1,0 +1,17 @@
+-- Move inventory_locations uniqueness from (organization_id, code) to (store_id, code).
+-- Stores operate independently; the organization is an informational boundary,
+-- not an operational one. Each store must be able to use standard codes like
+-- BOD-001 / BOD-002 regardless of sister stores within the same org.
+--
+-- Pre-deploy verification (run in prod): confirmed
+--   * 0 rows with store_id IS NULL
+--   * 0 rows with duplicate (store_id, code)
+--   * 61 total rows
+-- so the new unique index will not be violated by existing data.
+
+-- 1. Drop the old org-level unique index
+DROP INDEX IF EXISTS "inventory_locations_organization_id_code_key";
+
+-- 2. Create the new store-level unique index
+CREATE UNIQUE INDEX IF NOT EXISTS "inventory_locations_store_id_code_key"
+  ON "inventory_locations" USING btree (store_id, code);

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -1236,7 +1236,7 @@ model inventory_locations {
   dispatch_notes           dispatch_notes[]           @relation("dispatch_notes_location")
   dispatch_note_items      dispatch_note_items[]      @relation("dispatch_note_items_location")
 
-  @@unique([organization_id, code])
+  @@unique([store_id, code])
   @@index([organization_id, store_id])
   @@index([organization_id, type])
 }

--- a/apps/backend/src/domains/store/inventory/locations/locations.service.ts
+++ b/apps/backend/src/domains/store/inventory/locations/locations.service.ts
@@ -256,25 +256,31 @@ export class LocationsService {
   }
 
   /**
-   * Busca una ubicación activa por código (scope auto-aplica org/store)
+   * Busca una ubicación activa por código, restringido al store actual.
+   * El filtro explícito store_id evita matches cross-store con códigos idénticos
+   * (ahora que la uniqueness es a nivel store, no org).
    */
   async findByCode(code: string): Promise<any | null> {
+    const context = RequestContextService.getContext();
     return this.prisma.inventory_locations.findFirst({
       where: {
         code: { equals: code, mode: 'insensitive' },
         is_active: true,
+        ...(context?.store_id ? { store_id: context.store_id } : {}),
       },
     });
   }
 
   /**
-   * Busca una ubicación activa por nombre (scope auto-aplica org/store)
+   * Busca una ubicación activa por nombre, restringido al store actual.
    */
   async findByName(name: string): Promise<any | null> {
+    const context = RequestContextService.getContext();
     return this.prisma.inventory_locations.findFirst({
       where: {
         name: { equals: name, mode: 'insensitive' },
         is_active: true,
+        ...(context?.store_id ? { store_id: context.store_id } : {}),
       },
     });
   }


### PR DESCRIPTION
## Summary
- Promoción del fix #233 a producción.
- Mueve uniqueness de `inventory_locations` a nivel store — desbloquea bulk upload de productos en tiendas que reusan códigos estándar (BOD-001, etc) ya presentes en otra tienda de su organización.

## Test plan
- [ ] Workflow `deploy-backend-ec2.yml` corre y completa success.
- [ ] Migración `20260418040000_move_location_uniqueness_to_store` aplicada en RDS.
- [ ] Reintentar bulk upload en Aura Care — 54 productos pasan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)