### PR TITLE
Products: stock integrity, UX polish, tooltip system

### DIFF
--- a/apps/backend/src/domains/store/inventory/shared/services/stock-level-manager.service.ts
+++ b/apps/backend/src/domains/store/inventory/shared/services/stock-level-manager.service.ts
@@ -1249,9 +1249,38 @@ export class StockLevelManager {
       }
     }
 
-    await this.syncProductStock(prisma, product_id);
+    await this.enforceStockLevelsMode(prisma, product_id);
 
     return [...new Set(locationIds)];
+  }
+
+  /**
+   * Mantiene stock_levels coherente con el modo del producto.
+   * - Producto con variantes: elimina filas base (product_variant_id IS NULL).
+   * - Producto sin variantes: no-op (las filas de variantes se eliminan al borrar la variante).
+   *
+   * Invariante: un producto NUNCA coexiste con filas base y filas de variante simultáneamente.
+   * Esto evita doble conteo en findOne/findAll y stock fantasma heredado de transiciones previas.
+   */
+  async enforceStockLevelsMode(
+    prisma: any,
+    product_id: number,
+  ): Promise<void> {
+    const basePrisma = prisma._baseClient || prisma;
+    const variantCount = await basePrisma.product_variants.count({
+      where: { product_id },
+    });
+
+    if (variantCount > 0) {
+      await basePrisma.stock_levels.deleteMany({
+        where: {
+          product_id,
+          product_variant_id: null,
+        },
+      });
+    }
+
+    await this.syncProductStock(prisma, product_id);
   }
 
   async transferVariantStockToBase(

--- a/apps/backend/src/domains/store/payments/payments.service.ts
+++ b/apps/backend/src/domains/store/payments/payments.service.ts
@@ -442,17 +442,19 @@ export class PaymentsService {
           if (!product?.track_inventory) continue;
 
           // Get actual available stock from stock_levels table (source of truth)
-          const stockLevel = await tx.stock_levels.findFirst({
+          // Aggregate across ALL locations — a product may have stock spread across
+          // multiple inventory_locations and findFirst would only return one row.
+          const stockAggregate = await tx.stock_levels.aggregate({
             where: {
               product_id: item.product_id,
-              product_variant_id: item.product_variant_id || null,
+              product_variant_id: item.product_variant_id ?? null,
             },
-            select: {
+            _sum: {
               quantity_available: true,
             },
           });
 
-          const available = stockLevel?.quantity_available ?? 0;
+          const available = stockAggregate._sum.quantity_available ?? 0;
 
           // BLOCK: If not allowing oversell and requested quantity exceeds available, throw immediately
           if (!allowOversell && item.quantity > available) {

--- a/apps/backend/src/domains/store/products/dto/index.ts
+++ b/apps/backend/src/domains/store/products/dto/index.ts
@@ -150,6 +150,11 @@ export class CreateVariantWithStockDto {
   @IsOptional()
   @IsString()
   variant_image_url?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  @Type(() => Boolean)
+  track_inventory_override?: boolean | null;
 }
 
 export class ProductImageDto {

--- a/apps/backend/src/domains/store/products/products.service.ts
+++ b/apps/backend/src/domains/store/products/products.service.ts
@@ -1256,9 +1256,10 @@ export class ProductsService {
         stock_by_location,
         variants,
         stock_transfer_mode,
+        variant_removal_stock_mode,
         price, // Exclude as it's not in DB
         ...productData
-      } = updateProductDto;
+      } = updateProductDto as UpdateProductDto & { price?: number };
 
       const result = await this.prisma.$transaction(
         async (prisma) => {

--- a/apps/backend/src/domains/store/products/products.service.ts
+++ b/apps/backend/src/domains/store/products/products.service.ts
@@ -667,6 +667,7 @@ export class ProductsService {
           ...(include_stock && {
             stock_levels: {
               select: {
+                product_variant_id: true,
                 quantity_available: true,
                 quantity_reserved: true,
                 inventory_locations: {
@@ -819,19 +820,27 @@ export class ProductsService {
       };
     }
 
-    // Calcular stock totals dinámicamente para cada producto
+    // Calcular stock totals dinámicamente para cada producto.
+    // Cuando el producto tiene variantes, excluir filas base para no duplicar stock.
     const productsWithStock = await Promise.all(
       products.map(async (product) => {
-        const totalStockAvailable =
-          product.stock_levels?.reduce(
-            (sum, stock) => sum + stock.quantity_available,
-            0,
-          ) || 0;
-        const totalStockReserved =
-          product.stock_levels?.reduce(
-            (sum, stock) => sum + stock.quantity_reserved,
-            0,
-          ) || 0;
+        const hasVariants =
+          ((product as any)._count?.product_variants ??
+            (product as any).product_variants?.length ??
+            0) > 0;
+        const stockLevelsForTotals = hasVariants
+          ? product.stock_levels?.filter(
+              (sl: any) => sl.product_variant_id !== null,
+            ) || []
+          : product.stock_levels || [];
+        const totalStockAvailable = stockLevelsForTotals.reduce(
+          (sum: number, stock: any) => sum + stock.quantity_available,
+          0,
+        );
+        const totalStockReserved = stockLevelsForTotals.reduce(
+          (sum: number, stock: any) => sum + stock.quantity_reserved,
+          0,
+        );
 
         const raw_image_url = product.product_images?.[0]?.image_url || null;
         const signed_image_url = await this.s3Service.signUrl(raw_image_url);
@@ -982,6 +991,7 @@ export class ProductsService {
         },
         stock_levels: {
           select: {
+            product_variant_id: true,
             quantity_available: true,
             quantity_reserved: true,
             reorder_point: true,
@@ -1013,12 +1023,19 @@ export class ProductsService {
       throw new VendixHttpException(ErrorCodes.PROD_FIND_001);
     }
 
-    // Calcular stock totals dinámicamente
-    const totalStockAvailable = product.stock_levels.reduce(
+    // Calcular stock totals dinámicamente.
+    // Si el producto tiene variantes, sumar solo filas de variantes (excluir base)
+    // para evitar contar stock base huérfano dos veces.
+    const hasVariants =
+      (product._count?.product_variants ?? product.product_variants?.length ?? 0) > 0;
+    const stockLevelsForTotals = hasVariants
+      ? product.stock_levels.filter((sl: any) => sl.product_variant_id !== null)
+      : product.stock_levels;
+    const totalStockAvailable = stockLevelsForTotals.reduce(
       (sum, stock) => sum + stock.quantity_available,
       0,
     );
-    const totalStockReserved = product.stock_levels.reduce(
+    const totalStockReserved = stockLevelsForTotals.reduce(
       (sum, stock) => sum + stock.quantity_reserved,
       0,
     );
@@ -1690,8 +1707,9 @@ export class ProductsService {
               }
             }
 
-            // Sync product stock from remaining variants
-            await this.stockLevelManager.syncProductStock(prisma, id);
+            // Enforce stock_levels mode: eliminar filas base huérfanas si hay variantes.
+            // Invariante: producto con variantes no mantiene filas (product_variant_id IS NULL).
+            await this.stockLevelManager.enforceStockLevelsMode(prisma, id);
           }
 
           // Guard: skip base stock updates when product has variants

--- a/apps/backend/src/domains/store/products/products.service.ts
+++ b/apps/backend/src/domains/store/products/products.service.ts
@@ -1401,8 +1401,15 @@ export class ProductsService {
             const isTransitionToVariants =
               allExistingVariants.length === 0 && variants.length > 0;
 
-            // BLOCK: Changing track_inventory when variants exist requires explicit stock_transfer_mode
-            if (updateProductDto.track_inventory !== undefined && allExistingVariants.length > 0) {
+            // BLOCK: Actually CHANGING track_inventory value (not just echoing it) when
+            // variants exist requires explicit stock_transfer_mode. Comparing against
+            // existingProduct avoids false positives when the frontend always sends the
+            // current value in the payload.
+            if (
+              updateProductDto.track_inventory !== undefined &&
+              updateProductDto.track_inventory !== existingProduct.track_inventory &&
+              allExistingVariants.length > 0
+            ) {
               if (!updateProductDto.stock_transfer_mode) {
                 throw new VendixHttpException(
                   ErrorCodes.PROD_VALIDATE_001,

--- a/apps/backend/src/domains/store/products/products.service.ts
+++ b/apps/backend/src/domains/store/products/products.service.ts
@@ -1438,6 +1438,29 @@ export class ProductsService {
                 }
               }
 
+              // BLOCK: Transitioning simple→variants with existing base stock requires
+              // explicit stock_transfer_mode. 'reset' is forbidden (would wipe stock);
+              // only 'first' or 'distribute' actually transfer the base stock to variants.
+              const baseStockSum = await prisma.stock_levels.aggregate({
+                where: { product_id: id, product_variant_id: null },
+                _sum: { quantity_on_hand: true },
+              });
+              const baseStockTotal = baseStockSum._sum.quantity_on_hand ?? 0;
+              if (baseStockTotal > 0) {
+                if (!updateProductDto.stock_transfer_mode) {
+                  throw new VendixHttpException(
+                    ErrorCodes.PROD_VALIDATE_001,
+                    'El producto tiene stock base. Elige cómo distribuirlo entre las variantes (first | distribute).',
+                  );
+                }
+                if (updateProductDto.stock_transfer_mode === 'reset') {
+                  throw new VendixHttpException(
+                    ErrorCodes.PROD_VALIDATE_001,
+                    "No puedes descartar stock al activar variantes. Usa 'first' o 'distribute' para transferirlo.",
+                  );
+                }
+              }
+
               const transferMode =
                 updateProductDto.stock_transfer_mode || 'reset';
               inheritedLocationIds =

--- a/apps/frontend/src/app/private/modules/store/products/interfaces/product.interface.ts
+++ b/apps/frontend/src/app/private/modules/store/products/interfaces/product.interface.ts
@@ -244,6 +244,7 @@ export interface CreateProductDto {
   variants?: CreateProductVariantDto[];
   stock_by_location?: StockByLocationDto[];
   stock_transfer_mode?: 'first' | 'distribute' | 'reset';
+  variant_removal_stock_mode?: 'first' | 'distribute' | 'reset';
 }
 
 export interface UpdateProductDto {
@@ -291,6 +292,7 @@ export interface UpdateProductDto {
   variants?: CreateProductVariantDto[];
   stock_by_location?: StockByLocationDto[];
   stock_transfer_mode?: 'first' | 'distribute' | 'reset';
+  variant_removal_stock_mode?: 'first' | 'distribute' | 'reset';
 }
 
 export interface CreateProductVariantDto {

--- a/apps/frontend/src/app/private/modules/store/products/pages/product-create-page/product-create-page.component.html
+++ b/apps/frontend/src/app/private/modules/store/products/pages/product-create-page/product-create-page.component.html
@@ -67,6 +67,7 @@
                 placeholder="Ej. Camiseta Algodón Premium"
                 [error]="getErrorMessage('name')"
                 [required]="true"
+                tooltipText="Nombre visible del producto en catálogo, facturas y buscador. Sé descriptivo y consistente."
                 customWrapperClass="!mt-0"
               ></app-input>
 
@@ -75,6 +76,7 @@
                 formControlName="sku"
                 placeholder="Ej. CAM-001"
                 [error]="getErrorMessage('sku')"
+                tooltipText="Código interno único del producto. Útil para inventario, etiquetas y búsqueda rápida en POS."
                 customWrapperClass="!mt-0"
               ></app-input>
 
@@ -83,6 +85,7 @@
                 formControlName="slug"
                 placeholder="camiseta-algodon-premium"
                 [error]="getErrorMessage('slug')"
+                tooltipText="Identificador para la URL pública del producto. Se genera automáticamente desde el nombre."
                 customWrapperClass="!mt-0"
               ></app-input>
             </div>
@@ -155,7 +158,9 @@
           </div>
 
           <!-- Grid 3x2: Pricing compacto -->
-          <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+          <div
+            class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-x-3 md:gap-x-4 gap-y-4 md:gap-y-5"
+          >
             <!-- Row 1: Costo | Margen | Precio Base -->
             <app-input
               [label]="
@@ -217,7 +222,7 @@
                 [options]="taxCategoryOptions"
                 formControlName="tax_category_ids"
                 placeholder="Seleccionar impuestos..."
-                helpText="Afectan al precio final"
+                tooltipText="Impuestos que se suman al precio base en facturación y checkout (IVA, INC, retenciones)."
               ></app-multi-selector>
 
               <app-button
@@ -574,14 +579,17 @@
           </div>
         </section>
 
-        <!-- Clasificación y Etiquetas Section -->
+        <!-- Clasificación y Medidas (unificada: marca/categorías + dimensiones/peso) -->
         <section
           class="bg-white rounded-2xl border border-gray-100 p-4 md:p-6 shadow-sm space-y-4"
         >
           <div class="flex items-center gap-2">
             <app-icon name="tag" size="18" class="text-primary-600"></app-icon>
             <h2 class="text-base font-bold text-gray-900">
-              Clasificación y Etiquetas
+              Clasificación
+              @if (!isService) {
+                <span class="text-gray-400 font-medium"> y Medidas</span>
+              }
             </h2>
           </div>
 
@@ -595,6 +603,7 @@
                   [options]="brandOptions"
                   formControlName="brand_ids"
                   placeholder="Seleccionar marca..."
+                  tooltipText="Marca del producto. Se usa para filtros en catálogo y reportes de ventas."
                 ></app-multi-selector>
 
                 <app-button
@@ -616,6 +625,7 @@
                   [options]="categoryOptions"
                   formControlName="category_ids"
                   placeholder="Seleccionar categorías..."
+                  tooltipText="Categorías donde aparecerá el producto. Un producto puede pertenecer a varias a la vez."
                 ></app-multi-selector>
 
                 <app-button
@@ -628,6 +638,64 @@
               </div>
             </div>
           </div>
+
+          @if (!isService) {
+            <div class="pt-4 border-t border-gray-100 space-y-3">
+              <div class="flex items-center gap-2">
+                <app-icon
+                  name="package"
+                  size="16"
+                  class="text-primary-600"
+                ></app-icon>
+                <span class="text-sm font-semibold text-gray-700"
+                  >Dimensiones y Peso</span
+                >
+              </div>
+              <div class="grid grid-cols-2 md:grid-cols-4 gap-3 md:gap-4">
+                <ng-container formGroupName="dimensions">
+                  <app-input
+                    label="Largo (cm)"
+                    type="number"
+                    formControlName="length"
+                    [control]="
+                      $any(productForm.get('dimensions'))?.get('length')
+                    "
+                    placeholder="0.00"
+                    tooltipText="Largo del producto empacado en centímetros. Se usa para cotizar envíos y ocupar espacio en almacén."
+                    customWrapperClass="!mt-0"
+                  ></app-input>
+                  <app-input
+                    label="Ancho (cm)"
+                    type="number"
+                    formControlName="width"
+                    [control]="$any(productForm.get('dimensions'))?.get('width')"
+                    placeholder="0.00"
+                    tooltipText="Ancho del producto empacado en centímetros."
+                    customWrapperClass="!mt-0"
+                  ></app-input>
+                  <app-input
+                    label="Alto (cm)"
+                    type="number"
+                    formControlName="height"
+                    [control]="
+                      $any(productForm.get('dimensions'))?.get('height')
+                    "
+                    placeholder="0.00"
+                    tooltipText="Alto del producto empacado en centímetros."
+                    customWrapperClass="!mt-0"
+                  ></app-input>
+                </ng-container>
+                <app-input
+                  label="Peso (kg)"
+                  type="number"
+                  formControlName="weight"
+                  placeholder="0.00"
+                  tooltipText="Peso del producto empacado en kilogramos. Afecta el cálculo de envío."
+                  customWrapperClass="!mt-0"
+                ></app-input>
+              </div>
+            </div>
+          }
         </section>
 
         <!-- Service-Specific Fields -->
@@ -654,8 +722,8 @@
                 type="number"
                 formControlName="service_duration_minutes"
                 placeholder="Ej. 60"
+                tooltipText="Duración estimada del servicio en minutos. Define la franja horaria que bloquea al proveedor."
                 customWrapperClass="!mt-0"
-                helperText="Duración estimada en minutos"
               ></app-input>
 
               <app-selector
@@ -663,6 +731,7 @@
                 [options]="serviceModalityOptions"
                 formControlName="service_modality"
                 placeholder="Seleccionar modalidad"
+                tooltipText="Dónde se presta el servicio: presencial, virtual o híbrido."
                 customWrapperClass="!mt-0"
               >
               </app-selector>
@@ -672,6 +741,7 @@
                 [options]="servicePricingTypeOptions"
                 formControlName="service_pricing_type"
                 placeholder="Seleccionar tipo"
+                tooltipText="Forma de cobrar: por hora, por sesión, paquete o suscripción."
                 customWrapperClass="!mt-0"
               >
               </app-selector>
@@ -702,6 +772,7 @@
                   { value: 'free_booking', label: 'Reserva libre' },
                 ]"
                 placeholder="Seleccionar modo"
+                tooltipText="'Requiere proveedor' asocia la cita a un profesional específico; 'Reserva libre' solo bloquea horario."
                 customWrapperClass="!mt-0"
               >
               </app-selector>
@@ -804,70 +875,6 @@
           </section>
         }
 
-        <!-- Dimensiones y Peso Section (only for physical products) -->
-        @if (!isService) {
-          <section
-            class="bg-white rounded-2xl border border-gray-100 p-4 md:p-6 shadow-sm space-y-4"
-          >
-            <div class="flex items-center gap-2">
-              <app-icon
-                name="package"
-                size="18"
-                class="text-primary-600"
-              ></app-icon>
-              <h2 class="text-base font-bold text-gray-900">
-                Dimensiones y Peso
-              </h2>
-            </div>
-
-            <div class="grid grid-cols-2 md:grid-cols-4 gap-3 md:gap-6">
-              <ng-container formGroupName="dimensions">
-                <!-- Length -->
-                <app-input
-                  label="Largo"
-                  type="number"
-                  formControlName="length"
-                  [control]="$any(productForm.get('dimensions'))?.get('length')"
-                  placeholder="0.00"
-                  helperText="cm"
-                  customWrapperClass="!mt-0"
-                ></app-input>
-
-                <!-- Width -->
-                <app-input
-                  label="Ancho"
-                  type="number"
-                  formControlName="width"
-                  [control]="$any(productForm.get('dimensions'))?.get('width')"
-                  placeholder="0.00"
-                  helperText="cm"
-                  customWrapperClass="!mt-0"
-                ></app-input>
-
-                <!-- Height -->
-                <app-input
-                  label="Alto"
-                  type="number"
-                  formControlName="height"
-                  [control]="$any(productForm.get('dimensions'))?.get('height')"
-                  placeholder="0.00"
-                  helperText="cm"
-                  customWrapperClass="!mt-0"
-                ></app-input>
-              </ng-container>
-
-              <!-- Weight -->
-              <app-input
-                label="Peso"
-                type="number"
-                formControlName="weight"
-                placeholder="0.00"
-                helperText="kg"
-                customWrapperClass="!mt-0"
-              ></app-input>
-            </div>
-          </section>
-        }
       </div>
 
       <!-- Right Column: Images & Stock (Desktop only) -->
@@ -1345,22 +1352,69 @@
           <!-- end @else track_inventory -->
         </section>
 
-        <!-- Operaciones Section (Desktop sidebar) -->
+        <!-- Promociones & Operaciones (Desktop sidebar, unificada) -->
         <section
           class="bg-white rounded-2xl border border-gray-100 p-4 md:p-6 shadow-sm space-y-4"
         >
           <div class="flex items-center gap-2">
-            <app-icon name="clock" size="18" class="text-primary-600"></app-icon>
-            <h2 class="text-base font-bold text-gray-900">Operaciones</h2>
+            <app-icon name="tag" size="18" class="text-primary-600"></app-icon>
+            <h2 class="text-base font-bold text-gray-900">
+              @if (isEditMode()) {
+                Promociones
+                <span class="text-gray-400 font-medium"> & Operaciones</span>
+              } @else {
+                Operaciones
+              }
+            </h2>
           </div>
-          <app-input
-            label="Tiempo de preparación"
-            type="number"
-            formControlName="preparation_time_minutes"
-            placeholder="Usa default de tienda"
-            helperText="minutos"
-            customWrapperClass="!mt-0"
-          ></app-input>
+
+          @if (isEditMode()) {
+            <div class="space-y-2">
+              <p class="text-xs text-gray-500">
+                Asocia promociones activas a este producto.
+              </p>
+              <app-multi-selector
+                label="Promociones"
+                [options]="promotionOptions"
+                [ngModel]="productPromotionIds"
+                [ngModelOptions]="{ standalone: true }"
+                (valueChange)="onPromotionsChange($event)"
+                placeholder="Seleccionar promociones..."
+                tooltipText="Descuentos o campañas activas asociadas a este producto. Se aplican automáticamente al checkout."
+              >
+              </app-multi-selector>
+            </div>
+
+            <div class="pt-4 border-t border-gray-100 space-y-2">
+              <div class="flex items-center gap-2">
+                <app-icon
+                  name="clock"
+                  size="16"
+                  class="text-primary-600"
+                ></app-icon>
+                <span class="text-sm font-semibold text-gray-700"
+                  >Operaciones</span
+                >
+              </div>
+              <app-input
+                label="Tiempo de preparación (min)"
+                type="number"
+                formControlName="preparation_time_minutes"
+                placeholder="Usa default de tienda"
+                tooltipText="Minutos que tarda tu equipo en preparar este producto antes de entregarlo. Afecta la ETA del pedido."
+                customWrapperClass="!mt-0"
+              ></app-input>
+            </div>
+          } @else {
+            <app-input
+              label="Tiempo de preparación (min)"
+              type="number"
+              formControlName="preparation_time_minutes"
+              placeholder="Usa default de tienda"
+              tooltipText="Minutos que tarda tu equipo en preparar este producto antes de entregarlo. Afecta la ETA del pedido."
+              customWrapperClass="!mt-0"
+            ></app-input>
+          }
         </section>
 
         <!-- Proveedores del Servicio (Desktop sidebar) -->
@@ -1449,33 +1503,6 @@
           </section>
         }
 
-        <!-- Promotions Section (Desktop sidebar, edit mode only) -->
-        @if (isEditMode()) {
-          <section
-            class="bg-white rounded-2xl border border-gray-100 p-4 md:p-6 shadow-sm space-y-4"
-          >
-            <div class="flex items-center gap-2">
-              <app-icon
-                name="tag"
-                size="18"
-                class="text-primary-600"
-              ></app-icon>
-              <h2 class="text-base font-bold text-gray-900">Promociones</h2>
-            </div>
-            <p class="text-sm text-gray-500">
-              Asocia promociones activas a este producto.
-            </p>
-            <app-multi-selector
-              label="Promociones"
-              [options]="promotionOptions"
-              [ngModel]="productPromotionIds"
-              [ngModelOptions]="{ standalone: true }"
-              (valueChange)="onPromotionsChange($event)"
-              placeholder="Seleccionar promociones..."
-            >
-            </app-multi-selector>
-          </section>
-        }
       </div>
     </div>
 
@@ -1646,170 +1673,151 @@
       </section>
     }
 
-    <!-- MOBILE: Promotions Section (edit mode only) -->
-    @if (isEditMode()) {
-      <section
-        class="lg:hidden bg-white rounded-2xl border border-gray-100 p-4 shadow-sm space-y-4"
-      >
-        <div class="flex items-center gap-2">
-          <app-icon name="tag" size="18" class="text-primary-600"></app-icon>
-          <h2 class="text-base font-bold text-gray-900">Promociones</h2>
+    <!-- MOBILE: Promociones & Operaciones (unificada) -->
+    <section
+      class="lg:hidden bg-white rounded-2xl border border-gray-100 p-4 shadow-sm space-y-4"
+    >
+      <div class="flex items-center gap-2">
+        <app-icon name="tag" size="18" class="text-primary-600"></app-icon>
+        <h2 class="text-base font-bold text-gray-900">
+          @if (isEditMode()) {
+            Promociones
+            <span class="text-gray-400 font-medium"> & Operaciones</span>
+          } @else {
+            Operaciones
+          }
+        </h2>
+      </div>
+
+      @if (isEditMode()) {
+        <div class="space-y-2">
+          <p class="text-xs text-gray-500">
+            Asocia promociones activas a este producto.
+          </p>
+          <app-multi-selector
+            label="Promociones"
+            [options]="promotionOptions"
+            [ngModel]="productPromotionIds"
+            [ngModelOptions]="{ standalone: true }"
+            (valueChange)="onPromotionsChange($event)"
+            placeholder="Seleccionar promociones..."
+            tooltipText="Descuentos o campañas activas asociadas a este producto. Se aplican automáticamente al checkout."
+          >
+          </app-multi-selector>
         </div>
-        <p class="text-sm text-gray-500">
-          Asocia promociones activas a este producto.
-        </p>
-        <app-multi-selector
-          label="Promociones"
-          [options]="promotionOptions"
-          [ngModel]="productPromotionIds"
-          [ngModelOptions]="{ standalone: true }"
-          (valueChange)="onPromotionsChange($event)"
-          placeholder="Seleccionar promociones..."
-        >
-        </app-multi-selector>
-      </section>
-    }
+
+        <div class="pt-4 border-t border-gray-100 space-y-2">
+          <div class="flex items-center gap-2">
+            <app-icon
+              name="clock"
+              size="16"
+              class="text-primary-600"
+            ></app-icon>
+            <span class="text-sm font-semibold text-gray-700">Operaciones</span>
+          </div>
+          <app-input
+            label="Tiempo de preparación (min)"
+            type="number"
+            formControlName="preparation_time_minutes"
+            placeholder="Usa default de tienda"
+            tooltipText="Minutos que tarda tu equipo en preparar este producto antes de entregarlo. Afecta la ETA del pedido."
+            customWrapperClass="!mt-0"
+          ></app-input>
+        </div>
+      } @else {
+        <app-input
+          label="Tiempo de preparación (min)"
+          type="number"
+          formControlName="preparation_time_minutes"
+          placeholder="Usa default de tienda"
+          tooltipText="Minutos que tarda tu equipo en preparar este producto antes de entregarlo. Afecta la ETA del pedido."
+          customWrapperClass="!mt-0"
+        ></app-input>
+      }
+    </section>
 
     <!-- Variants Section (Full Width) -->
     @if (hasVariants) {
       <section
         class="bg-white rounded-2xl border border-gray-100 p-4 md:p-6 shadow-sm animate-fadeIn space-y-4 md:space-y-5"
       >
-        <div class="flex items-center gap-2">
-          <app-icon name="layers" size="18" class="text-primary-600"></app-icon>
-          <div>
-            <h2 class="text-base font-bold text-gray-900">
-              Variantes
-              @if (generatedVariants.length > 0) {
-                <span
-                  class="ml-2 inline-flex items-center justify-center px-2 py-0.5 text-[11px] font-bold leading-none text-white bg-primary rounded-full"
-                >
-                  {{ generatedVariants.length }}
-                </span>
-              }
-            </h2>
-            <p class="text-xs text-gray-500">
-              Configura las combinaciones de tu producto
-            </p>
-          </div>
+        <div class="flex items-center gap-2 min-w-0">
+          <app-icon
+            name="layers"
+            size="18"
+            class="text-primary-600"
+          ></app-icon>
+          <h2 class="text-base font-bold text-gray-900 flex items-center gap-2">
+            Variantes
+            @if (generatedVariants.length > 0) {
+              <span
+                class="inline-flex items-center justify-center px-2 py-0.5 text-[11px] font-bold leading-none text-white bg-primary rounded-full"
+              >
+                {{ generatedVariants.length }}
+              </span>
+            }
+            <span
+              class="help-icon-inline text-gray-400 hover:text-warning"
+              data-tooltip="Los atributos (Color, Talla, Material...) generan combinaciones. Cada combinación es una variante del producto con su propio SKU, precio y stock independientes."
+            >
+              <app-icon name="help-circle" [size]="14"></app-icon>
+            </span>
+          </h2>
         </div>
+
         <!-- Variants UI -->
         <div class="space-y-4 md:space-y-5">
-          <!-- Variant count preview -->
-          @if (
-            variantAttributes.length > 0 &&
-            previewVariantCount > 0 &&
-            generatedVariants.length > 0
-          ) {
-            <div
-              class="flex items-center gap-2 p-3 bg-primary/5 border border-primary/15 rounded-xl"
-            >
-              <app-icon
-                name="layers"
-                size="16"
-                class="text-primary-600"
-              ></app-icon>
-              <span class="text-sm font-medium text-primary-700">
-                <strong>{{ generatedVariants.length }}</strong> variante{{
-                  generatedVariants.length !== 1 ? "s" : ""
-                }}
-                generada{{ generatedVariants.length !== 1 ? "s" : "" }}
-                automáticamente
-              </span>
-            </div>
-          }
-
           <!-- Duplicate SKU Warning -->
           @if (hasDuplicateSkus && generatedVariants.length > 0) {
             <div
-              class="flex items-center gap-2 p-3 bg-red-50 border border-red-200 rounded-xl"
+              class="flex items-center gap-2 p-2.5 bg-red-50 border border-red-200 rounded-lg"
             >
               <app-icon
                 name="alert-triangle"
-                size="16"
-                class="text-red-600"
+                size="14"
+                class="text-red-600 flex-shrink-0"
               ></app-icon>
-              <span class="text-sm font-medium text-red-700">
-                Hay SKUs duplicados entre las variantes. Cada variante debe tener
-                un SKU único para guardar.
+              <span class="text-xs font-medium text-red-700">
+                SKUs duplicados. Cada variante debe tener un SKU único.
               </span>
-            </div>
-          }
-
-          <!-- Bulk Actions Bar -->
-          @if (generatedVariants.length > 0) {
-            <div
-              class="flex flex-wrap gap-2 p-3 bg-gray-50 border border-gray-200 rounded-xl"
-            >
-              <span
-                class="text-xs font-bold text-text-muted uppercase tracking-wider self-center mr-2"
-              >
-                {{ generatedVariants.length }} variantes
-              </span>
-              <app-button
-                variant="outline"
-                size="sm"
-                (clicked)="applyBasePriceToAll()"
-              >
-                <app-icon slot="icon" name="dollar-sign" [size]="14"></app-icon>
-                Aplicar precio base a todas
-              </app-button>
-              <app-button
-                variant="outline"
-                size="sm"
-                (clicked)="applyBaseCostToAll()"
-              >
-                <app-icon slot="icon" name="calculator" [size]="14"></app-icon>
-                Aplicar costo base a todas
-              </app-button>
             </div>
           }
 
           <!-- Quick Attribute Buttons -->
-          <div class="flex flex-wrap gap-2">
+          <div class="flex flex-wrap items-center gap-1.5">
+            <span class="text-xs text-gray-500 mr-1">Añadir atributo:</span>
             <button
               type="button"
               (click)="addQuickAttribute('Color')"
-              class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg border border-dashed border-primary/30 text-primary-600 bg-primary/5 hover:bg-primary/10 hover:border-primary/50 transition-colors"
+              data-tooltip="Agrega un atributo Color. Ingresa luego los valores (Rojo, Azul, ...)."
+              class="help-icon-inline inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-md border border-dashed border-primary/30 text-primary-600 hover:bg-primary/5 transition-colors"
             >
-              <app-icon name="plus" size="12"></app-icon> Color
+              <app-icon name="plus" size="11"></app-icon> Color
             </button>
             <button
               type="button"
               (click)="addQuickAttribute('Talla')"
-              class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg border border-dashed border-primary/30 text-primary-600 bg-primary/5 hover:bg-primary/10 hover:border-primary/50 transition-colors"
+              data-tooltip="Agrega un atributo Talla. Ingresa luego los valores (S, M, L, ...)."
+              class="help-icon-inline inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-md border border-dashed border-primary/30 text-primary-600 hover:bg-primary/5 transition-colors"
             >
-              <app-icon name="plus" size="12"></app-icon> Talla
+              <app-icon name="plus" size="11"></app-icon> Talla
             </button>
             <button
               type="button"
               (click)="addQuickAttribute('Material')"
-              class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg border border-dashed border-primary/30 text-primary-600 bg-primary/5 hover:bg-primary/10 hover:border-primary/50 transition-colors"
+              data-tooltip="Agrega un atributo Material. Ingresa luego los valores (Algodón, Lana, ...)."
+              class="help-icon-inline inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-md border border-dashed border-primary/30 text-primary-600 hover:bg-primary/5 transition-colors"
             >
-              <app-icon name="plus" size="12"></app-icon> Material
+              <app-icon name="plus" size="11"></app-icon> Material
             </button>
             <button
               type="button"
               (click)="addAttribute()"
-              class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg border border-dashed border-gray-300 text-gray-600 bg-gray-50 hover:bg-gray-100 hover:border-gray-400 transition-colors"
+              data-tooltip="Crea un atributo con un nombre personalizado (p.ej. Sabor, Capacidad, Edición)."
+              class="help-icon-inline inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-md border border-dashed border-gray-300 text-gray-600 hover:bg-gray-50 transition-colors"
             >
-              <app-icon name="plus" size="12"></app-icon> Personalizado
+              <app-icon name="plus" size="11"></app-icon> Personalizado
             </button>
-          </div>
-          <!-- Info tooltip about attributes -->
-          <div
-            class="flex items-start gap-2 p-2.5 bg-gray-50 border border-gray-200 rounded-lg"
-          >
-            <app-icon
-              name="info"
-              size="14"
-              class="text-gray-400 mt-0.5 flex-shrink-0"
-            ></app-icon>
-            <p class="text-[11px] text-gray-500 leading-relaxed">
-              Los valores se agregan con Enter. Cada combinación de valores
-              genera automáticamente una variante con su propio precio, stock y
-              SKU.
-            </p>
           </div>
           <!-- Attribute Manager -->
           <div class="space-y-3 md:space-y-4">
@@ -1826,14 +1834,22 @@
                       [ngModelOptions]="{ standalone: true }"
                       placeholder="Ej. Talla, Color"
                       (inputBlur)="onAttributeNameBlur(i)"
+                      tooltipText="Etiqueta del eje de variación. Ejemplos: 'Color', 'Talla', 'Material', 'Capacidad'. Define la dimensión, no los valores."
                       customWrapperClass="!mt-0"
                     ></app-input>
                   </div>
                   <div class="flex-1">
                     <label
-                      class="block text-sm font-medium text-text-primary mb-2"
-                      >Valores (Enter para agregar)</label
+                      class="flex items-center gap-1 text-sm font-medium text-text-primary mb-2"
                     >
+                      <span>Valores</span>
+                      <span
+                        class="help-icon-inline text-gray-400 hover:text-warning"
+                        data-tooltip="Opciones concretas del atributo. Escribe y presiona Enter para cada una (ej. 'Rojo', 'Azul'). El producto de todos los valores de cada atributo genera las variantes."
+                      >
+                        <app-icon name="help-circle" [size]="12"></app-icon>
+                      </span>
+                    </label>
                     <div
                       class="flex flex-wrap gap-2 px-3 py-1.5 bg-surface rounded-sm border border-border min-h-[34px] focus-within:ring-2 focus-within:ring-primary/50 focus-within:border-primary transition-colors"
                     >
@@ -1865,17 +1881,10 @@
                         (blur)="addAttributeValue(i, $event)"
                       />
                     </div>
-                    @if (attr.values.length === 0) {
-                      <p
-                        class="text-[10px] text-text-muted mt-1 flex items-center gap-1"
-                      >
-                        <app-icon name="info" size="10"></app-icon>
-                        Presiona Enter para agregar cada valor
-                      </p>
-                    }
                   </div>
                   <button
                     (click)="removeAttribute(i)"
+                    title="Eliminar este atributo"
                     class="self-end md:mt-6 text-destructive hover:text-destructive/80 p-2"
                   >
                     <app-icon name="trash-2" size="18"></app-icon>
@@ -1892,73 +1901,37 @@
               Agregar Atributo
             </button>
           </div>
-          <!-- Variant count preview -->
-          @if (
-            variantAttributes.length > 0 &&
-            previewVariantCount > 0 &&
-            generatedVariants.length > 0
-          ) {
-            <div
-              class="flex items-center gap-2 p-3 bg-primary/5 border border-primary/15 rounded-xl"
-            >
-              <app-icon
-                name="layers"
-                size="16"
-                class="text-primary-600"
-              ></app-icon>
-              <span class="text-sm font-medium text-primary-700">
-                <strong>{{ generatedVariants.length }}</strong> variante{{
-                  generatedVariants.length !== 1 ? "s" : ""
-                }}
-                generada{{ generatedVariants.length !== 1 ? "s" : "" }}
-                automáticamente
-              </span>
-            </div>
-          }
-          <!-- Duplicate SKU Warning -->
-          @if (hasDuplicateSkus && generatedVariants.length > 0) {
-            <div
-              class="flex items-center gap-2 p-3 bg-red-50 border border-red-200 rounded-xl"
-            >
-              <app-icon
-                name="alert-triangle"
-                size="16"
-                class="text-red-600"
-              ></app-icon>
-              <span class="text-sm font-medium text-red-700">
-                Hay SKUs duplicados entre las variantes. Cada variante debe
-                tener un SKU único para guardar.
-              </span>
-            </div>
-          }
-          <!-- Bulk Actions Bar -->
+          <!-- Bulk Actions Bar (encima de la lista/tabla de variantes) -->
           @if (generatedVariants.length > 0) {
             <div
-              class="flex flex-wrap gap-2 p-3 bg-gray-50 border border-gray-200 rounded-xl"
+              class="flex items-center justify-between gap-2 px-3 py-2 bg-gray-50 border border-gray-200 rounded-lg"
             >
-              <span
-                class="text-xs font-bold text-text-muted uppercase tracking-wider self-center mr-2"
-              >
-                {{ generatedVariants.length }} variantes
+              <span class="text-xs font-medium text-gray-500">
+                Aplicar a todas:
               </span>
-              <app-button
-                variant="outline"
-                size="sm"
-                (clicked)="applyBasePriceToAll()"
-              >
-                <app-icon slot="icon" name="dollar-sign" [size]="14"></app-icon>
-                Aplicar precio base a todas
-              </app-button>
-              <app-button
-                variant="outline"
-                size="sm"
-                (clicked)="applyBaseCostToAll()"
-              >
-                <app-icon slot="icon" name="calculator" [size]="14"></app-icon>
-                Aplicar costo base a todas
-              </app-button>
+              <div class="flex items-center gap-1.5">
+                <button
+                  type="button"
+                  (click)="applyBasePriceToAll()"
+                  class="help-icon-inline inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-md text-gray-700 border border-gray-200 bg-white hover:border-primary/40 hover:text-primary-700 transition-colors"
+                  data-tooltip="Copia el precio base del producto al precio de venta de todas las variantes."
+                >
+                  <app-icon name="dollar-sign" [size]="13"></app-icon>
+                  Precio
+                </button>
+                <button
+                  type="button"
+                  (click)="applyBaseCostToAll()"
+                  class="help-icon-inline inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-md text-gray-700 border border-gray-200 bg-white hover:border-primary/40 hover:text-primary-700 transition-colors"
+                  data-tooltip="Copia el precio de costo del producto al costo de todas las variantes."
+                >
+                  <app-icon name="calculator" [size]="13"></app-icon>
+                  Costo
+                </button>
+              </div>
             </div>
           }
+
           <!-- Generated Variants - Mobile Cards View (Collapsible) -->
           @if (generatedVariants.length > 0) {
             <div class="lg:hidden space-y-2">

--- a/apps/frontend/src/app/private/modules/store/products/pages/product-create-page/product-create-page.component.ts
+++ b/apps/frontend/src/app/private/modules/store/products/pages/product-create-page/product-create-page.component.ts
@@ -473,7 +473,9 @@ export class ProductCreatePageComponent {
   generatedVariants: GeneratedVariant[] = [];
   removedVariantKeys = new Set<string>();
   expandedVariantIndex = signal<number | null>(null);
-  stockTransferMode: 'first' | 'distribute' | 'reset' = 'reset';
+  stockTransferMode: 'first' | 'distribute' | 'reset' | null = null;
+  readonly originalBaseStock = signal(0);
+  readonly originalHadVariants = signal(false);
 
   // New Attribute Input
   newAttributeName = '';
@@ -824,6 +826,12 @@ export class ProductCreatePageComponent {
       this.imageIds = product.product_images.map((img: any) => img.id ?? null);
     }
 
+    // Capture original baseline for strict variant/stock transition guards
+    this.originalBaseStock.set(Number(product.stock_quantity ?? 0));
+    this.originalHadVariants.set(
+      !!(product.product_variants && product.product_variants.length > 0),
+    );
+
     // Load variants if present
     if (product.product_variants && product.product_variants.length > 0) {
       this.hasVariants = true;
@@ -969,7 +977,7 @@ export class ProductCreatePageComponent {
         return;
       }
 
-      this.stockTransferMode = 'reset';
+      this.stockTransferMode = null;
       this.applyVariantToggle(true);
     } else {
       if (this.isEditMode() && this.generatedVariants.length > 0) {
@@ -1142,7 +1150,8 @@ export class ProductCreatePageComponent {
         continue;
       }
 
-      // New variant
+      // New variant — defaults to track_inventory_override=true
+      // (la variante maneja su propio stock, no hereda del producto base).
       newVariants.push({
         name: `${this.productForm.get('name')?.value || 'Product'}${nameSuffix}`,
         sku: baseSku ? `${baseSku}${skuSuffix}` : '',
@@ -1153,6 +1162,7 @@ export class ProductCreatePageComponent {
         sale_price: 0,
         stock: 0,
         attributes,
+        track_inventory_override: true,
       });
     }
 
@@ -1714,6 +1724,47 @@ export class ProductCreatePageComponent {
         );
         return;
       }
+
+      // Strict guard: edit mode, transitioning simple→variants, base stock > 0.
+      // Force a non-reset mode AND ensure variant totals match the base stock
+      // (no stock can be "lost" in the transition).
+      const baseline = this.originalBaseStock();
+      const isTransitioning =
+        this.isEditMode() && !this.originalHadVariants() && baseline > 0;
+      if (isTransitioning) {
+        if (!this.stockTransferMode || this.stockTransferMode === 'reset') {
+          this.toastService.error(
+            "Debes redistribuir el stock base. Elige 'Asignar a una variante' o 'Distribuir'.",
+            'Redistribución requerida',
+          );
+          this.showStockTransferDialog(baseline);
+          return;
+        }
+        if (this.totalVariantStock !== baseline) {
+          this.toastService.error(
+            `La suma de stock de las variantes (${this.totalVariantStock}) debe igualar el stock base original (${baseline}).`,
+            'Totales desalineados',
+          );
+          return;
+        }
+      }
+
+      // Track-inventory products with variants must declare at least one unit of stock
+      // across the variants (otherwise the product becomes unsellable silently).
+      const trackInventoryEnabled = !!this.productForm.get('track_inventory')?.value;
+      if (trackInventoryEnabled) {
+        const allVariantsTrackInventory = this.generatedVariants.every((v) => {
+          if (v.track_inventory_override === false) return false;
+          return true;
+        });
+        if (allVariantsTrackInventory && this.totalVariantStock <= 0) {
+          this.toastService.error(
+            'Todas las variantes que manejan stock tienen 0 unidades. Asigna al menos 1 unidad antes de guardar.',
+            'Stock de variantes requerido',
+          );
+          return;
+        }
+      }
     }
 
     this.isSubmitting.set(true);
@@ -1834,8 +1885,15 @@ export class ProductCreatePageComponent {
       productData.variants = [];
     }
 
-    if (this.isEditMode()) {
+    if (this.isEditMode() && this.stockTransferMode) {
       productData.stock_transfer_mode = this.stockTransferMode;
+    }
+
+    // Reverse transfer: disabling variants on a product that previously had variants.
+    // Backend auto-sums all variant stock into base stock; flag is required as an
+    // explicit confirmation (any non-reset value works).
+    if (this.isEditMode() && !this.hasVariants && this.originalHadVariants()) {
+      productData.variant_removal_stock_mode = 'distribute';
     }
 
     const request$ =

--- a/apps/frontend/src/app/private/modules/store/products/pages/product-create-page/product-create-page.component.ts
+++ b/apps/frontend/src/app/private/modules/store/products/pages/product-create-page/product-create-page.component.ts
@@ -328,6 +328,50 @@ export type { GeneratedVariant };
           background-position: 0% 50%;
         }
       }
+
+      /* ── Inline tooltip help icon (styled tooltip, not native [title]) ── */
+      .help-icon-inline {
+        position: relative;
+        display: inline-flex;
+        align-items: center;
+        cursor: help;
+        transition: color 0.2s ease;
+      }
+
+      .help-icon-inline[data-tooltip]:hover::after {
+        content: attr(data-tooltip);
+        position: absolute;
+        bottom: 100%;
+        left: 50%;
+        transform: translateX(-50%);
+        padding: 0.375rem 0.5rem;
+        background: var(--color-text-primary);
+        color: var(--color-surface);
+        font-size: var(--fs-xs);
+        border-radius: var(--radius-sm);
+        white-space: normal;
+        box-shadow: var(--shadow-md);
+        z-index: 50;
+        margin-bottom: 0.375rem;
+        pointer-events: none;
+        max-width: 280px;
+        width: max-content;
+        text-align: center;
+        line-height: 1.4;
+      }
+
+      .help-icon-inline[data-tooltip]:hover::before {
+        content: '';
+        position: absolute;
+        bottom: 100%;
+        left: 50%;
+        transform: translateX(-50%);
+        border: 4px solid transparent;
+        border-top-color: var(--color-text-primary);
+        margin-bottom: -0.125rem;
+        z-index: 50;
+        pointer-events: none;
+      }
     `,
   ],
 })
@@ -951,7 +995,10 @@ export class ProductCreatePageComponent {
   }
 
   get totalVariantStock(): number {
-    return this.generatedVariants.reduce((sum, v) => sum + (v.stock || 0), 0);
+    return this.generatedVariants.reduce(
+      (sum, v) => sum + (Number(v.stock) || 0),
+      0,
+    );
   }
 
   toggleVariants(isChecked: boolean): void {

--- a/apps/frontend/src/app/shared/components/input/input.component.ts
+++ b/apps/frontend/src/app/shared/components/input/input.component.ts
@@ -17,6 +17,7 @@ import {
 
 import { FormStyleVariant } from '../../types/form.types';
 import { CurrencyFormatService } from '../../pipes/currency/currency.pipe';
+import { IconComponent } from '../icon/icon.component';
 
 export type InputType =
   | 'text'
@@ -34,7 +35,7 @@ export type InputSize = 'sm' | 'md' | 'lg';
 @Component({
   selector: 'app-input',
   standalone: true,
-  imports: [],
+  imports: [IconComponent],
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,
@@ -54,19 +55,7 @@ export type InputSize = 'sm' | 'md' | 'lg';
           <span>{{ label() }}</span>
           @if (tooltipText()) {
             <span class="help-icon" [attr.data-tooltip]="tooltipText()">
-              <svg
-                class="h-4 w-4"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                stroke-width="2"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                />
-              </svg>
+              <app-icon name="help-circle" [size]="14"></app-icon>
             </span>
           }
           @if (required()) {

--- a/apps/frontend/src/app/shared/components/multi-selector/multi-selector.component.ts
+++ b/apps/frontend/src/app/shared/components/multi-selector/multi-selector.component.ts
@@ -45,9 +45,15 @@ export type MultiSelectorSize = 'sm' | 'md' | 'lg';
       @if (label()) {
         <label
           [class]="labelClasses"
+          class="label-with-tooltip"
           [class.opacity-50]="disabled()"
           >
-          {{ label() }}
+          <span>{{ label() }}</span>
+          @if (tooltipText()) {
+            <span class="help-icon" [attr.data-tooltip]="tooltipText()">
+              <app-icon name="help-circle" [size]="14"></app-icon>
+            </span>
+          }
           @if (required()) {
             <span class="text-[var(--color-destructive)] ml-0.5">*</span>
           }
@@ -146,9 +152,12 @@ export type MultiSelectorSize = 'sm' | 'md' | 'lg';
                       ></app-icon>
                     }
                   </div>
-                  <span class="flex-1 text-[var(--color-text-primary)]" [class.text-primary-700]="isSelected(option.value)">{{ option.label }}</span>
+                  <span class="flex-1 min-w-0 text-[var(--color-text-primary)] truncate" [class.text-primary-700]="isSelected(option.value)">{{ option.label }}</span>
                   @if (option.description) {
-                    <span class="text-xs text-[var(--color-text-secondary)]">
+                    <span
+                      class="text-xs text-[var(--color-text-secondary)] truncate whitespace-nowrap overflow-hidden max-w-[40%] shrink-0"
+                      [title]="option.description"
+                    >
                       {{ option.description }}
                     </span>
                   }
@@ -188,6 +197,59 @@ export type MultiSelectorSize = 'sm' | 'md' | 'lg';
     :host {
       display: block;
     }
+
+    .label-with-tooltip {
+      display: flex;
+      align-items: center;
+      gap: 0.25rem;
+    }
+
+    .help-icon {
+      color: var(--color-text-muted);
+      cursor: help;
+      position: relative;
+      display: inline-flex;
+      transition: color 0.2s ease;
+    }
+
+    .help-icon:hover {
+      color: var(--color-warning);
+    }
+
+    .help-icon[data-tooltip]:hover::after {
+      content: attr(data-tooltip);
+      position: absolute;
+      bottom: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      padding: 0.375rem 0.5rem;
+      background: var(--color-text-primary);
+      color: var(--color-surface);
+      font-size: var(--fs-xs);
+      border-radius: var(--radius-sm);
+      white-space: normal;
+      box-shadow: var(--shadow-md);
+      z-index: 50;
+      margin-bottom: 0.375rem;
+      pointer-events: none;
+      max-width: 300px;
+      width: max-content;
+      text-align: center;
+      line-height: 1.4;
+    }
+
+    .help-icon[data-tooltip]:hover::before {
+      content: '';
+      position: absolute;
+      bottom: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 4px solid transparent;
+      border-top-color: var(--color-text-primary);
+      margin-bottom: -0.125rem;
+      z-index: 50;
+      pointer-events: none;
+    }
   `],
 })
 export class MultiSelectorComponent implements ControlValueAccessor {
@@ -196,6 +258,7 @@ export class MultiSelectorComponent implements ControlValueAccessor {
   readonly label = input<string>('');
   readonly placeholder = input<string>('Seleccionar...');
   readonly helpText = input<string>('');
+  readonly tooltipText = input<string>('');
   readonly errorText = input<string>('');
   readonly required = input<boolean>(false);
   readonly disabled = input<boolean>(false);

--- a/apps/frontend/src/app/shared/components/selector/selector.component.ts
+++ b/apps/frontend/src/app/shared/components/selector/selector.component.ts
@@ -52,19 +52,7 @@ export type SelectorVariant = 'default' | 'outline' | 'filled';
               class="help-icon"
               [attr.data-tooltip]="tooltipText()"
               >
-              <svg
-                class="h-4 w-4"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                stroke-width="2"
-                >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                  />
-              </svg>
+              <app-icon name="help-circle" [size]="14"></app-icon>
             </span>
           }
           @if (required()) {

--- a/apps/frontend/src/app/shared/components/textarea/textarea.component.ts
+++ b/apps/frontend/src/app/shared/components/textarea/textarea.component.ts
@@ -12,11 +12,12 @@ import {
   AbstractControl,
 } from '@angular/forms';
 import { FormStyleVariant } from '../../types/form.types';
+import { IconComponent } from '../icon/icon.component';
 
 @Component({
   selector: 'app-textarea',
   standalone: true,
-  imports: [],
+  imports: [IconComponent],
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,
@@ -31,8 +32,14 @@ import { FormStyleVariant } from '../../types/form.types';
         <label
           [for]="textareaId"
           [class]="labelClasses"
+          class="label-with-tooltip"
           >
-          {{ label() }}
+          <span>{{ label() }}</span>
+          @if (tooltipText()) {
+            <span class="help-icon" [attr.data-tooltip]="tooltipText()">
+              <app-icon name="help-circle" [size]="14"></app-icon>
+            </span>
+          }
           @if (required()) {
             <span class="text-[var(--color-destructive)] ml-1"
               >*</span
@@ -86,6 +93,59 @@ import { FormStyleVariant } from '../../types/form.types';
       resize: vertical;
       min-height: 80px;
     }
+
+    .label-with-tooltip {
+      display: flex;
+      align-items: center;
+      gap: 0.25rem;
+    }
+
+    .help-icon {
+      color: var(--color-text-muted);
+      cursor: help;
+      position: relative;
+      display: inline-flex;
+      transition: color 0.2s ease;
+    }
+
+    .help-icon:hover {
+      color: var(--color-warning);
+    }
+
+    .help-icon[data-tooltip]:hover::after {
+      content: attr(data-tooltip);
+      position: absolute;
+      bottom: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      padding: 0.375rem 0.5rem;
+      background: var(--color-text-primary);
+      color: var(--color-surface);
+      font-size: var(--fs-xs);
+      border-radius: var(--radius-sm);
+      white-space: normal;
+      box-shadow: var(--shadow-md);
+      z-index: 50;
+      margin-bottom: 0.375rem;
+      pointer-events: none;
+      max-width: 300px;
+      width: max-content;
+      text-align: center;
+      line-height: 1.4;
+    }
+
+    .help-icon[data-tooltip]:hover::before {
+      content: '';
+      position: absolute;
+      bottom: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 4px solid transparent;
+      border-top-color: var(--color-text-primary);
+      margin-bottom: -0.125rem;
+      z-index: 50;
+      pointer-events: none;
+    }
   `],
 })
 export class TextareaComponent implements ControlValueAccessor {
@@ -97,6 +157,7 @@ export class TextareaComponent implements ControlValueAccessor {
   readonly required = input(false);
   readonly error = input<string>();
   readonly helperText = input<string | undefined>(undefined);
+  readonly tooltipText = input<string>('');
   readonly control = input<AbstractControl | null>();
   readonly styleVariant = input<FormStyleVariant>('modern');
   readonly customStyle = input('');


### PR DESCRIPTION
## Summary

- **Stock integrity (variants ↔ base)**: Enforce invariant in backend so a product never has base and variant stock_levels rows simultaneously. Self-heals legacy products with orphan base rows. Fixes 2× counting in product responses.
- **Bidirectional stock transfer**: Strict guards + bidirectional redistribution between base product and variants with explicit modes (`first`/`distribute`). Frontend blocks save if totals are misaligned.
- **Product form UX**: Unified sections (Operaciones + Promociones, Clasificación + Dimensiones), compacted Variants section (removed duplicated banners/bars), fixed Operaciones hidden-on-mobile bug, moved bulk Precio/Costo actions above variant table.
- **Tooltip system**: Added `tooltipText` support to `app-multi-selector` and `app-textarea`; replaced inline SVG help-circle with `<app-icon>` across form controls; seeded accurate tooltips across all product form fields.
- **Bug fixes**:
  - `totalVariantStock` string-concat fix (was producing "010101" instead of summed integers).
  - Prisma `Unknown argument brand_id` fix (strip `variant_removal_stock_mode` before spread).
  - Track-inventory guard only fires when the value actually changes, not when echoed.
  - POS cross-location stock check via `aggregate._sum` (was missing stock from non-default locations).

## Test plan

- [ ] Product with stock on base, no variants → enable variants with `first` mode → base row deleted, variants share total stock.
- [ ] Product with stock on base, no variants → enable variants with `distribute` mode → base row deleted, variants receive distributed quantities.
- [ ] Product with variants → disable variants → variants collapse into base stock, `variant_removal_stock_mode` flag set, variants deleted.
- [ ] Legacy product with orphan base stock_level + variants → save → enforce runs, base row deleted, total_stock_available matches variant sum.
- [ ] POS checkout: sell a variant with stock in a non-default location → no false "Insufficient stock" error.
- [ ] Frontend form: tooltips visible on hover for all fields (Info General, Pricing, Classification, Dimensions, Services, Operations, Variants).
- [ ] Mobile view: Operaciones section now visible (was hidden before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)