### PR TITLE
fix: reject path traversal sequences in presigned-url key

### DIFF
--- a/apps/backend/src/domains/upload/upload.controller.ts
+++ b/apps/backend/src/domains/upload/upload.controller.ts
@@ -233,6 +233,11 @@ export class UploadController {
       throw new VendixHttpException(ErrorCodes.UPLOAD_ORG_001);
     }
 
+    // Validate key does not contain path traversal sequences before normalization
+    if (key.includes('..')) {
+      throw new VendixHttpException(ErrorCodes.UPLOAD_FORBIDDEN_001);
+    }
+
     const expectedOrgPrefix = this.s3PathHelper.buildOrgPath(org);
 
     // Normalize key to resolve path segments before checking prefix


### PR DESCRIPTION
## Summary
- Add validation to reject `..` path traversal sequences in presigned-url endpoint before normalization
- Prevents attacks like `org-slug/../../etc/passwd` that could bypass the prefix check after normalization

## Changes
- `apps/backend/src/domains/upload/upload.controller.ts` — Added explicit check for `..` in key before normalization

## Security
- **Severity**: Medium
- **Vulnerability**: Path traversal via `../` sequences in S3 key parameter

## Testing
- Key containing `../` should be rejected with UPLOAD_FORBIDDEN_001