### PR TITLE
fix(seed): actualizar seed al compound unique store_id_code

### DIFF
--- a/apps/backend/prisma/seeds/inventory-locations.seed.ts
+++ b/apps/backend/prisma/seeds/inventory-locations.seed.ts
@@ -105,8 +105,8 @@ export async function seedInventoryLocations(
   for (const location of locations) {
     const existing = await client.inventory_locations.findUnique({
       where: {
-        organization_id_code: {
-          organization_id: location.organization_id,
+        store_id_code: {
+          store_id: location.store_id,
           code: location.code,
         },
       },


### PR DESCRIPTION
Fix del build de Docker que reventó en deploy #24596896816 — seed usaba 'organization_id_code' pero el compound unique ahora es 'store_id_code'. Cambio mínimo de 2 líneas.