### PR TITLE
fix(quotations): pass user object to ordersService.create instead of raw user_id

### DIFF
--- a/apps/backend/src/domains/store/quotations/quotations.service.ts
+++ b/apps/backend/src/domains/store/quotations/quotations.service.ts
@@ -389,7 +389,7 @@ export class QuotationsService {
         internal_notes: `Convertida desde cotización ${quotation.quotation_number}`,
         channel: quotation.channel,
       } as any,
-      context?.user_id,
+      { id: context?.user_id },
     );
 
     // Update quotation status


### PR DESCRIPTION
## Resumen
Fix bug donde la conversion de cotizacion a orden falla porque ordersService.create() recibe un numero directo en lugar de un objeto de usuario.

## Bug
En el metodo convertToOrder(), context?.user_id (un numero) se pasaba como argumento creatingUser a ordersService.create(). El metodo espera un objeto { id: number } y accede a creatingUser?.id, que siempre retornaba undefined.

## Fix
Envolver context?.user_id en un objeto: { id: context?.user_id }.

## Archivos cambiados
- apps/backend/src/domains/store/quotations/quotations.service.ts -- linea 392