### PR TITLE
fix(auth): agregar @IsNotEmpty a first_name y last_name en register-staff.dto

### DIFF
--- a/apps/backend/src/domains/auth/dto/register-staff.dto.ts
+++ b/apps/backend/src/domains/auth/dto/register-staff.dto.ts
@@ -13,12 +13,14 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 export class RegisterStaffDto {
   @ApiProperty({ example: 'Juan', description: 'Nombre del staff' })
   @IsString()
+  @IsNotEmpty({ message: 'El nombre es requerido' })
   @MinLength(1)
   @MaxLength(100)
   first_name: string;
 
   @ApiProperty({ example: 'Pérez', description: 'Apellido del staff' })
   @IsString()
+  @IsNotEmpty({ message: 'El apellido es requerido' })
   @MinLength(1)
   @MaxLength(100)
   last_name: string;


### PR DESCRIPTION
## Resumen
Fix validacion donde first_name y last_name en register-staff.dto.ts aceptaban strings vacios porque solo tenian @MinLength(1) pero faltaba @IsNotEmpty().

## Bug
El DTO register-staff tiene @MinLength(1) en first_name y last_name, pero no tiene @IsNotEmpty(). Esto permite enviar strings vacios "" que pasan la validacion.

## Fix
Agregar @IsNotEmpty({ message: 'El nombre es requerido' }) y @IsNotEmpty({ message: 'El apellido es requerido' }) a los campos first_name y last_name.

## Archivos cambiados
- apps/backend/src/domains/auth/dto/register-staff.dto.ts — lineas 15-17 y 22-24