### PR TITLE
Release: POS price override, custom items, SaaS domains, settings hardening

### DIFF
--- a/apps/backend/prisma/migrations/20260516100000_add_pos_custom_items_and_price_override/migration.sql
+++ b/apps/backend/prisma/migrations/20260516100000_add_pos_custom_items_and_price_override/migration.sql
@@ -1,0 +1,19 @@
+-- DATA IMPACT:
+-- Tables affected: products, order_items
+-- Expected row changes: none; adds nullable/defaulted columns only
+-- Destructive operations: none
+-- FK/cascade risk: none
+-- Idempotency: guarded by IF NOT EXISTS
+-- Approval: requested and approved in chat with "dale"
+
+ALTER TABLE "products"
+  ADD COLUMN IF NOT EXISTS "allow_pos_price_override" BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE "order_items"
+  ADD COLUMN IF NOT EXISTS "catalog_unit_price" DECIMAL(12, 2),
+  ADD COLUMN IF NOT EXISTS "catalog_final_price" DECIMAL(12, 2),
+  ADD COLUMN IF NOT EXISTS "final_unit_price" DECIMAL(12, 2),
+  ADD COLUMN IF NOT EXISTS "is_price_overridden" BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS "price_override_reason" VARCHAR(500),
+  ADD COLUMN IF NOT EXISTS "price_overridden_by_user_id" INTEGER,
+  ADD COLUMN IF NOT EXISTS "description" TEXT;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -939,30 +939,37 @@ model order_item_taxes {
 }
 
 model order_items {
-  id                     Int                      @id @default(autoincrement())
-  order_id               Int
-  product_id             Int?
-  product_variant_id     Int?
-  product_name           String                   @db.VarChar(255)
-  variant_sku            String?                  @db.VarChar(100)
-  variant_attributes     String?
-  quantity               Int
-  unit_price             Decimal                  @db.Decimal(12, 2)
-  total_price            Decimal                  @db.Decimal(12, 2)
-  tax_rate               Decimal?                 @db.Decimal(6, 5)
-  tax_amount_item        Decimal?                 @db.Decimal(12, 2)
-  cost_price             Decimal?                 @db.Decimal(12, 2)
-  weight                 Decimal?                 @db.Decimal(10, 3)
-  weight_unit            String?                  @db.VarChar(10)
-  item_type              String?                  @default("physical") @db.VarChar(20)
-  created_at             DateTime?                @default(now()) @db.Timestamp(6)
-  updated_at             DateTime?                @default(now()) @db.Timestamp(6)
-  inventory_transactions inventory_transactions[]
-  order_item_taxes       order_item_taxes[]
-  orders                 orders                   @relation(fields: [order_id], references: [id], onUpdate: NoAction)
-  products               products?                @relation(fields: [product_id], references: [id], onDelete: Restrict, onUpdate: NoAction)
-  product_variants       product_variants?        @relation(fields: [product_variant_id], references: [id], onDelete: Restrict, onUpdate: NoAction)
-  refund_items           refund_items[]
+  id                          Int                      @id @default(autoincrement())
+  order_id                    Int
+  product_id                  Int?
+  product_variant_id          Int?
+  product_name                String                   @db.VarChar(255)
+  variant_sku                 String?                  @db.VarChar(100)
+  variant_attributes          String?
+  quantity                    Int
+  unit_price                  Decimal                  @db.Decimal(12, 2)
+  total_price                 Decimal                  @db.Decimal(12, 2)
+  tax_rate                    Decimal?                 @db.Decimal(6, 5)
+  tax_amount_item             Decimal?                 @db.Decimal(12, 2)
+  cost_price                  Decimal?                 @db.Decimal(12, 2)
+  catalog_unit_price          Decimal?                 @db.Decimal(12, 2)
+  catalog_final_price         Decimal?                 @db.Decimal(12, 2)
+  final_unit_price            Decimal?                 @db.Decimal(12, 2)
+  is_price_overridden         Boolean                  @default(false)
+  price_override_reason       String?                  @db.VarChar(500)
+  price_overridden_by_user_id Int?
+  description                 String?
+  weight                      Decimal?                 @db.Decimal(10, 3)
+  weight_unit                 String?                  @db.VarChar(10)
+  item_type                   String?                  @default("physical") @db.VarChar(20)
+  created_at                  DateTime?                @default(now()) @db.Timestamp(6)
+  updated_at                  DateTime?                @default(now()) @db.Timestamp(6)
+  inventory_transactions      inventory_transactions[]
+  order_item_taxes            order_item_taxes[]
+  orders                      orders                   @relation(fields: [order_id], references: [id], onUpdate: NoAction)
+  products                    products?                @relation(fields: [product_id], references: [id], onDelete: Restrict, onUpdate: NoAction)
+  product_variants            product_variants?        @relation(fields: [product_variant_id], references: [id], onDelete: Restrict, onUpdate: NoAction)
+  refund_items                refund_items[]
 }
 
 model orders {
@@ -1232,6 +1239,7 @@ model products {
   preconsultation_template_id   Int?
   preconsultation_template      data_collection_templates?      @relation("product_preconsultation_template", fields: [preconsultation_template_id], references: [id], onDelete: SetNull)
   available_for_ecommerce       Boolean                         @default(false)
+  allow_pos_price_override      Boolean                         @default(false)
   is_on_sale                    Boolean                         @default(false)
   sale_price                    Decimal?                        @db.Decimal(12, 2)
   weight                        Decimal?                        @db.Decimal(12, 3)

--- a/apps/backend/prisma/seeds/permissions-roles.seed.ts
+++ b/apps/backend/prisma/seeds/permissions-roles.seed.ts
@@ -1661,6 +1661,18 @@ export async function seedPermissionsAndRoles(
       path: '/api/store/settings/schedule-status',
       method: 'GET',
     },
+    {
+      name: 'store:pos:price_override',
+      description: 'Editar el precio final de productos permitidos en POS',
+      path: '/api/store/payments/pos/price-override',
+      method: 'POST',
+    },
+    {
+      name: 'store:pos:custom_items:create',
+      description: 'Crear ítems personalizados facturables desde POS',
+      path: '/api/store/payments/pos/custom-items',
+      method: 'POST',
+    },
 
     // Facturación (Invoicing)
     {

--- a/apps/backend/src/common/errors/error-codes.ts
+++ b/apps/backend/src/common/errors/error-codes.ts
@@ -526,6 +526,18 @@ export const ErrorCodes = {
     devMessage: 'track_inventory_override inválido',
   },
 
+  // Quotations
+  QUOTE_CONVERT_STATUS_001: {
+    code: 'QUOTE_CONVERT_STATUS_001',
+    httpStatus: 400,
+    devMessage: 'Quotation must be accepted before conversion',
+  },
+  QUOTE_CONVERT_CUSTOMER_001: {
+    code: 'QUOTE_CONVERT_CUSTOMER_001',
+    httpStatus: 400,
+    devMessage: 'Quotation must have a customer before conversion',
+  },
+
   // Orders
   ORD_FIND_001: {
     code: 'ORD_FIND_001',

--- a/apps/backend/src/domains/store/coupons/coupons.service.ts
+++ b/apps/backend/src/domains/store/coupons/coupons.service.ts
@@ -36,6 +36,12 @@ export class CouponsService {
       throw new VendixHttpException(ErrorCodes.CPN_VALIDATE_001);
     }
 
+    this.validateTargetSelection(
+      dto.applies_to ?? CouponAppliesTo.ALL_PRODUCTS,
+      dto.product_ids,
+      dto.category_ids,
+    );
+
     // Check unique code in store
     const existing = await this.prisma.coupons.findFirst({
       where: { code: dto.code },
@@ -174,7 +180,7 @@ export class CouponsService {
   }
 
   async update(id: number, dto: UpdateCouponDto) {
-    await this.findOne(id);
+    const existing = await this.findOne(id);
 
     // Validate: percentage <= 100
     if (
@@ -191,6 +197,16 @@ export class CouponsService {
         throw new VendixHttpException(ErrorCodes.CPN_VALIDATE_001);
       }
     }
+
+    this.validateTargetSelection(
+      dto.applies_to ?? existing.applies_to,
+      dto.product_ids ??
+        existing.coupon_products?.map((cp: any) => cp.product_id) ??
+        [],
+      dto.category_ids ??
+        existing.coupon_categories?.map((cc: any) => cc.category_id) ??
+        [],
+    );
 
     return this.prisma.$transaction(async (tx: any) => {
       const updateData: any = {};
@@ -318,52 +334,27 @@ export class CouponsService {
       throw new VendixHttpException(ErrorCodes.CPN_MIN_001);
     }
 
-    // Check product/category applicability
-    if (coupon.applies_to === 'SPECIFIC_PRODUCTS' && dto.product_ids?.length) {
-      const couponProductIds = coupon.coupon_products.map(
-        (cp) => cp.product_id,
-      );
-      const hasApplicable = dto.product_ids.some((pid) =>
-        couponProductIds.includes(pid),
-      );
-      if (!hasApplicable) {
-        throw new VendixHttpException(ErrorCodes.CPN_APPLY_001);
-      }
-    }
-
-    if (
-      coupon.applies_to === 'SPECIFIC_CATEGORIES' &&
-      dto.category_ids?.length
-    ) {
-      const couponCategoryIds = coupon.coupon_categories.map(
-        (cc) => cc.category_id,
-      );
-      const hasApplicable = dto.category_ids.some((cid) =>
-        couponCategoryIds.includes(cid),
-      );
-      if (!hasApplicable) {
-        throw new VendixHttpException(ErrorCodes.CPN_APPLY_001);
-      }
+    const applicableSubtotal = this.getApplicableSubtotal(coupon, dto);
+    if (applicableSubtotal <= 0) {
+      throw new VendixHttpException(ErrorCodes.CPN_APPLY_001);
     }
 
     // Calculate discount
     let discount_amount = 0;
     if (coupon.discount_type === 'PERCENTAGE') {
       discount_amount =
-        (dto.cart_subtotal * Number(coupon.discount_value)) / 100;
+        (applicableSubtotal * Number(coupon.discount_value)) / 100;
       // Apply cap
-      if (coupon.max_discount_amount) {
-        discount_amount = Math.min(
-          discount_amount,
-          Number(coupon.max_discount_amount),
-        );
+      const maxDiscountAmount = Number(coupon.max_discount_amount);
+      if (Number.isFinite(maxDiscountAmount) && maxDiscountAmount > 0) {
+        discount_amount = Math.min(discount_amount, maxDiscountAmount);
       }
     } else {
       discount_amount = Number(coupon.discount_value);
     }
 
     // Discount cannot exceed subtotal
-    discount_amount = Math.min(discount_amount, dto.cart_subtotal);
+    discount_amount = Math.min(discount_amount, applicableSubtotal);
     discount_amount = Math.round(discount_amount * 100) / 100;
 
     return {
@@ -381,6 +372,86 @@ export class CouponsService {
         ? Number(coupon.max_discount_amount)
         : null,
     };
+  }
+
+  private validateTargetSelection(
+    appliesTo: CouponAppliesTo | string,
+    productIds?: number[],
+    categoryIds?: number[],
+  ): void {
+    if (
+      appliesTo === CouponAppliesTo.SPECIFIC_PRODUCTS &&
+      (!productIds || productIds.length === 0)
+    ) {
+      throw new VendixHttpException(ErrorCodes.CPN_VALIDATE_001);
+    }
+
+    if (
+      appliesTo === CouponAppliesTo.SPECIFIC_CATEGORIES &&
+      (!categoryIds || categoryIds.length === 0)
+    ) {
+      throw new VendixHttpException(ErrorCodes.CPN_VALIDATE_001);
+    }
+  }
+
+  private getApplicableSubtotal(coupon: any, dto: ValidateCouponDto): number {
+    const cartItems = dto.items || [];
+
+    if (coupon.applies_to === CouponAppliesTo.SPECIFIC_PRODUCTS) {
+      const couponProductIds = coupon.coupon_products.map((cp) =>
+        Number(cp.product_id),
+      );
+      const matchingItems = cartItems.filter((item) =>
+        couponProductIds.includes(Number(item.product_id)),
+      );
+
+      if (cartItems.length > 0) {
+        return this.sumLineTotals(matchingItems);
+      }
+
+      const hasApplicable = (dto.product_ids || []).some((pid) =>
+        couponProductIds.includes(Number(pid)),
+      );
+      return hasApplicable ? dto.cart_subtotal : 0;
+    }
+
+    if (coupon.applies_to === CouponAppliesTo.SPECIFIC_CATEGORIES) {
+      const couponCategoryIds = coupon.coupon_categories.map((cc) =>
+        Number(cc.category_id),
+      );
+      const matchingItems = cartItems.filter((item) =>
+        this.getCouponItemCategoryIds(item).some((categoryId) =>
+          couponCategoryIds.includes(categoryId),
+        ),
+      );
+
+      if (cartItems.length > 0) {
+        return this.sumLineTotals(matchingItems);
+      }
+
+      const hasApplicable = (dto.category_ids || []).some((cid) =>
+        couponCategoryIds.includes(Number(cid)),
+      );
+      return hasApplicable ? dto.cart_subtotal : 0;
+    }
+
+    return dto.cart_subtotal;
+  }
+
+  private getCouponItemCategoryIds(item: any): number[] {
+    const categoryIds = Array.isArray(item.category_ids)
+      ? item.category_ids
+      : item.category_id
+        ? [item.category_id]
+        : [];
+
+    return categoryIds
+      .map((categoryId: string | number) => Number(categoryId))
+      .filter((categoryId: number) => Number.isFinite(categoryId));
+  }
+
+  private sumLineTotals(items: Array<{ line_total: number }>): number {
+    return items.reduce((sum, item) => sum + Number(item.line_total || 0), 0);
   }
 
   async getStats() {

--- a/apps/backend/src/domains/store/coupons/dto/index.ts
+++ b/apps/backend/src/domains/store/coupons/dto/index.ts
@@ -12,6 +12,7 @@ import {
   IsDateString,
   IsArray,
   Max,
+  ValidateNested,
 } from 'class-validator';
 import { Transform, Type } from 'class-transformer';
 import { PartialType } from '@nestjs/mapped-types';
@@ -141,6 +142,29 @@ export class CouponQueryDto {
   discount_type?: CouponDiscountType;
 }
 
+export class ValidateCouponItemDto {
+  @IsOptional()
+  @IsInt()
+  @Type(() => Number)
+  product_id?: number;
+
+  @IsOptional()
+  @IsInt()
+  @Type(() => Number)
+  category_id?: number;
+
+  @IsOptional()
+  @IsArray()
+  @IsInt({ each: true })
+  @Type(() => Number)
+  category_ids?: number[];
+
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @Min(0)
+  @Type(() => Number)
+  line_total: number;
+}
+
 export class ValidateCouponDto {
   @IsString()
   @IsNotEmpty()
@@ -168,4 +192,10 @@ export class ValidateCouponDto {
   @IsInt({ each: true })
   @Type(() => Number)
   category_ids?: number[];
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ValidateCouponItemDto)
+  items?: ValidateCouponItemDto[];
 }

--- a/apps/backend/src/domains/store/customers/customers.service.ts
+++ b/apps/backend/src/domains/store/customers/customers.service.ts
@@ -15,6 +15,14 @@ export class CustomersService {
     private readonly eventEmitter: EventEmitter2,
   ) {}
 
+  private normalizeOptionalString(
+    value?: string | null,
+  ): string | null | undefined {
+    if (value === undefined) return undefined;
+    const normalized = value?.trim();
+    return normalized ? normalized : null;
+  }
+
   private async generateUniqueUsername(email: string): Promise<string> {
     let baseUsername = email.split('@')[0];
     // Eliminar caracteres especiales
@@ -93,9 +101,9 @@ export class CustomersService {
         password: hashedPassword,
         first_name: formatted_first_name,
         last_name: formatted_last_name,
-        phone: dto.phone,
-        document_type: dto.document_type,
-        document_number: dto.document_number,
+        phone: this.normalizeOptionalString(dto.phone),
+        document_type: this.normalizeOptionalString(dto.document_type),
+        document_number: this.normalizeOptionalString(dto.document_number),
         username: username,
         email_verified: false,
         organization_id: store.organization_id,
@@ -240,9 +248,9 @@ export class CustomersService {
       data: {
         first_name: dto.first_name,
         last_name: dto.last_name,
-        phone: dto.phone,
-        document_number: dto.document_number,
-        document_type: dto.document_type,
+        phone: this.normalizeOptionalString(dto.phone),
+        document_number: this.normalizeOptionalString(dto.document_number),
+        document_type: this.normalizeOptionalString(dto.document_type),
         email: dto.email, // Can we update email? Usually requires verification, but for CRUD basic...
       },
     });

--- a/apps/backend/src/domains/store/customers/dto/create-customer.dto.ts
+++ b/apps/backend/src/domains/store/customers/dto/create-customer.dto.ts
@@ -23,15 +23,15 @@ export class CreateCustomerDto {
   @IsNotEmpty()
   last_name: string;
 
-  @ApiProperty({ example: '12345678' })
+  @ApiPropertyOptional({ example: '12345678' })
   @IsString()
-  @IsNotEmpty()
-  document_number: string;
+  @IsOptional()
+  document_number?: string | null;
 
   @ApiPropertyOptional({ example: 'CC' })
   @IsString()
   @IsOptional()
-  document_type?: string;
+  document_type?: string | null;
 
   @ApiPropertyOptional({ example: '3001234567' })
   @IsString()
@@ -40,5 +40,5 @@ export class CreateCustomerDto {
     message:
       'El teléfono solo puede contener números y los símbolos + # * ( ) -',
   })
-  phone?: string;
+  phone?: string | null;
 }

--- a/apps/backend/src/domains/store/invoicing/invoicing.service.ts
+++ b/apps/backend/src/domains/store/invoicing/invoicing.service.ts
@@ -244,7 +244,8 @@ export class InvoicingService {
       await this.invoice_number_generator.generateNextNumber();
 
     const productItems = (order.order_items || []).map((item: any) => {
-      const description = item.product_name || item.products?.name || 'Product';
+      const description =
+        item.description || item.product_name || item.products?.name || 'Product';
       const quantity = Number(item.quantity || 1);
       const unit_price = Number(item.unit_price || 0);
       const discount = Number(item.discount_amount || 0);

--- a/apps/backend/src/domains/store/orders/dto/create-order.dto.ts
+++ b/apps/backend/src/domains/store/orders/dto/create-order.dto.ts
@@ -4,6 +4,9 @@ import {
   IsOptional,
   IsNumber,
   IsArray,
+  ArrayMinSize,
+  IsBoolean,
+  IsIn,
   ValidateNested,
   IsEnum,
   Min,
@@ -14,17 +17,29 @@ import { Type, Transform } from 'class-transformer';
 import { order_state_enum, payments_state_enum } from '@prisma/client';
 
 export class CreateOrderItemDto {
+  @IsOptional()
   @IsInt()
   @Min(1)
-  product_id: number;
+  product_id?: number;
 
   @IsOptional()
   @IsInt()
   @Min(1)
   product_variant_id?: number;
 
+  @IsOptional()
   @IsString()
+  @IsIn(['product', 'custom', 'physical', 'service'])
+  item_type?: 'product' | 'custom' | 'physical' | 'service';
+
+  @IsString()
+  @MaxLength(255)
   product_name: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(1000)
+  description?: string;
 
   @IsOptional()
   @IsString()
@@ -55,6 +70,30 @@ export class CreateOrderItemDto {
   @Transform(({ value }) => parseFloat(value))
   @IsNumber({ maxDecimalPlaces: 2 })
   tax_amount_item?: number;
+
+  @IsOptional()
+  @Transform(({ value }) => parseFloat(value))
+  @IsNumber({ maxDecimalPlaces: 2 })
+  catalog_unit_price?: number;
+
+  @IsOptional()
+  @Transform(({ value }) => parseFloat(value))
+  @IsNumber({ maxDecimalPlaces: 2 })
+  catalog_final_price?: number;
+
+  @IsOptional()
+  @Transform(({ value }) => parseFloat(value))
+  @IsNumber({ maxDecimalPlaces: 2 })
+  final_unit_price?: number;
+
+  @IsOptional()
+  @IsBoolean()
+  is_price_overridden?: boolean;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  price_override_reason?: string;
 
   @IsOptional()
   @Transform(({ value }) => parseFloat(value))
@@ -140,6 +179,7 @@ export class CreateOrderDto {
   estimated_delivery_date?: string;
 
   @IsArray()
+  @ArrayMinSize(1)
   @ValidateNested({ each: true })
   @Type(() => CreateOrderItemDto)
   items: CreateOrderItemDto[];

--- a/apps/backend/src/domains/store/orders/dto/update-order-items.dto.ts
+++ b/apps/backend/src/domains/store/orders/dto/update-order-items.dto.ts
@@ -1,9 +1,16 @@
-import { IsArray, IsOptional, IsNumber, ValidateNested } from 'class-validator';
+import {
+  IsArray,
+  ArrayMinSize,
+  IsOptional,
+  IsNumber,
+  ValidateNested,
+} from 'class-validator';
 import { Type, Transform } from 'class-transformer';
 import { CreateOrderItemDto } from './create-order.dto';
 
 export class UpdateOrderItemsDto {
   @IsArray()
+  @ArrayMinSize(1)
   @ValidateNested({ each: true })
   @Type(() => CreateOrderItemDto)
   items: CreateOrderItemDto[];

--- a/apps/backend/src/domains/store/orders/order-flow/order-flow.service.ts
+++ b/apps/backend/src/domains/store/orders/order-flow/order-flow.service.ts
@@ -562,7 +562,8 @@ export class OrderFlowService {
   }
 
   /**
-   * Cancel payment of a processing order (processing -> created)
+   * Cancel payment of an order that has an active payment attempt
+   * (pending_payment/processing -> created)
    * Privileged reverse transition — bypasses normal state machine
    * Only admin/owner can perform this action
    */
@@ -573,9 +574,9 @@ export class OrderFlowService {
   ) {
     const order = await this.getOrder(orderId);
 
-    if (order.state !== 'processing') {
+    if (!['pending_payment', 'processing'].includes(order.state)) {
       throw new BadRequestException(
-        `Cannot cancel payment for order in state '${order.state}'. Order must be in 'processing' state.`,
+        `Cannot cancel payment for order in state '${order.state}'. Order must be in 'pending_payment' or 'processing' state.`,
       );
     }
 

--- a/apps/backend/src/domains/store/orders/orders.service.ts
+++ b/apps/backend/src/domains/store/orders/orders.service.ts
@@ -115,14 +115,23 @@ export class OrdersService {
               create: await Promise.all(
                 createOrderDto.items.map(async (item) => {
                   // Resolve product type for snapshot
-                  const product = await this.prisma.products.findUnique({
-                    where: { id: item.product_id },
-                    select: { product_type: true },
-                  });
+                  const product = item.product_id
+                    ? await this.prisma.products.findUnique({
+                        where: { id: item.product_id },
+                        select: { product_type: true },
+                      })
+                    : null;
+                  const itemType =
+                    item.item_type === 'product'
+                      ? product?.product_type || 'physical'
+                      : item.item_type || product?.product_type || 'custom';
                   return {
-                    product_id: item.product_id,
-                    product_variant_id: item.product_variant_id,
+                    product_id: item.product_id || null,
+                    product_variant_id: item.product_id
+                      ? item.product_variant_id
+                      : null,
                     product_name: item.product_name,
+                    description: item.description,
                     variant_sku: item.variant_sku,
                     variant_attributes: item.variant_attributes,
                     quantity: item.quantity,
@@ -130,14 +139,23 @@ export class OrdersService {
                     total_price: item.total_price,
                     tax_rate: item.tax_rate,
                     tax_amount_item: item.tax_amount_item,
+                    catalog_unit_price: item.catalog_unit_price,
+                    catalog_final_price: item.catalog_final_price,
+                    final_unit_price: item.final_unit_price ?? item.unit_price,
+                    is_price_overridden:
+                      item.is_price_overridden ??
+                      Boolean(item.price_override_reason),
+                    price_override_reason: item.price_override_reason,
                     weight: item.weight,
                     weight_unit: item.weight_unit,
-                    item_type: product?.product_type || 'physical',
-                    cost_price: await resolveCostPrice(
-                      this.prisma,
-                      item.product_id,
-                      item.product_variant_id,
-                    ),
+                    item_type: itemType,
+                    cost_price: item.product_id
+                      ? await resolveCostPrice(
+                          this.prisma,
+                          item.product_id,
+                          item.product_variant_id,
+                        )
+                      : null,
                     updated_at: new Date(),
                   };
                 }),
@@ -518,9 +536,10 @@ export class OrdersService {
       await tx.order_items.createMany({
         data: dto.items.map((item) => ({
           order_id: id,
-          product_id: item.product_id,
-          product_variant_id: item.product_variant_id,
+          product_id: item.product_id || null,
+          product_variant_id: item.product_id ? item.product_variant_id : null,
           product_name: item.product_name,
+          description: item.description,
           variant_sku: item.variant_sku,
           variant_attributes: item.variant_attributes,
           quantity: item.quantity,
@@ -528,8 +547,18 @@ export class OrdersService {
           total_price: item.total_price,
           tax_rate: item.tax_rate,
           tax_amount_item: item.tax_amount_item,
+          catalog_unit_price: item.catalog_unit_price,
+          catalog_final_price: item.catalog_final_price,
+          final_unit_price: item.final_unit_price ?? item.unit_price,
+          is_price_overridden:
+            item.is_price_overridden ?? Boolean(item.price_override_reason),
+          price_override_reason: item.price_override_reason,
           weight: item.weight,
           weight_unit: item.weight_unit,
+          item_type:
+            item.item_type === 'product'
+              ? 'physical'
+              : item.item_type || (item.product_id ? 'physical' : 'custom'),
           updated_at: new Date(),
         })),
       });

--- a/apps/backend/src/domains/store/payments/dto/create-pos-payment.dto.ts
+++ b/apps/backend/src/domains/store/payments/dto/create-pos-payment.dto.ts
@@ -4,6 +4,7 @@ import {
   IsOptional,
   IsBoolean,
   IsArray,
+  ArrayMinSize,
   IsDateString,
   IsEnum,
   IsIn,
@@ -17,9 +18,28 @@ import {
 import { Type } from 'class-transformer';
 
 export class PosOrderItemDto {
+  @IsOptional()
+  @IsString()
+  @IsIn(['product', 'custom'])
+  item_type?: 'product' | 'custom';
+
+  @IsOptional()
   @IsInt()
+  @Min(1)
   @Type(() => Number)
-  product_id: number;
+  product_id?: number;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Type(() => Number)
+  category_id?: number;
+
+  @IsOptional()
+  @IsArray()
+  @IsInt({ each: true })
+  @Type(() => Number)
+  category_ids?: number[];
 
   @IsOptional()
   @IsInt()
@@ -29,6 +49,11 @@ export class PosOrderItemDto {
   @IsString()
   @MaxLength(255)
   product_name: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(1000)
+  description?: string;
 
   @IsOptional()
   @IsString()
@@ -56,6 +81,23 @@ export class PosOrderItemDto {
   @Min(0)
   @Type(() => Number)
   total_price: number;
+
+  @IsOptional()
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @Min(0)
+  @Type(() => Number)
+  final_unit_price?: number;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Type(() => Number)
+  tax_category_id?: number;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  price_override_reason?: string;
 
   @IsOptional()
   @IsNumber({ maxDecimalPlaces: 5 })
@@ -177,6 +219,7 @@ export class CreatePosPaymentDto {
   cash_register_session_id?: number;
 
   @IsArray()
+  @ArrayMinSize(1)
   @ValidateNested({ each: true })
   @Type(() => PosOrderItemDto)
   items: PosOrderItemDto[];

--- a/apps/backend/src/domains/store/payments/payments.service.ts
+++ b/apps/backend/src/domains/store/payments/payments.service.ts
@@ -589,7 +589,6 @@ export class PaymentsService {
     createPosPaymentDto: CreatePosPaymentDto,
     user: any,
   ): Promise<PosPaymentResponseDto> {
-    try {
       // Resolve store_id from RequestContext (authoritative). Backward-compat:
       // if the client sent store_id in body, validate it matches the context.
       const context = RequestContextService.getContext();
@@ -641,10 +640,12 @@ export class PaymentsService {
 
         // 1.5. BLOCKING stock validation using stock_levels (source of truth)
         // Validate ALL items before any reservation occurs
-        // Use allow_oversell from DTO to decide if oversell is permitted
-        const allowOversell = createPosPaymentDto.allow_oversell ?? false;
+        // Oversell is intentionally not controlled by the public POS payload.
+        const allowOversell = false;
 
         for (const item of order.order_items) {
+          if (!item.product_id) continue;
+
           const product = await tx.products.findUnique({
             where: { id: item.product_id },
             select: {
@@ -683,7 +684,7 @@ export class PaymentsService {
               ? ` (variant ${item.product_variant_id})`
               : '';
             throw new BadRequestException(
-              `Insufficient stock for ${product.name}${variantInfo}: requested ${item.quantity}, available ${available}. Set allow_oversell=true to permit overselling.`,
+              `Stock insuficiente para ${product.name}${variantInfo}: solicitado ${item.quantity}, disponible ${available}.`,
             );
           }
         }
@@ -703,6 +704,8 @@ export class PaymentsService {
         });
 
         for (const item of order.order_items) {
+          if (!item.product_id) continue;
+
           const product = await tx.products.findUnique({
             where: { id: item.product_id },
             select: { track_inventory: true },
@@ -776,11 +779,15 @@ export class PaymentsService {
             try {
               const { discount } = await this.promotionEngine.validatePromotion(
                 promoId,
-                createPosPaymentDto.items.map((i) => ({
-                  product_id: i.product_id,
-                  unit_price: i.unit_price,
-                  quantity: i.quantity,
-                })),
+                createPosPaymentDto.items
+                  .filter((i) => i.product_id)
+                  .map((i) => ({
+                    product_id: i.product_id!,
+                    category_id: i.category_id,
+                    category_ids: i.category_ids,
+                    unit_price: i.final_unit_price ?? i.unit_price,
+                    quantity: i.quantity,
+                  })),
                 createPosPaymentDto.customer_id,
               );
               await this.promotionEngine.applyPromotion(
@@ -981,6 +988,7 @@ export class PaymentsService {
             {
               id: result.order.id,
               store_id: createPosPaymentDto.store_id,
+              grand_total: result.order.total_amount,
             } as any,
             createPosPaymentDto,
           );
@@ -1075,13 +1083,6 @@ export class PaymentsService {
       }
 
       return result;
-    } catch (error) {
-      return {
-        success: false,
-        message: error.message || 'Error processing payment',
-        errors: [error.message],
-      };
-    }
   }
 
   /**
@@ -1196,6 +1197,414 @@ export class PaymentsService {
     });
   }
 
+  private hasActivePermission(user: any, permissionName: string): boolean {
+    const roles = user?.roles || [];
+    if (roles.includes('super_admin') || roles.includes('SUPER_ADMIN')) {
+      return true;
+    }
+
+    return (user?.permissions || []).some(
+      (permission: any) =>
+        permission?.name === permissionName && permission?.status === 'active',
+    );
+  }
+
+  private requireActivePermission(user: any, permissionName: string): void {
+    if (!this.hasActivePermission(user, permissionName)) {
+      throw new VendixHttpException(
+        ErrorCodes.AUTH_PERM_001,
+        'No tienes permiso para realizar esta operación en POS.',
+      );
+    }
+  }
+
+  private roundMoney(value: number): number {
+    return Math.round((Number(value || 0) + Number.EPSILON) * 100) / 100;
+  }
+
+  private roundRate(value: number): number {
+    return Math.round((Number(value || 0) + Number.EPSILON) * 100000) / 100000;
+  }
+
+  private getPosLineUnits(item: any): number {
+    const weight = Number(item.weight || 0);
+    if (weight > 0) return weight;
+    return Number(item.quantity || 0);
+  }
+
+  private resolveRequestedFinalUnitPrice(
+    item: any,
+    lineUnits: number,
+    fallbackFinalUnitPrice: number,
+  ): number {
+    if (item.final_unit_price !== undefined && item.final_unit_price !== null) {
+      return this.roundMoney(Number(item.final_unit_price));
+    }
+
+    if (
+      item.total_price !== undefined &&
+      item.total_price !== null &&
+      lineUnits > 0
+    ) {
+      return this.roundMoney(Number(item.total_price) / lineUnits);
+    }
+
+    return this.roundMoney(fallbackFinalUnitPrice);
+  }
+
+  private resolveCatalogUnitBasePrice(product: any, variant?: any): number {
+    const productBase = Number(product.base_price || 0);
+
+    if (
+      variant?.is_on_sale &&
+      variant.sale_price != null &&
+      Number(variant.sale_price) > 0
+    ) {
+      return Number(variant.sale_price);
+    }
+
+    if (variant?.price_override != null && Number(variant.price_override) > 0) {
+      return Number(variant.price_override);
+    }
+
+    if (
+      product.is_on_sale &&
+      product.sale_price != null &&
+      Number(product.sale_price) > 0
+    ) {
+      return Number(product.sale_price);
+    }
+
+    return productBase;
+  }
+
+  private async calculateTaxCategoryTaxes(
+    tx: any,
+    taxCategoryId: number | undefined,
+    basePrice: number,
+    storeId: number,
+  ): Promise<{
+    total_rate: number;
+    total_tax_amount: number;
+    taxes: { tax_rate_id: number; name: string; rate: number; amount: number }[];
+  }> {
+    if (!taxCategoryId) {
+      return { total_rate: 0, total_tax_amount: 0, taxes: [] };
+    }
+
+    const store = await tx.stores.findUnique({
+      where: { id: storeId },
+      select: { organization_id: true },
+    });
+    const organizationId =
+      store?.organization_id ??
+      RequestContextService.getContext()?.organization_id;
+
+    const scopeOptions: any[] = [{ store_id: storeId }];
+    if (organizationId) {
+      scopeOptions.push({ organization_id: organizationId, store_id: null });
+    }
+
+    const taxCategory = await tx.tax_categories.findFirst({
+      where: {
+        id: taxCategoryId,
+        OR: scopeOptions,
+      },
+      include: { tax_rates: true },
+    });
+
+    if (!taxCategory) {
+      throw new BadRequestException(
+        'La categoría de impuesto seleccionada no existe para esta tienda.',
+      );
+    }
+
+    const taxes = (taxCategory.tax_rates || []).map((rate: any) => {
+      const rateValue = Number(rate.rate || 0);
+      return {
+        tax_rate_id: rate.id,
+        name: rate.name,
+        rate: rateValue,
+        amount: basePrice * rateValue,
+      };
+    });
+    const totalRate = taxes.reduce((sum, tax) => sum + tax.rate, 0);
+
+    return {
+      total_rate: totalRate,
+      total_tax_amount: basePrice * totalRate,
+      taxes,
+    };
+  }
+
+  private async buildPosOrderItem(
+    tx: any,
+    item: any,
+    dtoStoreId: number,
+    user: any,
+  ): Promise<any> {
+    const isCustomItem = item.item_type === 'custom' || !item.product_id;
+    const lineUnits = this.getPosLineUnits(item);
+
+    if (lineUnits <= 0) {
+      throw new BadRequestException('La cantidad del ítem debe ser mayor a 0.');
+    }
+
+    if (isCustomItem) {
+      this.requireActivePermission(user, 'store:pos:custom_items:create');
+
+      const productName = (item.product_name || '').trim();
+      if (!productName) {
+        throw new BadRequestException(
+          'El ítem personalizado requiere un nombre o descripción.',
+        );
+      }
+
+      const rateProbe = await this.calculateTaxCategoryTaxes(
+        tx,
+        item.tax_category_id,
+        1,
+        dtoStoreId,
+      );
+      const finalUnitPrice = this.resolveRequestedFinalUnitPrice(
+        item,
+        lineUnits,
+        Number(item.unit_price || 0) * (1 + rateProbe.total_rate),
+      );
+      const unitBasePrice =
+        rateProbe.total_rate > 0
+          ? finalUnitPrice / (1 + rateProbe.total_rate)
+          : finalUnitPrice;
+      const taxInfo = await this.calculateTaxCategoryTaxes(
+        tx,
+        item.tax_category_id,
+        unitBasePrice,
+        dtoStoreId,
+      );
+
+      return this.buildOrderItemSnapshot({
+        item,
+        productName,
+        sku: item.product_sku,
+        description: item.description || item.notes,
+        itemType: 'custom',
+        quantity: item.quantity,
+        lineUnits,
+        unitBasePrice,
+        finalUnitPrice,
+        taxInfo,
+        costPrice: null,
+        catalogUnitPrice: null,
+        catalogFinalPrice: null,
+        isPriceOverridden: false,
+        priceOverrideReason: undefined,
+        priceOverriddenByUserId: undefined,
+        productId: undefined,
+        productVariantId: undefined,
+      });
+    }
+
+    const product = await tx.products.findFirst({
+      where: {
+        id: item.product_id,
+        store_id: dtoStoreId,
+      },
+      select: {
+        id: true,
+        name: true,
+        sku: true,
+        base_price: true,
+        is_on_sale: true,
+        sale_price: true,
+        product_type: true,
+        allow_pos_price_override: true,
+      },
+    });
+
+    if (!product) {
+      throw new BadRequestException('Producto no encontrado para esta tienda.');
+    }
+
+    const variant = item.product_variant_id
+      ? await tx.product_variants.findFirst({
+          where: {
+            id: item.product_variant_id,
+            product_id: product.id,
+          },
+          select: {
+            id: true,
+            sku: true,
+            price_override: true,
+            is_on_sale: true,
+            sale_price: true,
+          },
+        })
+      : null;
+
+    if (item.product_variant_id && !variant) {
+      throw new BadRequestException('La variante no pertenece al producto.');
+    }
+
+    const catalogUnitPrice = this.roundMoney(
+      this.resolveCatalogUnitBasePrice(product, variant),
+    );
+    const catalogTaxInfo = await this.taxes_service.calculateProductTaxes(
+      product.id,
+      catalogUnitPrice,
+    );
+    const catalogFinalPrice = this.roundMoney(
+      catalogUnitPrice + catalogTaxInfo.total_tax_amount,
+    );
+    const finalUnitPrice = this.resolveRequestedFinalUnitPrice(
+      item,
+      lineUnits,
+      catalogFinalPrice,
+    );
+    const isPriceOverridden =
+      Math.abs(finalUnitPrice - catalogFinalPrice) >= 0.01;
+
+    if (isPriceOverridden) {
+      if (!product.allow_pos_price_override) {
+        throw new BadRequestException(
+          `El producto "${product.name}" no permite editar el precio en POS.`,
+        );
+      }
+      this.requireActivePermission(user, 'store:pos:price_override');
+    }
+
+    const unitBasePrice =
+      catalogTaxInfo.total_rate > 0
+        ? finalUnitPrice / (1 + catalogTaxInfo.total_rate)
+        : finalUnitPrice;
+    const taxInfo = await this.taxes_service.calculateProductTaxes(
+      product.id,
+      unitBasePrice,
+    );
+    const costPrice = await resolveCostPrice(
+      tx,
+      product.id,
+      item.product_variant_id,
+    );
+
+    return this.buildOrderItemSnapshot({
+      item,
+      productName: item.product_name || product.name,
+      sku: item.product_sku || variant?.sku || product.sku,
+      description: item.description || item.notes,
+      itemType: product.product_type === 'service' ? 'service' : 'physical',
+      quantity: item.quantity,
+      lineUnits,
+      unitBasePrice,
+      finalUnitPrice,
+      taxInfo,
+      costPrice,
+      catalogUnitPrice,
+      catalogFinalPrice,
+      isPriceOverridden,
+      priceOverrideReason: isPriceOverridden
+        ? item.price_override_reason
+        : undefined,
+      priceOverriddenByUserId: isPriceOverridden ? user?.id : undefined,
+      productId: product.id,
+      productVariantId: item.product_variant_id,
+    });
+  }
+
+  private buildOrderItemSnapshot(params: {
+    item: any;
+    productName: string;
+    sku?: string | null;
+    description?: string;
+    itemType: string;
+    quantity: number;
+    lineUnits: number;
+    unitBasePrice: number;
+    finalUnitPrice: number;
+    taxInfo: {
+      total_rate: number;
+      total_tax_amount: number;
+      taxes: {
+        tax_rate_id: number;
+        name: string;
+        rate: number;
+        amount: number;
+      }[];
+    };
+    costPrice: number | null;
+    catalogUnitPrice: number | null;
+    catalogFinalPrice: number | null;
+    isPriceOverridden: boolean;
+    priceOverrideReason?: string;
+    priceOverriddenByUserId?: number;
+    productId?: number;
+    productVariantId?: number;
+  }): any {
+    const lineBaseTotal = this.roundMoney(
+      params.unitBasePrice * params.lineUnits,
+    );
+    const lineTaxTotal = this.roundMoney(
+      params.taxInfo.total_tax_amount * params.lineUnits,
+    );
+    const isWeightedLine = Number(params.item.weight || 0) > 0;
+    const itemTaxAmount = isWeightedLine
+      ? lineTaxTotal
+      : this.roundMoney(params.taxInfo.total_tax_amount);
+
+    const orderItem: any = {
+      product_name: params.productName,
+      description: params.description,
+      variant_sku: params.sku || undefined,
+      variant_attributes: params.item.variant_attributes
+        ? JSON.stringify(params.item.variant_attributes)
+        : undefined,
+      quantity: params.quantity,
+      unit_price: this.roundMoney(params.unitBasePrice),
+      total_price: lineBaseTotal,
+      tax_rate: this.roundRate(params.taxInfo.total_rate),
+      tax_amount_item: itemTaxAmount,
+      cost_price: params.costPrice,
+      catalog_unit_price:
+        params.catalogUnitPrice === null
+          ? undefined
+          : this.roundMoney(params.catalogUnitPrice),
+      catalog_final_price:
+        params.catalogFinalPrice === null
+          ? undefined
+          : this.roundMoney(params.catalogFinalPrice),
+      final_unit_price: this.roundMoney(params.finalUnitPrice),
+      is_price_overridden: params.isPriceOverridden,
+      price_override_reason: params.priceOverrideReason || undefined,
+      price_overridden_by_user_id: params.priceOverriddenByUserId || undefined,
+      weight: params.item.weight || undefined,
+      weight_unit: params.item.weight_unit || undefined,
+      item_type: params.itemType,
+    };
+
+    if (params.productId) {
+      orderItem.products = { connect: { id: params.productId } };
+    }
+
+    if (params.productVariantId) {
+      orderItem.product_variants = {
+        connect: { id: params.productVariantId },
+      };
+    }
+
+    if (params.taxInfo.taxes.length > 0) {
+      orderItem.order_item_taxes = {
+        create: params.taxInfo.taxes.map((tax) => ({
+          tax_rate_id: tax.tax_rate_id,
+          tax_name: tax.name,
+          tax_rate: this.roundRate(tax.rate),
+          tax_amount: this.roundMoney(tax.amount * params.lineUnits),
+          is_compound: false,
+        })),
+      };
+    }
+
+    return orderItem;
+  }
+
   /**
    * Create or update order from POS data
    */
@@ -1220,56 +1629,48 @@ export class PaymentsService {
         // Generate order number for this store
         orderNumber = await this.generateOrderNumber(tx, dtoStoreId);
 
-        // Create order items
+        // Create order items from backend-normalized financial snapshots.
         const orderItems = await Promise.all(
-          dto.items.map(async (item) => {
-            let item_tax_rate = item.tax_rate;
-            let item_tax_amount = item.tax_amount_item;
+          dto.items.map((item) =>
+            this.buildPosOrderItem(tx, item, dtoStoreId, user),
+          ),
+        );
 
-            // If taxes are missing or 0, calculate them
-            if (!item_tax_rate || item_tax_rate === 0) {
-              const taxInfo = await this.taxes_service.calculateProductTaxes(
-                item.product_id,
-                item.unit_price,
+        const calculatedSubtotal = this.roundMoney(
+          orderItems.reduce(
+            (sum, item) => sum + Number(item.total_price || 0),
+            0,
+          ),
+        );
+        const calculatedTaxAmount = this.roundMoney(
+          orderItems.reduce((sum, item) => {
+            const nestedTaxes = item.order_item_taxes?.create || [];
+            if (nestedTaxes.length > 0) {
+              return (
+                sum +
+                nestedTaxes.reduce(
+                  (taxSum: number, tax: any) =>
+                    taxSum + Number(tax.tax_amount || 0),
+                  0,
+                )
               );
-              item_tax_rate = taxInfo.total_rate;
-              item_tax_amount = taxInfo.total_tax_amount;
             }
 
-            const cost_price = await resolveCostPrice(
-              tx,
-              item.product_id,
-              item.product_variant_id,
-            );
-
-            const orderItem: any = {
-              product_name: item.product_name,
-              variant_sku: item.product_sku,
-              variant_attributes: item.variant_attributes
-                ? JSON.stringify(item.variant_attributes)
-                : undefined,
-              quantity: item.quantity,
-              unit_price: item.unit_price,
-              total_price: item.total_price,
-              tax_rate: item_tax_rate,
-              tax_amount_item: item_tax_amount,
-              cost_price,
-              weight: item.weight || undefined,
-              weight_unit: item.weight_unit || undefined,
-            };
-
-            if (item.product_id) {
-              orderItem.products = { connect: { id: item.product_id } };
-            }
-
-            if (item.product_variant_id) {
-              orderItem.product_variants = {
-                connect: { id: item.product_variant_id },
-              };
-            }
-
-            return orderItem;
-          }),
+            const multiplier =
+              Number(item.weight || 0) > 0 ? 1 : Number(item.quantity || 1);
+            return sum + Number(item.tax_amount_item || 0) * multiplier;
+          }, 0),
+        );
+        const discountAmount = this.roundMoney(dto.discount_amount || 0);
+        const shippingCost = this.roundMoney(dto.shipping_cost || 0);
+        const grandTotal = this.roundMoney(
+          Math.max(
+            0,
+            calculatedSubtotal +
+              calculatedTaxAmount -
+              discountAmount +
+              shippingCost,
+          ),
         );
 
         // Build order data - only include customer_id if provided (for anonymous sales)
@@ -1279,10 +1680,10 @@ export class PaymentsService {
           order_number: orderNumber,
           state: 'created', // Orders start in 'created' state, flow service handles transitions
           channel: 'pos', // POS orders are assigned 'pos' channel
-          subtotal_amount: dto.subtotal,
-          tax_amount: dto.tax_amount || 0,
-          discount_amount: dto.discount_amount || 0,
-          grand_total: dto.total_amount,
+          subtotal_amount: calculatedSubtotal,
+          tax_amount: calculatedTaxAmount,
+          discount_amount: discountAmount,
+          grand_total: grandTotal,
           currency: dto.currency,
           coupon_id: dto.coupon_id || undefined,
           coupon_code: dto.coupon_code || undefined,
@@ -1292,7 +1693,7 @@ export class PaymentsService {
           // Shipping fields (for delivery orders)
           delivery_type: dto.delivery_type || 'direct_delivery',
           payment_form: dto.payment_form || (dto.requires_payment ? '1' : '2'),
-          shipping_cost: dto.shipping_cost || 0,
+          shipping_cost: shippingCost,
           shipping_address_snapshot: dto.shipping_address_snapshot || undefined,
           order_items: {
             create: orderItems,
@@ -1371,6 +1772,9 @@ export class PaymentsService {
       throw new VendixHttpException(ErrorCodes.STORE_CONTEXT_001);
     }
     const dtoStoreId: number = dto.store_id;
+    const payableAmount = this.roundMoney(
+      Number(order?.grand_total ?? order?.total_amount ?? dto.total_amount ?? 0),
+    );
 
     // Get payment method details
     if (!dto.store_payment_method_id) {
@@ -1403,7 +1807,7 @@ export class PaymentsService {
       const gatewayResult = await this.paymentGateway.processPayment({
         orderId: order.id,
         customerId: dto.customer_id,
-        amount: dto.total_amount,
+        amount: payableAmount,
         currency: dto.currency || 'COP',
         storePaymentMethodId: dto.store_payment_method_id,
         storeId: dtoStoreId,
@@ -1444,11 +1848,17 @@ export class PaymentsService {
     // Direct methods (cash, card, bank_transfer) - existing flow continues below
     // Calculate change for cash payments
     let change = 0;
-    if (
-      paymentMethod.system_payment_method.type === 'cash' &&
-      dto.amount_received
-    ) {
-      change = dto.amount_received - dto.total_amount;
+    const amountReceived =
+      dto.amount_received !== undefined && dto.amount_received !== null
+        ? Number(dto.amount_received)
+        : payableAmount;
+    if (paymentMethod.system_payment_method.type === 'cash') {
+      if (amountReceived < payableAmount) {
+        throw new BadRequestException(
+          'El monto recibido no puede ser menor al total de la orden.',
+        );
+      }
+      change = this.roundMoney(amountReceived - payableAmount);
     }
 
     // Create payment record
@@ -1456,7 +1866,7 @@ export class PaymentsService {
       data: {
         order_id: order.id,
         store_payment_method_id: dto.store_payment_method_id,
-        amount: dto.total_amount,
+        amount: payableAmount,
         currency: dto.currency,
         state: 'succeeded',
         transaction_id: await this.generateTransactionId(),
@@ -1466,7 +1876,7 @@ export class PaymentsService {
           metadata: {
             register_id: dto.register_id,
             seller_user_id: dto.seller_user_id,
-            amount_received: dto.amount_received,
+            amount_received: amountReceived,
             is_pos_payment: true,
           },
         },
@@ -1541,6 +1951,8 @@ export class PaymentsService {
   private async updateInventoryFromOrder(tx: any, order: any): Promise<number> {
     let totalCost = 0;
     for (const item of order.order_items) {
+      if (!item.product_id) continue;
+
       const product = await tx.products.findUnique({
         where: { id: item.product_id },
         select: { track_inventory: true, product_type: true },

--- a/apps/backend/src/domains/store/products/dto/index.ts
+++ b/apps/backend/src/domains/store/products/dto/index.ts
@@ -242,6 +242,11 @@ export class CreateProductDto {
   available_for_ecommerce?: boolean;
 
   @IsOptional()
+  @IsBoolean()
+  @Type(() => Boolean)
+  allow_pos_price_override?: boolean;
+
+  @IsOptional()
   @IsNumber({ maxDecimalPlaces: 2 })
   @Type(() => Number)
   @Min(0, { message: 'El precio de oferta no puede ser negativo' })
@@ -475,6 +480,11 @@ export class UpdateProductDto {
   @IsBoolean()
   @Type(() => Boolean)
   available_for_ecommerce?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  @Type(() => Boolean)
+  allow_pos_price_override?: boolean;
 
   @IsOptional()
   @IsNumber({ maxDecimalPlaces: 2 })

--- a/apps/backend/src/domains/store/products/products.service.ts
+++ b/apps/backend/src/domains/store/products/products.service.ts
@@ -793,6 +793,7 @@ export class ProductsService {
             product_type: product.product_type,
             track_inventory: product.track_inventory,
             available_for_ecommerce: product.available_for_ecommerce,
+            allow_pos_price_override: product.allow_pos_price_override,
             requires_batch_tracking: product.requires_batch_tracking,
             requires_booking: product.requires_booking,
             booking_mode: product.booking_mode,
@@ -907,6 +908,7 @@ export class ProductsService {
           product_type: product.product_type,
           track_inventory: product.track_inventory,
           available_for_ecommerce: product.available_for_ecommerce,
+          allow_pos_price_override: product.allow_pos_price_override,
           requires_batch_tracking: product.requires_batch_tracking,
           requires_booking: product.requires_booking,
           booking_mode: product.booking_mode,
@@ -1088,6 +1090,7 @@ export class ProductsService {
       product_type: product.product_type,
       track_inventory: product.track_inventory,
       available_for_ecommerce: product.available_for_ecommerce,
+      allow_pos_price_override: product.allow_pos_price_override,
       // Service-specific fields
       service_duration_minutes: product.service_duration_minutes,
       service_modality: product.service_modality,

--- a/apps/backend/src/domains/store/promotions/promotion-engine/promotion-engine.service.ts
+++ b/apps/backend/src/domains/store/promotions/promotion-engine/promotion-engine.service.ts
@@ -41,29 +41,8 @@ export class PromotionEngineService {
         if (customerUsage >= promo.per_customer_limit) continue;
       }
 
-      // Check scope eligibility
-      if (promo.scope === 'product') {
-        const promoProductIds = promo.promotion_products.map(
-          (pp) => pp.product_id,
-        );
-        const hasEligibleProduct = cartItems.some((item) =>
-          promoProductIds.includes(item.product_id),
-        );
-        if (!hasEligibleProduct) continue;
-      }
-
-      if (promo.scope === 'category') {
-        // For category scope, we need product category info from the caller
-        // If cart items include category_id, we can match; otherwise skip
-        const promoCategoryIds = promo.promotion_categories.map(
-          (pc) => pc.category_id,
-        );
-        const hasEligibleCategory = cartItems.some(
-          (item) =>
-            item.category_id && promoCategoryIds.includes(item.category_id),
-        );
-        if (!hasEligibleCategory) continue;
-      }
+      const applicableTotal = this.calculateApplicableTotal(promo, cartItems);
+      if (applicableTotal <= 0) continue;
 
       // Check minimum purchase
       const cartTotal = cartItems.reduce(
@@ -92,20 +71,7 @@ export class PromotionEngineService {
    * Calculate discount amount for a promotion
    */
   calculateDiscount(promotion: any, cartItems: any[]): number {
-    let applicableTotal = 0;
-
-    if (promotion.scope === 'product') {
-      const promoProductIds =
-        promotion.promotion_products?.map((pp: any) => pp.product_id) || [];
-      applicableTotal = cartItems
-        .filter((item) => promoProductIds.includes(item.product_id))
-        .reduce((sum, item) => sum + item.unit_price * item.quantity, 0);
-    } else {
-      applicableTotal = cartItems.reduce(
-        (sum, item) => sum + item.unit_price * item.quantity,
-        0,
-      );
-    }
+    const applicableTotal = this.calculateApplicableTotal(promotion, cartItems);
 
     let discount = 0;
     if (promotion.type === 'percentage') {
@@ -115,11 +81,55 @@ export class PromotionEngineService {
     }
 
     // Apply max_discount_amount cap
-    if (promotion.max_discount_amount) {
-      discount = Math.min(discount, Number(promotion.max_discount_amount));
+    const maxDiscountAmount = Number(promotion.max_discount_amount);
+    if (Number.isFinite(maxDiscountAmount) && maxDiscountAmount > 0) {
+      discount = Math.min(discount, maxDiscountAmount);
     }
 
     return Math.round(discount * 100) / 100;
+  }
+
+  private calculateApplicableTotal(promotion: any, cartItems: any[]): number {
+    if (promotion.scope === 'product') {
+      const promoProductIds =
+        promotion.promotion_products?.map((pp: any) => Number(pp.product_id)) ||
+        [];
+
+      return cartItems
+        .filter((item) => promoProductIds.includes(Number(item.product_id)))
+        .reduce((sum, item) => sum + Number(item.unit_price) * Number(item.quantity), 0);
+    }
+
+    if (promotion.scope === 'category') {
+      const promoCategoryIds =
+        promotion.promotion_categories?.map((pc: any) => Number(pc.category_id)) ||
+        [];
+
+      return cartItems
+        .filter((item) =>
+          this.getItemCategoryIds(item).some((categoryId) =>
+            promoCategoryIds.includes(categoryId),
+          ),
+        )
+        .reduce((sum, item) => sum + Number(item.unit_price) * Number(item.quantity), 0);
+    }
+
+    return cartItems.reduce(
+      (sum, item) => sum + Number(item.unit_price) * Number(item.quantity),
+      0,
+    );
+  }
+
+  private getItemCategoryIds(item: any): number[] {
+    const categoryIds = Array.isArray(item.category_ids)
+      ? item.category_ids
+      : item.category_id
+        ? [item.category_id]
+        : [];
+
+    return categoryIds
+      .map((categoryId: string | number) => Number(categoryId))
+      .filter((categoryId: number) => Number.isFinite(categoryId));
   }
 
   /**
@@ -207,6 +217,11 @@ export class PromotionEngineService {
       throw new BadRequestException(
         `Compra minima de ${promotion.min_purchase_amount} requerida`,
       );
+    }
+
+    const applicableTotal = this.calculateApplicableTotal(promotion, cartItems);
+    if (applicableTotal <= 0) {
+      throw new BadRequestException('Promocion no aplica a los items del carrito');
     }
 
     const discount = this.calculateDiscount(promotion, cartItems);

--- a/apps/backend/src/domains/store/promotions/promotions.service.ts
+++ b/apps/backend/src/domains/store/promotions/promotions.service.ts
@@ -161,6 +161,7 @@ export class PromotionsService {
 
   async create(dto: CreatePromotionDto) {
     const { product_ids, category_ids, ...promotionData } = dto;
+    this.validateScopeSelection(dto.scope || 'order', product_ids, category_ids);
 
     const data: any = {
       ...promotionData,
@@ -196,6 +197,10 @@ export class PromotionsService {
   async update(id: number, dto: UpdatePromotionDto) {
     const existing = await this.prisma.promotions.findFirst({
       where: { id },
+      include: {
+        promotion_products: true,
+        promotion_categories: true,
+      },
     });
 
     if (!existing) {
@@ -203,6 +208,11 @@ export class PromotionsService {
     }
 
     const { product_ids, category_ids, ...updateData } = dto;
+    this.validateScopeSelection(
+      dto.scope || existing.scope,
+      product_ids ?? existing.promotion_products.map((pp) => pp.product_id),
+      category_ids ?? existing.promotion_categories.map((pc) => pc.category_id),
+    );
 
     // Prepare date conversions
     const data: any = { ...updateData };
@@ -327,5 +337,25 @@ export class PromotionsService {
       });
       await tx.promotions.delete({ where: { id } });
     });
+  }
+
+  private validateScopeSelection(
+    scope: 'order' | 'product' | 'category',
+    productIds?: number[],
+    categoryIds?: number[],
+  ): void {
+    if (scope === 'product' && (!productIds || productIds.length === 0)) {
+      throw new VendixHttpException(
+        ErrorCodes.SYS_VALIDATION_001,
+        'Selecciona al menos un producto para esta promocion',
+      );
+    }
+
+    if (scope === 'category' && (!categoryIds || categoryIds.length === 0)) {
+      throw new VendixHttpException(
+        ErrorCodes.SYS_VALIDATION_001,
+        'Selecciona al menos una categoria para esta promocion',
+      );
+    }
   }
 }

--- a/apps/backend/src/domains/store/quotations/quotations.service.ts
+++ b/apps/backend/src/domains/store/quotations/quotations.service.ts
@@ -349,14 +349,21 @@ export class QuotationsService {
   async convertToOrder(id: number) {
     const quotation = await this.findOne(id);
     if (quotation.status !== quotation_status_enum.accepted) {
-      throw new BadRequestException(
-        'Solo se pueden convertir cotizaciones aceptadas',
+      throw new VendixHttpException(
+        ErrorCodes.QUOTE_CONVERT_STATUS_001,
+        undefined,
+        {
+          current_status: quotation.status,
+          required_status: quotation_status_enum.accepted,
+        },
       );
     }
 
     if (!quotation.customer_id) {
-      throw new BadRequestException(
-        'La cotización debe tener un cliente asignado para convertirse a orden',
+      throw new VendixHttpException(
+        ErrorCodes.QUOTE_CONVERT_CUSTOMER_001,
+        undefined,
+        { quotation_id: quotation.id },
       );
     }
 

--- a/apps/frontend/public/brave-rewards-verification.txt
+++ b/apps/frontend/public/brave-rewards-verification.txt
@@ -1,4 +1,4 @@
 This is a Brave Creators publisher verification file.
 
 Domain: vendix.online
-Token: 27940c9d71f0286c8c0d5c0dc35eded6985f039536d35c95c7e9f88e36bec343
+Token: 55500eef66f848afc25503ee4ddb47cf9e372dfc8d1fc76e24d29cdc5652b3ed

--- a/apps/frontend/src/app/core/utils/api-error-handler.ts
+++ b/apps/frontend/src/app/core/utils/api-error-handler.ts
@@ -36,6 +36,34 @@ export interface NormalizedApiPayload {
   timestamp?: string;
 }
 
+function extractNestedMessage(value: any): string | null {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.filter((item) => typeof item === 'string').join(', ') || null;
+  }
+
+  if (value && typeof value === 'object') {
+    if (typeof value.message === 'string') {
+      return value.message;
+    }
+
+    if (Array.isArray(value.message)) {
+      return value.message
+        .filter((item: unknown) => typeof item === 'string')
+        .join(', ') || null;
+    }
+
+    if (typeof value.error === 'string') {
+      return value.error;
+    }
+  }
+
+  return null;
+}
+
 /**
  * Extrae el mensaje de error de una respuesta de API
  * @param response Respuesta de la API
@@ -78,8 +106,9 @@ export function extractApiErrorMessage(response: any): string {
         return apiResponse.error;
       }
       // Caso 3: Si hay un mensaje en la raíz
-      if (apiResponse.message) {
-        return apiResponse.message;
+      const apiMessage = extractNestedMessage(apiResponse.message);
+      if (apiMessage) {
+        return apiMessage;
       }
       // Caso por defecto
       return 'Error en la operación';
@@ -89,6 +118,11 @@ export function extractApiErrorMessage(response: any): string {
     if (apiResponse.success) {
       return apiResponse.message || 'Operación completada';
     }
+  }
+
+  const nestedMessage = extractNestedMessage(response?.message);
+  if (nestedMessage) {
+    return nestedMessage;
   }
 
   // Para errores HTTP estándar
@@ -118,8 +152,9 @@ export function extractApiErrorMessage(response: any): string {
   }
 
   // Para errores genéricos
-  if (response && typeof response === 'object' && 'message' in response) {
-    return response.message as string;
+  const genericMessage = extractNestedMessage(response?.message);
+  if (genericMessage) {
+    return genericMessage;
   }
 
   // Valor por defecto
@@ -146,8 +181,9 @@ export function normalizeApiPayload(response: any): NormalizedApiPayload {
     payload.success = Boolean(response.success);
   }
 
-  if (typeof response.message === 'string') {
-    payload.message = response.message;
+  const message = extractNestedMessage(response.message);
+  if (message) {
+    payload.message = message;
   } else if (response.error && typeof response.error === 'string') {
     // caso en el que `error` es string y contiene mensaje
     payload.message = response.error;
@@ -161,7 +197,7 @@ export function normalizeApiPayload(response: any): NormalizedApiPayload {
     typeof response.error === 'object' &&
     response.error.message
   ) {
-    payload.error = response.error.message;
+    payload.error = extractNestedMessage(response.error.message) ?? undefined;
   }
 
   if (typeof response.statusCode === 'number') {

--- a/apps/frontend/src/app/core/utils/error-messages.ts
+++ b/apps/frontend/src/app/core/utils/error-messages.ts
@@ -139,6 +139,12 @@ export const ERROR_MESSAGES: Record<string, string> = {
   ORD_SHIP_RATE_MISMATCH_001: 'La tarifa seleccionada no corresponde al método de envío.',
   ORD_SHIP_LOCKED_001: 'No es posible cambiar el método: la orden ya fue enviada.',
 
+  // Quotations
+  QUOTE_CONVERT_STATUS_001:
+    'Para convertir esta cotización en orden, primero debes marcarla como aceptada.',
+  QUOTE_CONVERT_CUSTOMER_001:
+    'Asigna un cliente a esta cotización antes de convertirla en orden.',
+
   // Inventory
   INV_FIND_001: 'Inventario no encontrado.',
   INV_CREATE_001: 'Error al crear el registro de inventario.',

--- a/apps/frontend/src/app/private/layouts/store-admin/store-admin-layout.component.ts
+++ b/apps/frontend/src/app/private/layouts/store-admin/store-admin-layout.component.ts
@@ -17,7 +17,6 @@ import { HeaderComponent } from '../../../shared/components/header/header.compon
 import { IconComponent } from '../../../shared/components/icon/icon.component';
 import { AuthFacade } from '../../../core/store/auth/auth.facade';
 import { ConfigFacade } from '../../../core/store/config';
-import { OnboardingWizardService } from '../../../core/services/onboarding-wizard.service';
 import { OnboardingModalComponent } from '../../../shared/components/onboarding-modal';
 import { TourModalComponent } from '../../../shared/components/tour/tour-modal/tour-modal.component';
 import { TourService } from '../../../shared/components/tour/services/tour.service';
@@ -143,11 +142,13 @@ import { map, distinctUntilChanged, skip } from 'rxjs/operators';
       </div>
     </div>
 
-    <!-- Onboarding Modal -->
-    <app-onboarding-modal
-      [(isOpen)]="showOnboardingModal"
-      (completed)="onOnboardingCompleted($event)"
-    ></app-onboarding-modal>
+    <!-- Onboarding Modal - Only render if onboarding is needed -->
+    @if (needsOnboarding()) {
+      <app-onboarding-modal
+        [(isOpen)]="showOnboardingModal"
+        (completed)="onOnboardingCompleted($event)"
+      ></app-onboarding-modal>
+    }
 
     <!-- Tour Modal -->
     <app-tour-modal [(isOpen)]="showTourModal" [tourConfig]="posTourConfig">
@@ -163,7 +164,6 @@ export class StoreAdminLayoutComponent {
 
   private authFacade = inject(AuthFacade);
   private configFacade = inject(ConfigFacade);
-  private onboardingWizardService = inject(OnboardingWizardService);
   private tourService = inject(TourService);
   private menuFilterService = inject(MenuFilterService);
   private subscriptionFacade = inject(SubscriptionFacade);

--- a/apps/frontend/src/app/private/modules/store/customers/customers.component.ts
+++ b/apps/frontend/src/app/private/modules/store/customers/customers.component.ts
@@ -14,6 +14,7 @@ import {
 import { ToastService, DialogService } from '../../../../shared/components';
 import { AuthFacade } from '../../../../core/store/auth/auth.facade';
 import { CurrencyFormatService } from '../../../../shared/pipes/currency';
+import { extractApiErrorMessage } from '../../../../core/utils/api-error-handler';
 
 @Component({
   selector: 'app-customers',
@@ -156,7 +157,10 @@ export class CustomersComponent {
         next: (stats: CustomerStats) => this.stats.set(stats),
         error: (error: any) => {
           console.error('Error loading stats:', error);
-          this.toastService.error('Error al cargar estadísticas');
+          this.toastService.error(
+            extractApiErrorMessage(error),
+            'Error al cargar estadísticas',
+          );
         },
       });
   }
@@ -174,8 +178,11 @@ export class CustomersComponent {
           this.customers.set(response.data);
           this.totalItems.set(response.meta.total);
         },
-        error: () => {
-          this.toastService.error('Error al cargar clientes');
+        error: (error) => {
+          this.toastService.error(
+            extractApiErrorMessage(error),
+            'Error al cargar clientes',
+          );
         },
       });
   }
@@ -230,9 +237,12 @@ export class CustomersComponent {
           this.loadCustomers();
           this.loadStats(); // Refresh stats too
         },
-        error: (err) => {
-          console.error(err);
-          this.toastService.error('Operación fallida');
+        error: (error) => {
+          console.error('Error saving customer:', error);
+          this.toastService.error(
+            extractApiErrorMessage(error),
+            `Error al ${this.selectedCustomer() ? 'actualizar' : 'crear'} cliente`,
+          );
         },
       });
   }
@@ -264,8 +274,11 @@ export class CustomersComponent {
                 this.loadCustomers();
                 this.loadStats();
               },
-              error: () => {
-                this.toastService.error('Error al eliminar cliente');
+              error: (error) => {
+                this.toastService.error(
+                  extractApiErrorMessage(error),
+                  'Error al eliminar cliente',
+                );
               },
             });
         }

--- a/apps/frontend/src/app/private/modules/store/customers/models/customer.model.ts
+++ b/apps/frontend/src/app/private/modules/store/customers/models/customer.model.ts
@@ -3,9 +3,9 @@ export interface Customer {
     email: string;
     first_name: string;
     last_name: string;
-    phone?: string;
-    document_type?: string;
-    document_number?: string;
+    phone?: string | null;
+    document_type?: string | null;
+    document_number?: string | null;
     created_at?: string;
     updated_at?: string;
     total_orders?: number;
@@ -18,9 +18,9 @@ export interface CreateCustomerRequest {
     email: string;
     first_name: string;
     last_name: string;
-    phone?: string;
-    document_type?: string;
-    document_number?: string;
+    phone?: string | null;
+    document_type?: string | null;
+    document_number?: string | null;
 }
 
 export interface UpdateCustomerRequest extends Partial<CreateCustomerRequest> { }

--- a/apps/frontend/src/app/private/modules/store/customers/services/customers.service.ts
+++ b/apps/frontend/src/app/private/modules/store/customers/services/customers.service.ts
@@ -57,7 +57,7 @@ export class CustomersService {
             }),
             catchError((error) => {
                 console.error('Error fetching customer stats:', error);
-                return throwError(() => new Error('Failed to fetch customer stats'));
+                return throwError(() => error);
             }),
         );
 

--- a/apps/frontend/src/app/private/modules/store/marketing/coupons/components/coupon-modal/coupon-modal.component.ts
+++ b/apps/frontend/src/app/private/modules/store/marketing/coupons/components/coupon-modal/coupon-modal.component.ts
@@ -1,12 +1,19 @@
-import { Component, inject, input, output } from '@angular/core';
+import { Component, DestroyRef, effect, inject, input, output, signal } from '@angular/core';
 
 import {
   ReactiveFormsModule,
+  AbstractControl,
   FormBuilder,
   FormGroup,
+  ValidationErrors,
   Validators,
 } from '@angular/forms';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Coupon, CreateCouponRequest } from '../../interfaces/coupon.interface';
+import {
+  MultiSelectorComponent,
+  MultiSelectorOption,
+} from '../../../../../../../shared/components/multi-selector/multi-selector.component';
 import {
   ModalComponent,
   ButtonComponent,
@@ -16,6 +23,8 @@ import {
   TextareaComponent,
   SettingToggleComponent,
 } from '../../../../../../../shared/components';
+import { ProductsService } from '../../../../products/services/products.service';
+import { CategoriesService } from '../../../../products/services/categories.service';
 
 @Component({
   selector: 'app-coupon-modal',
@@ -27,7 +36,8 @@ import {
     InputComponent,
     SelectorComponent,
     TextareaComponent,
-    SettingToggleComponent
+    SettingToggleComponent,
+    MultiSelectorComponent,
 ],
   template: `
     @if (visible()) {
@@ -104,6 +114,28 @@ import {
             formControlName="applies_to"
           ></app-selector>
         </div>
+
+        @if (form.get('applies_to')?.value === 'SPECIFIC_PRODUCTS') {
+          <app-multi-selector
+            label="Productos"
+            [options]="productOptions()"
+            formControlName="product_ids"
+            placeholder="Buscar productos..."
+            [required]="true"
+            [errorText]="form.get('product_ids')?.touched && form.get('product_ids')?.invalid ? 'Selecciona al menos un producto' : ''"
+          ></app-multi-selector>
+        }
+
+        @if (form.get('applies_to')?.value === 'SPECIFIC_CATEGORIES') {
+          <app-multi-selector
+            label="Categorias"
+            [options]="categoryOptions()"
+            formControlName="category_ids"
+            placeholder="Buscar categorias..."
+            [required]="true"
+            [errorText]="form.get('category_ids')?.touched && form.get('category_ids')?.invalid ? 'Selecciona al menos una categoria' : ''"
+          ></app-multi-selector>
+        }
 
         <!-- Valid From + Valid Until + Min Purchase -->
         <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
@@ -184,6 +216,12 @@ export class CouponModalComponent {
   save = output<CreateCouponRequest>();
 
   private fb = inject(FormBuilder);
+  private productsService = inject(ProductsService);
+  private categoriesService = inject(CategoriesService);
+  private destroyRef = inject(DestroyRef);
+
+  readonly productOptions = signal<MultiSelectorOption[]>([]);
+  readonly categoryOptions = signal<MultiSelectorOption[]>([]);
 
   discountTypeOptions: SelectorOption[] = [
     { value: 'PERCENTAGE', label: 'Porcentaje' },
@@ -210,38 +248,102 @@ export class CouponModalComponent {
     valid_until: ['', Validators.required],
     is_active: [true],
     applies_to: ['ALL_PRODUCTS'],
+    product_ids: [[]],
+    category_ids: [[]],
   });
 
-  ngOnChanges() {
-    const c = this.coupon();
-    if (c) {
-      this.form.patchValue({
-        code: c.code,
-        name: c.name,
-        description: c.description || '',
-        discount_type: c.discount_type,
-        discount_value: Number(c.discount_value),
-        min_purchase_amount: c.min_purchase_amount
-          ? Number(c.min_purchase_amount)
-          : null,
-        max_discount_amount: c.max_discount_amount
-          ? Number(c.max_discount_amount)
-          : null,
-        max_uses: c.max_uses,
-        max_uses_per_customer: c.max_uses_per_customer,
-        valid_from: this.toDatetimeLocal(c.valid_from),
-        valid_until: this.toDatetimeLocal(c.valid_until),
-        is_active: c.is_active,
-        applies_to: c.applies_to,
+  constructor() {
+    effect(() => {
+      this.populateForm(this.coupon());
+    });
+
+    this.form.get('discount_type')?.valueChanges
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((type) => this.configureDiscountValueValidators(type));
+
+    this.form.get('applies_to')?.valueChanges
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((appliesTo) => this.configureAppliesToValidators(appliesTo));
+
+    this.productsService.getProducts({ limit: 500 })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((res) => {
+        this.productOptions.set(res.data.map((product) => ({
+          value: product.id,
+          label: product.name,
+          description: product.sku,
+        })));
       });
-    } else if (!this.coupon()) {
-      this.form.reset({
-        discount_type: 'PERCENTAGE',
-        is_active: true,
-        applies_to: 'ALL_PRODUCTS',
-        max_uses_per_customer: 1,
+
+    this.categoriesService.getCategories()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((categories) => {
+        this.categoryOptions.set(categories.map((category) => ({
+          value: category.id,
+          label: category.name,
+        })));
       });
+  }
+
+  private populateForm(coupon: Coupon | null): void {
+    this.form.reset({
+      code: coupon?.code || '',
+      name: coupon?.name || '',
+      description: coupon?.description || '',
+      discount_type: coupon?.discount_type || 'PERCENTAGE',
+      discount_value: coupon?.discount_value ? Number(coupon.discount_value) : null,
+      min_purchase_amount: coupon?.min_purchase_amount
+        ? Number(coupon.min_purchase_amount)
+        : null,
+      max_discount_amount: coupon?.max_discount_amount
+        ? Number(coupon.max_discount_amount)
+        : null,
+      max_uses: coupon?.max_uses ?? null,
+      max_uses_per_customer: coupon?.max_uses_per_customer ?? 1,
+      valid_from: this.toDatetimeLocal(coupon?.valid_from),
+      valid_until: this.toDatetimeLocal(coupon?.valid_until),
+      is_active: coupon?.is_active ?? true,
+      applies_to: coupon?.applies_to || 'ALL_PRODUCTS',
+      product_ids: coupon?.coupon_products?.map((cp) => cp.product_id ?? cp.product?.id).filter(Boolean) || [],
+      category_ids: coupon?.coupon_categories?.map((cc) => cc.category_id ?? cc.category?.id).filter(Boolean) || [],
+    }, { emitEvent: false });
+
+    this.configureDiscountValueValidators(this.form.get('discount_type')?.value);
+    this.configureAppliesToValidators(this.form.get('applies_to')?.value);
+  }
+
+  private configureDiscountValueValidators(type: string): void {
+    const discountValueControl = this.form.get('discount_value');
+    const validators = [Validators.required, Validators.min(0.01)];
+    if (type === 'PERCENTAGE') {
+      validators.push(Validators.max(100));
     }
+    discountValueControl?.setValidators(validators);
+    discountValueControl?.updateValueAndValidity({ emitEvent: false });
+  }
+
+  private configureAppliesToValidators(appliesTo: string): void {
+    const productIdsControl = this.form.get('product_ids');
+    const categoryIdsControl = this.form.get('category_ids');
+
+    productIdsControl?.clearValidators();
+    categoryIdsControl?.clearValidators();
+
+    if (appliesTo === 'SPECIFIC_PRODUCTS') {
+      productIdsControl?.setValidators([this.requiredArray]);
+    }
+    if (appliesTo === 'SPECIFIC_CATEGORIES') {
+      categoryIdsControl?.setValidators([this.requiredArray]);
+    }
+
+    productIdsControl?.updateValueAndValidity({ emitEvent: false });
+    categoryIdsControl?.updateValueAndValidity({ emitEvent: false });
+  }
+
+  private requiredArray(control: AbstractControl): ValidationErrors | null {
+    return Array.isArray(control.value) && control.value.length > 0
+      ? null
+      : { required: true };
   }
 
   generateCode() {
@@ -254,7 +356,11 @@ export class CouponModalComponent {
   }
 
   onSubmit() {
-    if (this.form.invalid) return;
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
     const raw = this.form.getRawValue();
     const request: CreateCouponRequest = {
       code: raw.code.toUpperCase().trim(),
@@ -271,10 +377,24 @@ export class CouponModalComponent {
       is_active: raw.is_active,
       applies_to: raw.applies_to,
     };
+
+    if (raw.applies_to === 'SPECIFIC_PRODUCTS') {
+      request.product_ids = this.toNumberArray(raw.product_ids);
+    }
+    if (raw.applies_to === 'SPECIFIC_CATEGORIES') {
+      request.category_ids = this.toNumberArray(raw.category_ids);
+    }
+
     this.save.emit(request);
   }
 
-  private toDatetimeLocal(iso: string): string {
+  private toNumberArray(value: unknown): number[] {
+    return Array.isArray(value)
+      ? value.map((item) => Number(item)).filter((item) => Number.isFinite(item))
+      : [];
+  }
+
+  private toDatetimeLocal(iso?: string): string {
     if (!iso) return '';
     const d = new Date(iso);
     return d.toISOString().slice(0, 16);

--- a/apps/frontend/src/app/private/modules/store/marketing/coupons/interfaces/coupon.interface.ts
+++ b/apps/frontend/src/app/private/modules/store/marketing/coupons/interfaces/coupon.interface.ts
@@ -17,8 +17,8 @@ export interface Coupon {
   applies_to: 'ALL_PRODUCTS' | 'SPECIFIC_PRODUCTS' | 'SPECIFIC_CATEGORIES';
   created_at: string;
   updated_at: string;
-  coupon_products?: { product: { id: number; name: string; sku?: string } }[];
-  coupon_categories?: { category: { id: number; name: string } }[];
+  coupon_products?: { product_id?: number; product: { id: number; name: string; sku?: string } }[];
+  coupon_categories?: { category_id?: number; category: { id: number; name: string } }[];
   _count?: { coupon_uses: number };
 }
 

--- a/apps/frontend/src/app/private/modules/store/marketing/promotions/components/promotion-form-modal/promotion-form-modal.component.ts
+++ b/apps/frontend/src/app/private/modules/store/marketing/promotions/components/promotion-form-modal/promotion-form-modal.component.ts
@@ -1,8 +1,10 @@
-import { Component, DestroyRef, inject, input, output } from '@angular/core';
+import { Component, DestroyRef, effect, inject, input, output, signal } from '@angular/core';
 import {
   ReactiveFormsModule,
+  AbstractControl,
   FormBuilder,
   FormGroup,
+  ValidationErrors,
   Validators,
 } from '@angular/forms';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -110,9 +112,11 @@ import { CategoriesService } from '../../../../products/services/categories.serv
         @if (form.get('scope')?.value === 'product') {
           <app-multi-selector
             label="Productos"
-            [options]="productOptions"
+            [options]="productOptions()"
             formControlName="product_ids"
             placeholder="Buscar productos..."
+            [required]="true"
+            [errorText]="form.get('product_ids')?.touched && form.get('product_ids')?.invalid ? 'Selecciona al menos un producto' : ''"
           ></app-multi-selector>
         }
 
@@ -120,9 +124,11 @@ import { CategoriesService } from '../../../../products/services/categories.serv
         @if (form.get('scope')?.value === 'category') {
           <app-multi-selector
             label="Categorias"
-            [options]="categoryOptions"
+            [options]="categoryOptions()"
             formControlName="category_ids"
             placeholder="Buscar categorias..."
+            [required]="true"
+            [errorText]="form.get('category_ids')?.touched && form.get('category_ids')?.invalid ? 'Selecciona al menos una categoria' : ''"
           ></app-multi-selector>
         }
 
@@ -212,10 +218,11 @@ export class PromotionFormModalComponent {
   private productsService = inject(ProductsService);
   private categoriesService = inject(CategoriesService);
   private destroyRef = inject(DestroyRef);
+  private fb = inject(FormBuilder);
 
   form!: FormGroup;
-  productOptions: MultiSelectorOption[] = [];
-  categoryOptions: MultiSelectorOption[] = [];
+  readonly productOptions = signal<MultiSelectorOption[]>([]);
+  readonly categoryOptions = signal<MultiSelectorOption[]>([]);
 
   typeOptions: SelectorOption[] = [
     { value: 'percentage', label: 'Porcentaje' },
@@ -228,43 +235,130 @@ export class PromotionFormModalComponent {
     { value: 'category', label: 'Categoria' },
   ];
 
-  constructor(private fb: FormBuilder) {
-    const p = this.promotion();
+  constructor() {
     this.form = this.fb.group({
-      name: [p?.name || '', Validators.required],
-      description: [p?.description || ''],
-      code: [p?.code || ''],
-      type: [p?.type || 'percentage', Validators.required],
-      value: [p?.value || null, [Validators.required, Validators.min(0.01)]],
-      scope: [p?.scope || 'order'],
-      start_date: [p?.start_date?.split('T')[0] || '', Validators.required],
-      end_date: [p?.end_date?.split('T')[0] || ''],
-      min_purchase_amount: [p?.min_purchase_amount || null],
-      max_discount_amount: [p?.max_discount_amount || null],
-      usage_limit: [p?.usage_limit || null],
-      per_customer_limit: [p?.per_customer_limit || null],
-      is_auto_apply: [p?.is_auto_apply ?? false],
-      priority: [p?.priority ?? 0],
-      product_ids: [p?.promotion_products?.map(pp => pp.product_id) || []],
-      category_ids: [p?.promotion_categories?.map(pc => pc.category_id) || []],
+      name: ['', Validators.required],
+      description: [''],
+      code: [''],
+      type: ['percentage', Validators.required],
+      value: [null, [Validators.required, Validators.min(0.01), Validators.max(100)]],
+      scope: ['order'],
+      start_date: ['', Validators.required],
+      end_date: [''],
+      min_purchase_amount: [null],
+      max_discount_amount: [null],
+      usage_limit: [null],
+      per_customer_limit: [null],
+      is_auto_apply: [false],
+      priority: [0],
+      product_ids: [[]],
+      category_ids: [[]],
     });
+
+    effect(() => {
+      this.populateForm(this.promotion());
+    });
+
+    this.form.get('type')?.valueChanges
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((type) => {
+        this.configureValueValidators(type);
+        if (type !== 'percentage') {
+          this.form.patchValue({ max_discount_amount: null }, { emitEvent: false });
+        }
+      });
+
+    this.form.get('scope')?.valueChanges
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((scope) => this.configureScopeValidators(scope));
 
     // Load product and category options for multi-selectors
     this.productsService.getProducts({ limit: 500 })
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(res => {
-        this.productOptions = res.data.map(p => ({ value: p.id, label: p.name, description: p.sku }));
+        this.productOptions.set(res.data.map(p => ({ value: p.id, label: p.name, description: p.sku })));
       });
 
     this.categoriesService.getCategories()
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(cats => {
-        this.categoryOptions = cats.map(c => ({ value: c.id, label: c.name }));
+        this.categoryOptions.set(cats.map(c => ({ value: c.id, label: c.name })));
       });
   }
 
+  private populateForm(promotion: Promotion | null): void {
+    this.form.reset({
+      name: promotion?.name || '',
+      description: promotion?.description || '',
+      code: promotion?.code || '',
+      type: promotion?.type || 'percentage',
+      value: promotion?.value ?? null,
+      scope: promotion?.scope || 'order',
+      start_date: this.toDateInputValue(promotion?.start_date),
+      end_date: this.toDateInputValue(promotion?.end_date),
+      min_purchase_amount: promotion?.min_purchase_amount ?? null,
+      max_discount_amount: promotion?.max_discount_amount ?? null,
+      usage_limit: promotion?.usage_limit ?? null,
+      per_customer_limit: promotion?.per_customer_limit ?? null,
+      is_auto_apply: promotion?.is_auto_apply ?? false,
+      priority: promotion?.priority ?? 0,
+      product_ids: promotion?.promotion_products?.map((pp) => pp.product_id) || [],
+      category_ids: promotion?.promotion_categories?.map((pc) => pc.category_id) || [],
+    }, { emitEvent: false });
+
+    this.configureValueValidators(this.form.get('type')?.value);
+    this.configureScopeValidators(this.form.get('scope')?.value);
+  }
+
+  private configureValueValidators(type: string): void {
+    const valueControl = this.form.get('value');
+    const validators = [Validators.required, Validators.min(0.01)];
+    if (type === 'percentage') {
+      validators.push(Validators.max(100));
+    }
+    valueControl?.setValidators(validators);
+    valueControl?.updateValueAndValidity({ emitEvent: false });
+  }
+
+  private configureScopeValidators(scope: string): void {
+    const productIdsControl = this.form.get('product_ids');
+    const categoryIdsControl = this.form.get('category_ids');
+
+    productIdsControl?.clearValidators();
+    categoryIdsControl?.clearValidators();
+
+    if (scope === 'product') {
+      productIdsControl?.setValidators([this.requiredArray]);
+    }
+    if (scope === 'category') {
+      categoryIdsControl?.setValidators([this.requiredArray]);
+    }
+
+    productIdsControl?.updateValueAndValidity({ emitEvent: false });
+    categoryIdsControl?.updateValueAndValidity({ emitEvent: false });
+  }
+
+  private requiredArray(control: AbstractControl): ValidationErrors | null {
+    return Array.isArray(control.value) && control.value.length > 0
+      ? null
+      : { required: true };
+  }
+
+  private toDateInputValue(value?: string | null): string {
+    return value ? value.split('T')[0] : '';
+  }
+
+  private toNumberArray(value: unknown): number[] {
+    return Array.isArray(value)
+      ? value.map((item) => Number(item)).filter((item) => Number.isFinite(item))
+      : [];
+  }
+
   onSubmit(): void {
-    if (this.form.invalid) return;
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
 
     const raw = this.form.getRawValue();
 
@@ -273,15 +367,18 @@ export class PromotionFormModalComponent {
     if (!dto.description) delete dto.description;
     if (!dto.code) delete dto.code;
     if (!dto.end_date) delete dto.end_date;
-    if (dto.min_purchase_amount === null) delete dto.min_purchase_amount;
-    if (dto.max_discount_amount === null) delete dto.max_discount_amount;
-    if (dto.usage_limit === null) delete dto.usage_limit;
-    if (dto.per_customer_limit === null) delete dto.per_customer_limit;
+    if (dto.min_purchase_amount === null || dto.min_purchase_amount === '') delete dto.min_purchase_amount;
+    if (dto.max_discount_amount === null || dto.max_discount_amount === '') delete dto.max_discount_amount;
+    if (dto.usage_limit === null || dto.usage_limit === '') delete dto.usage_limit;
+    if (dto.per_customer_limit === null || dto.per_customer_limit === '') delete dto.per_customer_limit;
+    if (dto.type !== 'percentage') delete dto.max_discount_amount;
 
     // Clean up scope-specific IDs
     if (dto.scope === 'product') {
+      dto.product_ids = this.toNumberArray(dto.product_ids);
       delete dto.category_ids;
     } else if (dto.scope === 'category') {
+      dto.category_ids = this.toNumberArray(dto.category_ids);
       delete dto.product_ids;
     } else {
       delete dto.product_ids;

--- a/apps/frontend/src/app/private/modules/store/pos/cart/pos-cart.component.ts
+++ b/apps/frontend/src/app/private/modules/store/pos/cart/pos-cart.component.ts
@@ -1,4 +1,4 @@
-import { Component, input, output, inject, DestroyRef } from '@angular/core';
+import { Component, input, output, inject, DestroyRef, computed, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { Observable } from 'rxjs';
 import { map, distinctUntilChanged, skip } from 'rxjs/operators';
@@ -11,15 +11,35 @@ import { CartDiscount } from '../models/cart.model';
 import { ToastService } from '../../../../../shared/components/toast/toast.service';
 import { IconComponent } from '../../../../../shared/components/icon/icon.component';
 import { DialogService } from '../../../../../shared/components/dialog/dialog.service';
+import { ModalComponent } from '../../../../../shared/components/modal/modal.component';
+import {
+  ButtonComponent,
+  InputComponent,
+  SelectorComponent,
+  TextareaComponent,
+} from '../../../../../shared/components';
+import type { SelectorOption } from '../../../../../shared/components/selector/selector.component';
 import { QuantityControlComponent } from '../../../../../shared/components/quantity-control/quantity-control.component';
 import { CurrencyFormatService } from '../../../../../shared/pipes/currency';
 import { PosScaleService } from '../services/pos-scale.service';
 import { PosApiService } from '../services/pos-api.service';
+import { AuthFacade } from '../../../../../core/store/auth/auth.facade';
+import { TaxesService } from '../../products/services/taxes.service';
+import { TaxCategory } from '../../products/interfaces';
 
 @Component({
   selector: 'app-pos-cart',
   standalone: true,
-  imports: [FormsModule, IconComponent, QuantityControlComponent],
+  imports: [
+    FormsModule,
+    IconComponent,
+    ModalComponent,
+    ButtonComponent,
+    InputComponent,
+    SelectorComponent,
+    TextareaComponent,
+    QuantityControlComponent,
+  ],
   template: `
     <div
       class="h-full flex flex-col bg-surface rounded-card shadow-card border border-border overflow-hidden"
@@ -197,6 +217,16 @@ import { PosApiService } from '../services/pos-api.service';
               <div class="cart-actions-row">
                 <button
                   type="button"
+                  class="cart-btn custom-item-btn"
+                  (click)="openCustomItemModal()"
+                  [disabled]="!canCreateCustomItems()"
+                  title="Agregar ítem personalizado"
+                >
+                  <app-icon name="file-plus" [size]="16"></app-icon>
+                  <span>Ítem</span>
+                </button>
+                <button
+                  type="button"
                   class="cart-btn save-btn"
                   (click)="saveCart()"
                   [disabled]="isEmpty()"
@@ -323,6 +353,13 @@ import { PosApiService } from '../services/pos-api.service';
                       {{ item.variant_display_name }}
                     </p>
                   }
+                  @if (item.itemType === 'custom' || item.description) {
+                    <p
+                      class="text-[10px] text-text-secondary truncate leading-tight"
+                    >
+                      {{ item.itemType === 'custom' ? 'Ítem personalizado' : item.description }}
+                    </p>
+                  }
                   <div class="flex items-center gap-2 mt-0.5">
                     <span class="text-[10px] text-text-muted">
                       Base: {{ formatCurrency(item.unitPrice)
@@ -346,55 +383,87 @@ import { PosApiService } from '../services/pos-api.service';
                         +{{ formatCurrency(getItemTaxAmount(item)) }}
                       </span>
                     }
+                    @if (item.isPriceOverridden) {
+                      <span
+                        class="inline-flex items-center px-1 py-0.5 rounded text-[9px] font-medium bg-purple-100 text-purple-800"
+                      >
+                        precio editado
+                      </span>
+                    }
                   </div>
                 </div>
-                <!-- Remove Button -->
-                <button
-                  (click)="removeFromCart(item.id)"
-                  class="p-1 rounded-sm text-text-secondary hover:text-destructive hover:bg-destructive/10 transition-colors self-start"
-                  title="Eliminar"
-                >
-                  <app-icon name="trash-2" [size]="14"></app-icon>
-                </button>
+                <!-- Item actions -->
+                <div class="flex items-start gap-1 self-start">
+                  @if (item.itemType === 'custom' && canEditItemPrice(item)) {
+                    <button
+                      type="button"
+                      (click)="editItemPrice(item)"
+                      class="p-1 rounded-sm text-text-secondary hover:text-primary hover:bg-primary/10 transition-colors"
+                      title="Editar ítem personalizado"
+                    >
+                      <app-icon name="pencil" [size]="14"></app-icon>
+                    </button>
+                  }
+                  <button
+                    type="button"
+                    (click)="removeFromCart(item.id)"
+                    class="p-1 rounded-sm text-text-secondary hover:text-destructive hover:bg-destructive/10 transition-colors"
+                    title="Eliminar"
+                  >
+                    <app-icon name="trash-2" [size]="14"></app-icon>
+                  </button>
+                </div>
                 <!-- Actions Row: Quantity + Total -->
                 <div
                   class="col-span-3 flex items-center justify-between pt-2 mt-1 border-t border-border/50"
                 >
-                  <!-- Weight products: show clickable weight badge instead of quantity control -->
-                  @if (item.is_weight_product) {
-                    <button
-                      (click)="editWeight(item)"
-                      class="flex items-center gap-1.5 px-2 py-1 bg-blue-50 rounded-lg border border-blue-200 hover:bg-blue-100 hover:border-blue-300 transition-colors cursor-pointer"
-                      title="Editar peso"
-                    >
-                      <app-icon
-                        name="scale"
-                        [size]="14"
-                        class="text-blue-600"
-                      ></app-icon>
-                      <span class="text-xs font-bold text-blue-700"
-                        >{{ item.weight }} {{ item.weight_unit || 'kg' }}</span
+                  <div class="flex items-center gap-2 min-w-0">
+                    <!-- Weight products: show clickable weight badge instead of quantity control -->
+                    @if (item.is_weight_product) {
+                      <button
+                        (click)="editWeight(item)"
+                        class="flex items-center gap-1.5 px-2 py-1 bg-blue-50 rounded-lg border border-blue-200 hover:bg-blue-100 hover:border-blue-300 transition-colors cursor-pointer"
+                        title="Editar peso"
                       >
-                      <app-icon
-                        name="edit"
-                        [size]="10"
-                        class="text-blue-400"
-                      ></app-icon>
-                    </button>
-                  } @else {
-                    <app-quantity-control
-                      [value]="item.quantity"
-                      [min]="1"
-                      [max]="
-                        item.product.track_inventory !== false
-                          ? item.product.stock
-                          : 999
-                      "
-                      [editable]="true"
-                      [size]="'sm'"
-                      (valueChange)="updateQuantity(item.id, $event)"
-                    ></app-quantity-control>
-                  }
+                        <app-icon
+                          name="scale"
+                          [size]="14"
+                          class="text-blue-600"
+                        ></app-icon>
+                        <span class="text-xs font-bold text-blue-700"
+                          >{{ item.weight }} {{ item.weight_unit || 'kg' }}</span
+                        >
+                        <app-icon
+                          name="edit"
+                          [size]="10"
+                          class="text-blue-400"
+                        ></app-icon>
+                      </button>
+                    } @else {
+                      <app-quantity-control
+                        [value]="item.quantity"
+                        [min]="1"
+                        [max]="
+                          item.product.track_inventory !== false
+                            ? item.product.stock
+                            : 999
+                        "
+                        [editable]="true"
+                        [size]="'sm'"
+                        (valueChange)="updateQuantity(item.id, $event)"
+                      ></app-quantity-control>
+                    }
+                    @if (item.itemType !== 'custom' && canEditItemPrice(item)) {
+                      <button
+                        type="button"
+                        (click)="editItemPrice(item)"
+                        class="p-1.5 rounded-md text-text-secondary hover:text-primary hover:bg-primary/10 transition-colors"
+                        title="Editar precio de venta"
+                      >
+                        <app-icon name="pencil" [size]="14"></app-icon>
+                      </button>
+                    }
+                  </div>
                   <span class="text-sm font-extrabold text-primary">
                     {{ formatCurrency(item.totalPrice) }}
                   </span>
@@ -405,6 +474,106 @@ import { PosApiService } from '../services/pos-api.service';
         }
       </div>
     </div>
+
+    <app-modal
+      [isOpen]="customItemModalOpen()"
+      title="Ítem personalizado"
+      subtitle="Agrega una línea facturable sin afectar inventario"
+      size="sm"
+      (closed)="customItemModalOpen.set(false)"
+    >
+      <div class="space-y-4">
+        <app-input
+          label="Nombre"
+          placeholder="Servicio de instalación"
+          [ngModel]="customItemDraft().name"
+          (ngModelChange)="updateCustomItemDraft('name', $event)"
+        ></app-input>
+
+        <app-textarea
+          label="Detalle"
+          placeholder="Alcance, materiales, condiciones o notas visibles en la orden"
+          [rows]="3"
+          [ngModel]="customItemDraft().description"
+          (ngModelChange)="updateCustomItemDraft('description', $event)"
+        ></app-textarea>
+
+        <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <app-input
+            label="Cantidad"
+            type="number"
+            min="1"
+            [ngModel]="customItemDraft().quantity"
+            (ngModelChange)="updateCustomItemDraft('quantity', $event)"
+          ></app-input>
+
+          <app-input
+            label="Precio final"
+            placeholder="$0"
+            min="0"
+            [currency]="true"
+            [ngModel]="customItemDraft().finalPrice"
+            (ngModelChange)="updateCustomItemDraft('finalPrice', $event)"
+          ></app-input>
+        </div>
+
+        <app-selector
+          label="IVA / impuesto"
+          helpText="Usa los impuestos configurados para la tienda."
+          [options]="taxCategoryOptions()"
+          [ngModel]="customItemDraft().taxCategoryId ?? 0"
+          (ngModelChange)="updateCustomItemDraft('taxCategoryId', $event)"
+        ></app-selector>
+
+        <div
+          class="rounded-xl border border-border bg-[var(--color-background)]/60 px-3 py-2 text-xs"
+        >
+          <div class="flex justify-between">
+            <span class="text-text-secondary">Base</span>
+            <span class="font-semibold">{{
+              formatCurrency(customItemBasePrice())
+            }}</span>
+          </div>
+          <div class="flex justify-between">
+            <span class="text-text-secondary">Impuesto</span>
+            <span class="font-semibold">{{
+              formatCurrency(customItemTaxAmount())
+            }}</span>
+          </div>
+          <div class="mt-1 flex justify-between border-t border-border/60 pt-1">
+            <span class="font-semibold text-text-primary">Total línea</span>
+            <span class="font-bold text-[var(--color-primary)]">{{
+              formatCurrency(customItemTotal())
+            }}</span>
+          </div>
+        </div>
+      </div>
+
+      <div
+        slot="footer"
+        class="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end"
+      >
+        <app-button
+          class="w-full sm:w-auto"
+          variant="outline"
+          size="md"
+          customClasses="min-w-[120px]"
+          (clicked)="customItemModalOpen.set(false)"
+        >
+          Cancelar
+        </app-button>
+        <app-button
+          class="w-full sm:w-auto"
+          variant="primary"
+          size="md"
+          customClasses="min-w-[120px]"
+          [disabled]="!canSubmitCustomItem()"
+          (clicked)="addCustomItem()"
+        >
+          Agregar
+        </app-button>
+      </div>
+    </app-modal>
   `,
   styles: [
     `
@@ -421,7 +590,7 @@ import { PosApiService } from '../services/pos-api.service';
 
       .cart-actions-row {
         display: grid;
-        grid-template-columns: 1fr 1fr;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
         gap: 8px;
       }
 
@@ -481,6 +650,16 @@ import { PosApiService } from '../services/pos-api.service';
         opacity: 0.85;
       }
 
+      .custom-item-btn {
+        background: color-mix(in srgb, var(--color-primary) 10%, var(--color-surface));
+        border: 1px solid color-mix(in srgb, var(--color-primary) 25%, var(--color-border));
+        color: var(--color-primary);
+      }
+
+      .custom-item-btn:hover:not(:disabled) {
+        background: color-mix(in srgb, var(--color-primary) 16%, var(--color-surface));
+      }
+
       .shipping-btn:hover:not(:disabled) {
         opacity: 1;
       }
@@ -494,10 +673,42 @@ private cartService = inject(PosCartService);
   private currencyService = inject(CurrencyFormatService);
   private scaleService = inject(PosScaleService);
   private posApiService = inject(PosApiService);
+  private authFacade = inject(AuthFacade);
+  private taxesService = inject(TaxesService);
 
   readonly cartState = this.cartService.cartState;
   readonly isEmpty = toSignal(this.cartService.isEmpty, { initialValue: false });
   readonly summary = toSignal(this.cartService.summary, { initialValue: null! });
+  readonly taxCategories = signal<TaxCategory[]>([]);
+  readonly customItemModalOpen = signal(false);
+  readonly customItemDraft = signal({
+    name: '',
+    description: '',
+    quantity: 1,
+    finalPrice: 0,
+    taxCategoryId: null as number | null,
+  });
+  readonly taxCategoryOptions = computed<SelectorOption[]>(() => [
+    { value: 0, label: 'Sin impuesto' },
+    ...this.taxCategories().map((tax) => ({
+      value: tax.id,
+      label: `${tax.name} (${this.formatPercentRate(tax)})`,
+    })),
+  ]);
+  readonly canSubmitCustomItem = computed(() => {
+    const draft = this.customItemDraft();
+    return (
+      draft.name.trim().length > 0 &&
+      Number(draft.quantity || 0) > 0 &&
+      Number(draft.finalPrice || 0) >= 0
+    );
+  });
+  readonly canCreateCustomItems = computed(() =>
+    this.hasPermission('store:pos:custom_items:create'),
+  );
+  readonly canOverridePrices = computed(() =>
+    this.hasPermission('store:pos:price_override'),
+  );
 
   activePromotions: any[] = [];
   couponCode = '';
@@ -513,6 +724,14 @@ private cartService = inject(PosCartService);
   readonly layaway = output<void>();
 
   constructor() {
+    this.taxesService
+      .getTaxCategories()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (taxCategories) => this.taxCategories.set(taxCategories || []),
+        error: () => this.taxCategories.set([]),
+      });
+
 // Load active promotions
     this.posApiService
       .getActivePromotions()
@@ -553,6 +772,139 @@ private cartService = inject(PosCartService);
 
   trackByItemId(_index: number, item: CartItem): string {
     return item.id;
+  }
+
+  private hasPermission(permission: string): boolean {
+    const permissions = this.authFacade.userPermissions();
+    const roles = this.authFacade.userRoles();
+    return (
+      permissions.includes(permission) ||
+      roles.includes('super_admin') ||
+      roles.includes('SUPER_ADMIN')
+    );
+  }
+
+  openCustomItemModal(): void {
+    if (!this.canCreateCustomItems()) {
+      this.toastService.warning('No tienes permiso para agregar ítems personalizados');
+      return;
+    }
+    this.customItemDraft.set({
+      name: '',
+      description: '',
+      quantity: 1,
+      finalPrice: 0,
+      taxCategoryId: null,
+    });
+    this.customItemModalOpen.set(true);
+  }
+
+  updateCustomItemDraft(
+    field: 'name' | 'description' | 'quantity' | 'finalPrice' | 'taxCategoryId',
+    value: string | number | null,
+  ): void {
+    this.customItemDraft.update((draft) => ({
+      ...draft,
+      [field]:
+        field === 'quantity' || field === 'finalPrice'
+          ? Number(value || 0)
+          : field === 'taxCategoryId'
+            ? value === null || value === '' || Number(value) <= 0
+              ? null
+              : Number(value)
+            : String(value || ''),
+    }));
+  }
+
+  addCustomItem(): void {
+    if (!this.canSubmitCustomItem()) {
+      this.toastService.warning('Completa el nombre y un valor válido para el ítem');
+      return;
+    }
+
+    const draft = this.customItemDraft();
+    const taxCategory = this.getSelectedTaxCategory();
+
+    this.cartService
+      .addCustomItem({
+        name: draft.name.trim(),
+        description: draft.description.trim(),
+        quantity: Number(draft.quantity || 1),
+        finalPrice: Number(draft.finalPrice || 0),
+        taxCategory,
+      })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          this.customItemModalOpen.set(false);
+          this.toastService.success('Ítem personalizado agregado');
+        },
+        error: (error) => {
+          this.toastService.error(error.message || 'Error al agregar el ítem');
+        },
+      });
+  }
+
+  canEditItemPrice(item: CartItem): boolean {
+    if (item.itemType === 'custom') {
+      return this.canCreateCustomItems();
+    }
+
+    return (
+      item.product.allow_pos_price_override === true &&
+      this.canOverridePrices()
+    );
+  }
+
+  async editItemPrice(item: CartItem): Promise<void> {
+    if (!this.canEditItemPrice(item)) {
+      this.toastService.warning('No tienes permiso para editar este precio');
+      return;
+    }
+
+    const value = await this.dialogService.prompt(
+      {
+        title: 'Editar precio de venta',
+        message: item.product.name,
+        placeholder: 'Precio final',
+        defaultValue: item.finalPrice.toString(),
+        confirmText: 'Actualizar',
+        cancelText: 'Cancelar',
+        inputType: 'number',
+      },
+      { size: 'sm' },
+    );
+
+    if (value === undefined) return;
+    const finalPrice = Number(value);
+    if (Number.isNaN(finalPrice) || finalPrice < 0) {
+      this.toastService.warning('El precio debe ser un número válido');
+      return;
+    }
+
+    let reason = item.priceOverrideReason;
+    if (item.itemType !== 'custom') {
+      reason = await this.dialogService.prompt(
+        {
+          title: 'Motivo del cambio',
+          message: 'Opcional, queda como referencia de auditoría de la orden.',
+          placeholder: 'Ej. precio negociado con el cliente',
+          defaultValue: item.priceOverrideReason || '',
+          confirmText: 'Guardar',
+          cancelText: 'Omitir',
+        },
+        { size: 'sm' },
+      );
+    }
+
+    this.cartService
+      .updateCartItemPrice({ itemId: item.id, finalPrice, reason })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => this.toastService.success('Precio actualizado'),
+        error: (error) =>
+          this.toastService.error(error.message || 'Error al actualizar precio'),
+      });
   }
 
   updateQuantity(itemId: string, quantity: number): void {
@@ -704,13 +1056,48 @@ private cartService = inject(PosCartService);
     const subtotal =
       currentState.summary.subtotal + currentState.summary.taxAmount;
     const customerId = currentState.customer?.id;
-    const productIds = currentState.items.map((item) =>
-      parseInt(item.product.id),
+    const productIds = currentState.items
+      .filter((item) => item.itemType !== 'custom')
+      .map((item) => parseInt(item.product.id))
+      .filter((id) => Number.isFinite(id));
+    const categoryIds = Array.from(
+      new Set(
+        currentState.items.flatMap((item) => {
+          const product = item.product as any;
+          const ids = Array.isArray(product.category_ids)
+            ? product.category_ids
+            : product.category_id
+              ? [product.category_id]
+              : [];
+          return ids
+            .map((id: string | number) => Number(id))
+            .filter((id: number) => Number.isFinite(id));
+        }),
+      ),
     );
+    const couponItems = currentState.items
+      .filter((item) => item.itemType !== 'custom')
+      .map((item) => {
+        const product = item.product as any;
+        const itemCategoryIds = Array.isArray(product.category_ids)
+          ? product.category_ids
+          : product.category_id
+            ? [product.category_id]
+            : [];
+
+        return {
+          product_id: Number(item.product.id),
+          category_ids: itemCategoryIds
+            .map((id: string | number) => Number(id))
+            .filter((id: number) => Number.isFinite(id)),
+          line_total: Number(item.totalPrice || 0),
+        };
+      })
+      .filter((item) => Number.isFinite(item.product_id));
 
     this.couponLoading = true;
     this.posApiService
-      .validateCoupon(code, subtotal, customerId, productIds)
+      .validateCoupon(code, subtotal, customerId, productIds, categoryIds, couponItems)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (response) => {
@@ -769,6 +1156,43 @@ private cartService = inject(PosCartService);
 
   formatCurrency(amount: number): string {
     return this.currencyService.format(amount);
+  }
+
+  getTaxCategoryRate(taxCategory?: TaxCategory | null): number {
+    return (
+      taxCategory?.tax_rates?.reduce(
+        (sum, rate: any) => sum + Number(rate.rate || 0),
+        0,
+      ) || 0
+    );
+  }
+
+  formatPercentRate(taxCategory: TaxCategory): string {
+    return `${(this.getTaxCategoryRate(taxCategory) * 100).toFixed(2)}%`;
+  }
+
+  getSelectedTaxCategory(): TaxCategory | null {
+    const selectedId = this.customItemDraft().taxCategoryId;
+    if (!selectedId) return null;
+    return this.taxCategories().find((tax) => tax.id === selectedId) || null;
+  }
+
+  customItemBasePrice(): number {
+    const draft = this.customItemDraft();
+    const finalPrice = Number(draft.finalPrice || 0);
+    const rate = this.getTaxCategoryRate(this.getSelectedTaxCategory());
+    return rate > 0 ? finalPrice / (1 + rate) : finalPrice;
+  }
+
+  customItemTaxAmount(): number {
+    const draft = this.customItemDraft();
+    const quantity = Number(draft.quantity || 1);
+    return (Number(draft.finalPrice || 0) - this.customItemBasePrice()) * quantity;
+  }
+
+  customItemTotal(): number {
+    const draft = this.customItemDraft();
+    return Number(draft.finalPrice || 0) * Number(draft.quantity || 1);
   }
 
   getItemTaxRate(item: CartItem): number {

--- a/apps/frontend/src/app/private/modules/store/pos/components/pos-cart-modal.component.ts
+++ b/apps/frontend/src/app/private/modules/store/pos/components/pos-cart-modal.component.ts
@@ -59,6 +59,16 @@ import { CurrencyFormatService } from '../../../../../shared/pipes/currency';
               </div>
               <p class="empty-text">Tu carrito está vacío</p>
               <p class="empty-hint">Selecciona productos para comenzar</p>
+              @if (canCreateCustomItems()) {
+                <button
+                  type="button"
+                  class="empty-custom-item-btn"
+                  (click)="customItemRequested.emit()"
+                >
+                  <app-icon name="file-plus" [size]="16"></app-icon>
+                  <span>Agregar ítem personalizado</span>
+                </button>
+              }
             </div>
           }
     
@@ -94,6 +104,11 @@ import { CurrencyFormatService } from '../../../../../shared/pipes/currency';
                         {{ item.variant_display_name }}
                       </p>
                     }
+                    @if (item.itemType === 'custom' || item.description) {
+                      <p class="item-description">
+                        {{ item.itemType === 'custom' ? 'Ítem personalizado' : item.description }}
+                      </p>
+                    }
                     <div class="item-meta">
                       @if (item.variant_sku || item.product.sku) {
                         <span class="item-sku">{{ item.variant_sku || item.product.sku }}</span>
@@ -106,6 +121,14 @@ import { CurrencyFormatService } from '../../../../../shared/pipes/currency';
                       <span class="item-unit-price">
                         {{ formatCurrency(item.finalPrice) }}{{ item.is_weight_product ? '/' + (item.weight_unit || 'kg') : ' c/u' }}
                       </span>
+                      @if ((item.taxAmount || 0) > 0) {
+                        <span class="item-tax-badge">
+                          IVA {{ formatCurrency(item.taxAmount) }}
+                        </span>
+                      }
+                      @if (item.isPriceOverridden) {
+                        <span class="item-price-badge">precio editado</span>
+                      }
                     </div>
                   </div>
                   <!-- Remove Button -->
@@ -132,6 +155,16 @@ import { CurrencyFormatService } from '../../../../../shared/pipes/currency';
                         (valueChange)="onQuantityChange(item.id, $event)"
                       ></app-quantity-control>
                     }
+                    @if (canEditItemPrice(item)) {
+                      <button
+                        type="button"
+                        class="edit-price-btn"
+                        (click)="itemPriceEditRequested.emit(item)"
+                        title="Editar precio de venta"
+                      >
+                        <app-icon name="pencil" [size]="15"></app-icon>
+                      </button>
+                    }
                     <span class="item-total">{{ formatCurrency(item.totalPrice) }}</span>
                   </div>
                 </div>
@@ -143,12 +176,21 @@ import { CurrencyFormatService } from '../../../../../shared/pipes/currency';
         <!-- Summary Section -->
         @if (cartState()?.items?.length) {
           <div class="summary-section">
+            <button
+              type="button"
+              class="summary-custom-item-btn"
+              (click)="customItemRequested.emit()"
+              [disabled]="!canCreateCustomItems()"
+            >
+              <app-icon name="file-plus" [size]="16"></app-icon>
+              <span>Ítem personalizado</span>
+            </button>
             <div class="summary-row">
               <span>Subtotal</span>
               <span>{{ formatCurrency(cartState()?.summary?.subtotal || 0) }}</span>
             </div>
             <div class="summary-row">
-              <span>Impuestos</span>
+              <span>IVA / impuestos</span>
               <span>{{ formatCurrency(cartState()?.summary?.taxAmount || 0) }}</span>
             </div>
             <div class="summary-row total">
@@ -335,6 +377,22 @@ import { CurrencyFormatService } from '../../../../../shared/pipes/currency';
         margin: 0;
       }
 
+      .empty-custom-item-btn {
+        margin-top: 18px;
+        min-height: 44px;
+        padding: 0 16px;
+        border: 1px solid rgba(var(--color-primary-rgb), 0.28);
+        border-radius: 12px;
+        background: rgba(var(--color-primary-rgb), 0.08);
+        color: var(--color-primary);
+        font-size: 14px;
+        font-weight: 700;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+      }
+
       /* Items List */
       .items-list {
         display: flex;
@@ -407,8 +465,20 @@ import { CurrencyFormatService } from '../../../../../shared/pipes/currency';
       .item-meta {
         display: flex;
         align-items: center;
+        flex-wrap: wrap;
         gap: 6px;
         margin-top: 2px;
+      }
+
+      .item-description {
+        margin: 2px 0 0;
+        color: var(--color-text-secondary);
+        font-size: 11px;
+        line-height: 1.25;
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
       }
 
       .item-sku {
@@ -420,6 +490,27 @@ import { CurrencyFormatService } from '../../../../../shared/pipes/currency';
       .item-unit-price {
         font-size: 12px;
         color: var(--color-text-secondary);
+      }
+
+      .item-tax-badge,
+      .item-price-badge {
+        display: inline-flex;
+        align-items: center;
+        padding: 1px 6px;
+        border-radius: 999px;
+        font-size: 10px;
+        font-weight: 700;
+        white-space: nowrap;
+      }
+
+      .item-tax-badge {
+        background: rgba(249, 115, 22, 0.12);
+        color: rgb(194, 65, 12);
+      }
+
+      .item-price-badge {
+        background: rgba(147, 51, 234, 0.12);
+        color: rgb(126, 34, 206);
       }
 
       .item-weight-badge {
@@ -485,6 +576,23 @@ import { CurrencyFormatService } from '../../../../../shared/pipes/currency';
         font-size: 15px;
         font-weight: 700;
         color: var(--color-primary);
+        margin-left: auto;
+      }
+
+      .edit-price-btn {
+        width: 34px;
+        height: 34px;
+        border: 1px solid var(--color-border);
+        border-radius: 10px;
+        background: var(--color-surface);
+        color: var(--color-text-secondary);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .edit-price-btn:active {
+        transform: scale(0.96);
       }
 
       /* Summary Section */
@@ -493,6 +601,26 @@ import { CurrencyFormatService } from '../../../../../shared/pipes/currency';
         border-top: 1px solid var(--color-border);
         background: var(--color-muted);
         flex-shrink: 0;
+      }
+
+      .summary-custom-item-btn {
+        width: 100%;
+        min-height: 42px;
+        margin-bottom: 10px;
+        border: 1px solid rgba(var(--color-primary-rgb), 0.24);
+        border-radius: 12px;
+        background: var(--color-surface);
+        color: var(--color-primary);
+        font-size: 14px;
+        font-weight: 700;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+      }
+
+      .summary-custom-item-btn:disabled {
+        opacity: 0.4;
       }
 
       .summary-row {
@@ -611,8 +739,12 @@ export class PosCartModalComponent {
 
   readonly isOpen = input<boolean>(false);
   readonly cartState = input<CartState | null>(null);
+  readonly canCreateCustomItems = input<boolean>(false);
+  readonly canOverridePrices = input<boolean>(false);
 
   readonly closed = output<void>();
+  readonly customItemRequested = output<void>();
+  readonly itemPriceEditRequested = output<CartItem>();
   readonly itemQuantityChanged = output<{ itemId: string; quantity: number }>();
   readonly itemRemoved = output<string>();
   readonly clearCart = output<void>();
@@ -621,10 +753,11 @@ export class PosCartModalComponent {
   readonly checkout = output<void>();
 
   constructor() {
+    void this.currencyService.loadCurrency();
+
     effect(() => {
       if (this.isOpen()) {
         document.body.style.overflow = 'hidden';
-        this.currencyService.loadCurrency();
       } else {
         document.body.style.overflow = '';
       }
@@ -651,6 +784,12 @@ export class PosCartModalComponent {
 
   trackByItemId(_index: number, item: CartItem): string {
     return item.id;
+  }
+
+  canEditItemPrice(item: CartItem): boolean {
+    return item.itemType === 'custom'
+      ? this.canCreateCustomItems()
+      : item.product.allow_pos_price_override === true && this.canOverridePrices();
   }
 
   handleImageError(event: Event): void {

--- a/apps/frontend/src/app/private/modules/store/pos/components/pos-mobile-footer.component.ts
+++ b/apps/frontend/src/app/private/modules/store/pos/components/pos-mobile-footer.component.ts
@@ -31,6 +31,9 @@ import { CurrencyFormatService } from '../../../../../shared/pipes/currency';
             <span class="total-amount">{{
               formatCurrency(cartSummary()?.total || 0)
             }}</span>
+            <span class="tax-amount">
+              IVA {{ formatCurrency(cartSummary()?.taxAmount || 0) }}
+            </span>
           </div>
         </div>
 
@@ -67,6 +70,14 @@ import { CurrencyFormatService } from '../../../../../shared/pipes/currency';
       } @else {
         <!-- Row 2: Secondary Action Buttons -->
         <div class="actions-row">
+          <button
+            class="action-btn custom-item-btn"
+            (click)="customItem.emit()"
+            [disabled]="!canCreateCustomItems()"
+            >
+            <app-icon name="file-plus" [size]="16"></app-icon>
+            <span>Ítem</span>
+          </button>
           <button
             class="action-btn save-btn"
             (click)="saveDraft.emit()"
@@ -190,6 +201,14 @@ import { CurrencyFormatService } from '../../../../../shared/pipes/currency';
         text-overflow: ellipsis;
       }
 
+      .tax-amount {
+        margin-top: 2px;
+        font-size: 11px;
+        font-weight: 600;
+        color: var(--color-text-secondary);
+        line-height: 1.1;
+      }
+
       .view-detail-btn {
         display: flex;
         align-items: center;
@@ -225,7 +244,7 @@ import { CurrencyFormatService } from '../../../../../shared/pipes/currency';
       /* Row 2: Actions */
       .actions-row {
         display: grid;
-        grid-template-columns: 1fr 1fr;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
         gap: 10px;
       }
 
@@ -264,6 +283,16 @@ import { CurrencyFormatService } from '../../../../../shared/pipes/currency';
         background: var(--color-surface);
         border: 1px solid var(--color-border);
         color: var(--color-text-primary);
+      }
+
+      .custom-item-btn {
+        background: rgba(var(--color-primary-rgb), 0.08);
+        border: 1px solid rgba(var(--color-primary-rgb), 0.24);
+        color: var(--color-primary);
+      }
+
+      .custom-item-btn:hover:not(:disabled) {
+        background: rgba(var(--color-primary-rgb), 0.14);
       }
 
       .save-btn:hover:not(:disabled) {
@@ -319,7 +348,7 @@ import { CurrencyFormatService } from '../../../../../shared/pipes/currency';
         }
 
         .action-btn {
-          font-size: 13px;
+          font-size: 12px;
           gap: 6px;
         }
       }
@@ -334,8 +363,10 @@ export class PosMobileFooterComponent {
   readonly isTablet = input<boolean>(false);
   readonly isQuotationMode = input<boolean>(false);
   readonly isLayawayMode = input<boolean>(false);
+  readonly canCreateCustomItems = input<boolean>(false);
 
   readonly viewCart = output<void>();
+  readonly customItem = output<void>();
   readonly saveDraft = output<void>();
   readonly shipping = output<void>();
   readonly checkout = output<void>();

--- a/apps/frontend/src/app/private/modules/store/pos/components/pos-shipping-modal/pos-shipping-modal.component.ts
+++ b/apps/frontend/src/app/private/modules/store/pos/components/pos-shipping-modal/pos-shipping-modal.component.ts
@@ -1162,10 +1162,12 @@ private customerSearchSubject = new Subject<string>(); // LEGÍTIMO — debounce
 
     this.isCalculatingShipping.set(true);
 
-    const items = this.cartState()!.items.map((item) => ({
-      product_id: parseInt(item.product.id),
-      quantity: item.quantity,
-      price: item.totalPrice }));
+    const items = this.cartState()!.items
+      .filter((item) => item.itemType !== 'custom')
+      .map((item) => ({
+        product_id: parseInt(item.product.id),
+        quantity: item.quantity,
+        price: item.totalPrice }));
 
     this.shippingService
       .calculateShipping(items, {

--- a/apps/frontend/src/app/private/modules/store/pos/models/cart.model.ts
+++ b/apps/frontend/src/app/private/modules/store/pos/models/cart.model.ts
@@ -3,6 +3,7 @@ import { PosCustomer } from '../models/customer.model';
 
 export interface CartItem {
   id: string;
+  itemType?: 'product' | 'custom';
   product: Product;
   quantity: number;
   unitPrice: number;
@@ -11,6 +12,12 @@ export interface CartItem {
   taxAmount: number;
   addedAt: Date;
   notes?: string;
+  description?: string;
+  taxCategoryId?: number | null;
+  taxRate?: number;
+  originalFinalPrice?: number;
+  isPriceOverridden?: boolean;
+  priceOverrideReason?: string;
   discounts?: CartDiscount[];
   variant_id?: number;
   variant_sku?: string;
@@ -79,10 +86,28 @@ export interface AddToCartRequest {
   weight_unit?: 'kg' | 'g' | 'lb';
 }
 
+export interface AddCustomItemRequest {
+  name: string;
+  description?: string;
+  quantity: number;
+  finalPrice: number;
+  taxCategory?: {
+    id: number;
+    name: string;
+    tax_rates?: Array<{ rate: string | number }>;
+  } | null;
+}
+
 export interface UpdateCartItemRequest {
   itemId: string;
   quantity: number;
   notes?: string;
+}
+
+export interface UpdateCartItemPriceRequest {
+  itemId: string;
+  finalPrice: number;
+  reason?: string;
 }
 
 export interface ApplyDiscountRequest {

--- a/apps/frontend/src/app/private/modules/store/pos/pos.component.ts
+++ b/apps/frontend/src/app/private/modules/store/pos/pos.component.ts
@@ -7,6 +7,7 @@ import {
   inject,
   DestroyRef,
 } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 
 import { Router, ActivatedRoute } from '@angular/router';
@@ -20,11 +21,18 @@ import {
   CardComponent,
   BadgeComponent,
   DialogService,
+  ModalComponent,
+  InputComponent,
+  SelectorComponent,
+  TextareaComponent,
 } from '../../../../shared/components';
+import type { SelectorOption } from '../../../../shared/components/selector/selector.component';
+import { CurrencyFormatService } from '../../../../shared/pipes/currency';
 import {
   selectStoreSettings,
   selectUserDomainHostname,
 } from '../../../../core/store/auth/auth.selectors';
+import { AuthFacade } from '../../../../core/store/auth/auth.facade';
 import {
   PosCartService,
   CartState,
@@ -67,6 +75,8 @@ import { PosScheduleModalComponent } from './components/pos-schedule-modal.compo
 import { PosHeaderDropdownComponent } from './components/pos-header-dropdown.component';
 import { ReservationFormModalComponent } from '../reservations/components/reservation-form-modal/reservation-form-modal.component';
 import { PosAISummaryModalComponent } from './components/pos-ai-summary-modal.component';
+import { TaxesService } from '../products/services/taxes.service';
+import { TaxCategory } from '../products/interfaces';
 
 const DEFAULT_CART_SUMMARY: CartSummary = {
   subtotal: 0,
@@ -81,8 +91,13 @@ const DEFAULT_CART_SUMMARY: CartSummary = {
   selector: 'app-pos',
   standalone: true,
   imports: [
+    FormsModule,
     ButtonComponent,
     IconComponent,
+    ModalComponent,
+    InputComponent,
+    SelectorComponent,
+    TextareaComponent,
     SpinnerComponent,
     CardComponent,
     PosStatsComponent,
@@ -254,14 +269,15 @@ const DEFAULT_CART_SUMMARY: CartSummary = {
                     (detailClicked)="showSessionDetailModal.set(true)"
                   ></app-pos-session-status-bar>
                 }
-
               </div>
             </div>
           </div>
         </div>
 
         @if (activeSession()?.register?.location) {
-          <div class="flex-none px-4 lg:px-6 py-1 bg-blue-50 border-b border-blue-100 text-xs text-blue-600">
+          <div
+            class="flex-none px-4 lg:px-6 py-1 bg-blue-50 border-b border-blue-100 text-xs text-blue-600"
+          >
             Descontando de: {{ activeSession()!.register!.location!.name }}
           </div>
         }
@@ -399,7 +415,9 @@ const DEFAULT_CART_SUMMARY: CartSummary = {
           [isTablet]="isTablet()"
           [isQuotationMode]="isQuotationMode()"
           [isLayawayMode]="isLayawayMode()"
+          [canCreateCustomItems]="canCreateCustomItems()"
           (viewCart)="onOpenCartModal()"
+          (customItem)="openCustomItemModal()"
           (saveDraft)="onSaveDraft()"
           (shipping)="onShipping()"
           (checkout)="onCheckout()"
@@ -412,7 +430,11 @@ const DEFAULT_CART_SUMMARY: CartSummary = {
       <app-pos-cart-modal
         [isOpen]="showCartModal() && (isMobile() || isTablet())"
         [cartState]="cartState()"
+        [canCreateCustomItems]="canCreateCustomItems()"
+        [canOverridePrices]="canOverridePrices()"
         (closed)="onCloseCartModal()"
+        (customItemRequested)="openCustomItemModal()"
+        (itemPriceEditRequested)="editItemPriceFromMobile($event)"
         (itemQuantityChanged)="onCartItemQuantityChanged($event)"
         (itemRemoved)="onCartItemRemoved($event)"
         (clearCart)="onClearCart()"
@@ -420,6 +442,108 @@ const DEFAULT_CART_SUMMARY: CartSummary = {
         (shipping)="onShippingFromModal()"
         (checkout)="onCheckoutFromModal()"
       ></app-pos-cart-modal>
+
+      <app-modal
+        [isOpen]="customItemModalOpen()"
+        title="Ítem personalizado"
+        subtitle="Agrega una línea facturable sin afectar inventario"
+        size="sm"
+        (closed)="closeCustomItemModal()"
+      >
+        <div class="space-y-4">
+          <app-input
+            label="Nombre"
+            placeholder="Servicio de instalación"
+            [ngModel]="customItemDraft().name"
+            (ngModelChange)="updateCustomItemDraft('name', $event)"
+          ></app-input>
+
+          <app-textarea
+            label="Detalle"
+            placeholder="Alcance, materiales, condiciones o notas visibles en la orden"
+            [rows]="3"
+            [ngModel]="customItemDraft().description"
+            (ngModelChange)="updateCustomItemDraft('description', $event)"
+          ></app-textarea>
+
+          <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <app-input
+              label="Cantidad"
+              type="number"
+              min="1"
+              [ngModel]="customItemDraft().quantity"
+              (ngModelChange)="updateCustomItemDraft('quantity', $event)"
+            ></app-input>
+
+            <app-input
+              label="Precio final"
+              placeholder="$0"
+              min="0"
+              [currency]="true"
+              [ngModel]="customItemDraft().finalPrice"
+              (ngModelChange)="updateCustomItemDraft('finalPrice', $event)"
+            ></app-input>
+          </div>
+
+          <app-selector
+            label="IVA / impuesto"
+            helpText="Usa los impuestos configurados para la tienda."
+            [options]="taxCategoryOptions()"
+            [ngModel]="customItemDraft().taxCategoryId ?? 0"
+            (ngModelChange)="updateCustomItemDraft('taxCategoryId', $event)"
+          ></app-selector>
+
+          <div
+            class="rounded-xl border border-border bg-[var(--color-background)]/60 px-3 py-2 text-xs"
+          >
+            <div class="flex justify-between">
+              <span class="text-text-secondary">Base</span>
+              <span class="font-semibold">{{
+                formatCurrency(customItemBasePrice())
+              }}</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-text-secondary">IVA / impuesto</span>
+              <span class="font-semibold">{{
+                formatCurrency(customItemTaxAmount())
+              }}</span>
+            </div>
+            <div
+              class="mt-1 flex justify-between border-t border-border/60 pt-1"
+            >
+              <span class="font-semibold text-text-primary">Total línea</span>
+              <span class="font-bold text-[var(--color-primary)]">{{
+                formatCurrency(customItemTotal())
+              }}</span>
+            </div>
+          </div>
+        </div>
+
+        <div
+          slot="footer"
+          class="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end"
+        >
+          <app-button
+            class="w-full sm:w-auto"
+            variant="outline"
+            size="md"
+            customClasses="min-w-[120px]"
+            (clicked)="closeCustomItemModal()"
+          >
+            Cancelar
+          </app-button>
+          <app-button
+            class="w-full sm:w-auto"
+            variant="primary"
+            size="md"
+            customClasses="min-w-[120px]"
+            [disabled]="!canSubmitCustomItem()"
+            (clicked)="addCustomItemFromMobile()"
+          >
+            Agregar
+          </app-button>
+        </div>
+      </app-modal>
 
       <!-- Loading Overlay -->
       @if (loading()) {
@@ -675,6 +799,30 @@ export class PosComponent {
   showOrderConfirmation = signal(false);
   productRefreshCounter = signal(0);
   showCartModal = signal(false);
+  customItemModalOpen = signal(false);
+  customItemDraft = signal({
+    name: '',
+    description: '',
+    quantity: 1,
+    finalPrice: 0,
+    taxCategoryId: null as number | null,
+  });
+  taxCategories = signal<TaxCategory[]>([]);
+  readonly taxCategoryOptions = computed<SelectorOption[]>(() => [
+    { value: 0, label: 'Sin impuesto' },
+    ...this.taxCategories().map((tax) => ({
+      value: tax.id,
+      label: `${tax.name} (${this.formatPercentRate(tax)})`,
+    })),
+  ]);
+  readonly canSubmitCustomItem = computed(() => {
+    const draft = this.customItemDraft();
+    return (
+      draft.name.trim().length > 0 &&
+      Number(draft.quantity || 0) > 0 &&
+      Number(draft.finalPrice || 0) >= 0
+    );
+  });
 
   currentOrderId = signal<string | null>(null);
   currentOrderNumber = signal<string | null>(null);
@@ -772,6 +920,9 @@ export class PosComponent {
 
   // Store domain for QR URL construction
   private storeDomainHostname: string | null = null;
+  private posSettingsHydrationRequested = false;
+  private queueSubscriptionInitialized = false;
+  private cashRegisterSessionInitialized = false;
 
   private destroyRef = inject(DestroyRef);
   private cartService = inject(PosCartService);
@@ -789,6 +940,16 @@ export class PosComponent {
   private layawayService = inject(LayawayApiService);
   private cashRegisterService = inject(PosCashRegisterService);
   private queueService = inject(PosQueueService);
+  private authFacade = inject(AuthFacade);
+  private taxesService = inject(TaxesService);
+  private currencyService = inject(CurrencyFormatService);
+
+  readonly canCreateCustomItems = computed(() =>
+    this.hasPermission('store:pos:custom_items:create'),
+  );
+  readonly canOverridePrices = computed(() =>
+    this.hasPermission('store:pos:price_override'),
+  );
 
   constructor() {
     this.checkMobile();
@@ -798,6 +959,7 @@ export class PosComponent {
     this.checkQuotationMode();
     this.checkLayawayMode();
     this.validateScheduleOnInit();
+    this.loadTaxCategories();
 
     this.store
       .select(selectUserDomainHostname)
@@ -910,6 +1072,26 @@ export class PosComponent {
       .subscribe((loading: boolean) => {
         this.loading.set(Boolean(loading));
       });
+  }
+
+  private loadTaxCategories(): void {
+    this.taxesService
+      .getTaxCategories()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (taxCategories) => this.taxCategories.set(taxCategories || []),
+        error: () => this.taxCategories.set([]),
+      });
+  }
+
+  private hasPermission(permission: string): boolean {
+    const permissions = this.authFacade.userPermissions();
+    const roles = this.authFacade.userRoles();
+    return (
+      permissions.includes(permission) ||
+      roles.includes('super_admin') ||
+      roles.includes('SUPER_ADMIN')
+    );
   }
 
   get isEmpty(): boolean {
@@ -1378,6 +1560,180 @@ export class PosComponent {
     this.showCartModal.set(false);
   }
 
+  openCustomItemModal(): void {
+    if (!this.canCreateCustomItems()) {
+      this.toastService.warning(
+        'No tienes permiso para agregar ítems personalizados',
+      );
+      return;
+    }
+
+    this.customItemDraft.set({
+      name: '',
+      description: '',
+      quantity: 1,
+      finalPrice: 0,
+      taxCategoryId: null,
+    });
+    this.customItemModalOpen.set(true);
+  }
+
+  closeCustomItemModal(): void {
+    this.customItemModalOpen.set(false);
+  }
+
+  updateCustomItemDraft(
+    field: 'name' | 'description' | 'quantity' | 'finalPrice' | 'taxCategoryId',
+    value: string | number | null,
+  ): void {
+    this.customItemDraft.update((draft) => ({
+      ...draft,
+      [field]:
+        field === 'quantity' || field === 'finalPrice'
+          ? Number(value || 0)
+          : field === 'taxCategoryId'
+            ? value === null || value === '' || Number(value) <= 0
+              ? null
+              : Number(value)
+            : String(value || ''),
+    }));
+  }
+
+  addCustomItemFromMobile(): void {
+    if (!this.canSubmitCustomItem()) {
+      this.toastService.warning(
+        'Completa el nombre y un valor válido para el ítem',
+      );
+      return;
+    }
+
+    const draft = this.customItemDraft();
+    const taxCategory = this.getSelectedTaxCategory();
+
+    this.cartService
+      .addCustomItem({
+        name: draft.name.trim(),
+        description: draft.description.trim(),
+        quantity: Number(draft.quantity || 1),
+        finalPrice: Number(draft.finalPrice || 0),
+        taxCategory,
+      })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          this.customItemModalOpen.set(false);
+          this.showCartModal.set(true);
+          this.toastService.success('Ítem personalizado agregado');
+        },
+        error: (error: any) => {
+          this.toastService.error(error.message || 'Error al agregar el ítem');
+        },
+      });
+  }
+
+  async editItemPriceFromMobile(item: CartItem): Promise<void> {
+    if (!this.canEditItemPrice(item)) {
+      this.toastService.warning('No tienes permiso para editar este precio');
+      return;
+    }
+
+    const value = await this.dialogService.prompt(
+      {
+        title: 'Editar precio de venta',
+        message: item.product.name,
+        placeholder: 'Precio final',
+        defaultValue: item.finalPrice.toString(),
+        confirmText: 'Actualizar',
+        cancelText: 'Cancelar',
+        inputType: 'number',
+      },
+      { size: 'sm' },
+    );
+
+    if (value === undefined) return;
+    const finalPrice = Number(value);
+    if (Number.isNaN(finalPrice) || finalPrice < 0) {
+      this.toastService.warning('El precio debe ser un número válido');
+      return;
+    }
+
+    let reason = item.priceOverrideReason;
+    if (item.itemType !== 'custom') {
+      reason = await this.dialogService.prompt(
+        {
+          title: 'Motivo del cambio',
+          message: 'Opcional, queda como referencia de auditoría de la orden.',
+          placeholder: 'Ej. precio negociado con el cliente',
+          defaultValue: item.priceOverrideReason || '',
+          confirmText: 'Guardar',
+          cancelText: 'Omitir',
+        },
+        { size: 'sm' },
+      );
+    }
+
+    this.cartService
+      .updateCartItemPrice({ itemId: item.id, finalPrice, reason })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => this.toastService.success('Precio actualizado'),
+        error: (error: any) =>
+          this.toastService.error(
+            error.message || 'Error al actualizar precio',
+          ),
+      });
+  }
+
+  private canEditItemPrice(item: CartItem): boolean {
+    return item.itemType === 'custom'
+      ? this.canCreateCustomItems()
+      : item.product.allow_pos_price_override === true &&
+          this.canOverridePrices();
+  }
+
+  getTaxCategoryRate(taxCategory?: TaxCategory | null): number {
+    return (
+      taxCategory?.tax_rates?.reduce(
+        (sum, rate: any) => sum + Number(rate.rate || 0),
+        0,
+      ) || 0
+    );
+  }
+
+  formatPercentRate(taxCategory: TaxCategory): string {
+    return `${(this.getTaxCategoryRate(taxCategory) * 100).toFixed(2)}%`;
+  }
+
+  getSelectedTaxCategory(): TaxCategory | null {
+    const selectedId = this.customItemDraft().taxCategoryId;
+    if (!selectedId) return null;
+    return this.taxCategories().find((tax) => tax.id === selectedId) || null;
+  }
+
+  customItemBasePrice(): number {
+    const draft = this.customItemDraft();
+    const finalPrice = Number(draft.finalPrice || 0);
+    const rate = this.getTaxCategoryRate(this.getSelectedTaxCategory());
+    return rate > 0 ? finalPrice / (1 + rate) : finalPrice;
+  }
+
+  customItemTaxAmount(): number {
+    const draft = this.customItemDraft();
+    const quantity = Number(draft.quantity || 1);
+    return (
+      (Number(draft.finalPrice || 0) - this.customItemBasePrice()) * quantity
+    );
+  }
+
+  customItemTotal(): number {
+    const draft = this.customItemDraft();
+    return Number(draft.finalPrice || 0) * Number(draft.quantity || 1);
+  }
+
+  formatCurrency(amount: number): string {
+    return this.currencyService.format(amount);
+  }
+
   onCartItemQuantityChanged(event: { itemId: string; quantity: number }): void {
     if (event.quantity <= 0) {
       this.onCartItemRemoved(event.itemId);
@@ -1697,86 +2053,111 @@ export class PosComponent {
       .select(selectStoreSettings)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((storeSettings: any) => {
-        const settings = storeSettings;
-        if (settings?.general?.timezone) {
-          this.storeTimezone.set(settings.general.timezone);
+        if (!storeSettings) {
+          return;
         }
-        if (settings?.pos) {
-          this.enableScheduleValidation.set(
-            settings.pos.enable_schedule_validation || false,
-          );
-          this.businessHours.set(settings.pos.business_hours || {});
 
-          const crEnabled = settings.pos.cash_register?.enabled || false;
-          this.cashRegisterEnabled.set(crEnabled);
-          this.cashRegisterService.setFeatureEnabled(crEnabled);
-          this.paymentService.setRequireSessionForSales(
-            settings.pos.cash_register?.require_session_for_sales || false,
-          );
-          if (crEnabled) {
-            this.initCashRegisterSession();
-          }
-
-          const cqEnabled = settings.pos.customer_queue?.enabled || false;
-          this.queueEnabled.set(cqEnabled);
-          if (cqEnabled) {
-            this.initQueueSubscription();
-          }
-
-          if (!settings.pos.cash_register) {
-            this.settingsService
-              .getSettings()
-              .pipe(takeUntilDestroyed(this.destroyRef))
-              .subscribe((response) => {
-                const freshSettings = response?.data;
-                if (freshSettings?.pos?.cash_register) {
-                  const crFresh =
-                    freshSettings.pos.cash_register.enabled || false;
-                  this.cashRegisterEnabled.set(crFresh);
-                  this.cashRegisterService.setFeatureEnabled(crFresh);
-                  this.paymentService.setRequireSessionForSales(
-                    freshSettings.pos.cash_register.require_session_for_sales ||
-                      false,
-                  );
-                  if (crFresh) {
-                    this.initCashRegisterSession();
-                  }
-                }
-              });
-          }
-
-          if (!cqEnabled) {
-            this.settingsService
-              .getSettings()
-              .pipe(takeUntilDestroyed(this.destroyRef))
-              .subscribe((response) => {
-                const freshSettings = response?.data;
-                if (freshSettings?.pos?.customer_queue?.enabled) {
-                  this.queueEnabled.set(true);
-                  this.initQueueSubscription();
-                }
-              });
-          }
-
-          if (
-            !this.scheduleHandledByBackend() &&
-            this.scheduleStatusChecked() &&
-            this.enableScheduleValidation()
-          ) {
-            const localOutOfHours = !this.isWithinBusinessHours();
-            if (localOutOfHours) {
-              this.isActuallyOutOfHours.set(true);
-              if (!this.canBypassSchedule()) {
-                this.isOutOfHours.set(true);
-                this.nextOpenTime.set(this.getLocalNextOpenDay());
-                this.outOfHoursMessage.set(
-                  'El punto de venta está fuera del horario de atención configurado (Validación local).',
-                );
-              }
-            }
-          }
+        if (!storeSettings.pos) {
+          this.hydrateMissingPosSettings();
+          return;
         }
+
+        this.applyPosSettings(storeSettings);
       });
+  }
+
+  private applyPosSettings(settings: any): void {
+    if (settings?.general?.timezone) {
+      this.storeTimezone.set(settings.general.timezone);
+    }
+
+    const posSettings = settings?.pos;
+    if (!posSettings) {
+      return;
+    }
+
+    this.enableScheduleValidation.set(
+      posSettings.enable_schedule_validation === true,
+    );
+    this.businessHours.set(posSettings.business_hours || {});
+
+    const cashRegisterSettings = posSettings.cash_register;
+    const crEnabled = cashRegisterSettings?.enabled === true;
+    this.cashRegisterEnabled.set(crEnabled);
+    this.cashRegisterService.setFeatureEnabled(crEnabled);
+    this.paymentService.setRequireSessionForSales(
+      cashRegisterSettings?.require_session_for_sales === true,
+    );
+
+    if (crEnabled && !this.cashRegisterSessionInitialized) {
+      this.cashRegisterSessionInitialized = true;
+      this.initCashRegisterSession();
+    } else if (!crEnabled) {
+      this.cashRegisterSessionInitialized = false;
+    }
+
+    const customerQueueSettings = posSettings.customer_queue;
+    const cqEnabled = customerQueueSettings?.enabled === true;
+    this.queueEnabled.set(cqEnabled);
+    if (cqEnabled && !this.queueSubscriptionInitialized) {
+      this.queueSubscriptionInitialized = true;
+      this.initQueueSubscription();
+    } else if (!cqEnabled) {
+      this.queueSubscriptionInitialized = false;
+    }
+
+    if (!cashRegisterSettings || !customerQueueSettings) {
+      this.hydrateMissingPosSettings();
+    }
+
+    this.validateLocalScheduleIfNeeded();
+  }
+
+  private hydrateMissingPosSettings(): void {
+    if (this.posSettingsHydrationRequested) {
+      return;
+    }
+
+    this.posSettingsHydrationRequested = true;
+    this.settingsService
+      .getSettings({ forceRefresh: true })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (response) => {
+          if (response?.data?.pos) {
+            this.applyPosSettings(response.data);
+          }
+        },
+        error: (error) => {
+          console.warn('No se pudo hidratar la configuración POS', error);
+        },
+      });
+  }
+
+  private validateLocalScheduleIfNeeded(): void {
+    if (
+      this.scheduleHandledByBackend() ||
+      !this.scheduleStatusChecked() ||
+      !this.enableScheduleValidation()
+    ) {
+      return;
+    }
+
+    const localOutOfHours = !this.isWithinBusinessHours();
+    if (!localOutOfHours) {
+      return;
+    }
+
+    this.isActuallyOutOfHours.set(true);
+    if (this.canBypassSchedule()) {
+      return;
+    }
+
+    this.isOutOfHours.set(true);
+    this.nextOpenTime.set(this.getLocalNextOpenDay());
+    this.outOfHoursMessage.set(
+      'El punto de venta está fuera del horario de atención configurado (Validación local).',
+    );
   }
 
   private initQueueSubscription(): void {

--- a/apps/frontend/src/app/private/modules/store/pos/services/pos-api.service.ts
+++ b/apps/frontend/src/app/private/modules/store/pos/services/pos-api.service.ts
@@ -124,13 +124,21 @@ export class PosApiService {
     return this.http.get(`${this.apiUrl}/store/promotions/active`);
   }
 
-  validateCoupon(code: string, cartSubtotal?: number, customerId?: number, productIds?: number[], categoryIds?: number[]): Observable<any> {
+  validateCoupon(
+    code: string,
+    cartSubtotal?: number,
+    customerId?: number,
+    productIds?: number[],
+    categoryIds?: number[],
+    items?: Array<{ product_id?: number; category_ids?: number[]; line_total: number }>,
+  ): Observable<any> {
     return this.http.post(`${this.apiUrl}/store/coupons/validate`, {
       code,
       cart_subtotal: cartSubtotal,
       customer_id: customerId,
       product_ids: productIds,
       category_ids: categoryIds,
+      items,
     });
   }
 }

--- a/apps/frontend/src/app/private/modules/store/pos/services/pos-cart.service.ts
+++ b/apps/frontend/src/app/private/modules/store/pos/services/pos-cart.service.ts
@@ -8,7 +8,9 @@ import {
   CartState,
   CartDiscount,
   AddToCartRequest,
+  AddCustomItemRequest,
   UpdateCartItemRequest,
+  UpdateCartItemPriceRequest,
   ApplyDiscountRequest,
   CartValidationError,
   PendingBooking,
@@ -17,9 +19,11 @@ import {
 // Re-export types for component usage
 export type {
   AddToCartRequest,
+  AddCustomItemRequest,
   CartItem,
   CartState,
   PendingBooking,
+  UpdateCartItemPriceRequest,
 } from '../models/cart.model';
 import { PosCustomer } from '../models/customer.model';
 import { PosProductService, Product, PosProductVariant } from './pos-product.service';
@@ -82,11 +86,30 @@ export class PosCartService {
   }
 
   /**
+   * Add a billable custom item to the cart.
+   */
+  addCustomItem(request: AddCustomItemRequest): Observable<CartState> {
+    return of(request).pipe(
+      map((req) => this.processAddCustomItem(req)),
+      tap((newState) => this.cartState.set(newState)),
+    );
+  }
+
+  /**
    * Update cart item quantity
    */
   updateCartItem(request: UpdateCartItemRequest): Observable<CartState> {
     return of(request).pipe(
       map((req) => this.processUpdateCartItem(req)),
+      tap((newState) => this.cartState.set(newState)),
+    );
+  }
+
+  updateCartItemPrice(
+    request: UpdateCartItemPriceRequest,
+  ): Observable<CartState> {
+    return of(request).pipe(
+      map((req) => this.processUpdateCartItemPrice(req)),
       tap((newState) => this.cartState.set(newState)),
     );
   }
@@ -183,10 +206,12 @@ export class PosCartService {
 
     // Fetch full product data for each order item
     const productRequests: Observable<{ item: any; product: Product | null }>[] = order.order_items.map((item: any) =>
-      this.productService.getProductById(item.product_id.toString()).pipe(
-        map((product: Product | null) => ({ item, product })),
-        catchError(() => of({ item, product: null as Product | null })),
-      )
+      item.product_id
+        ? this.productService.getProductById(item.product_id.toString()).pipe(
+            map((product: Product | null) => ({ item, product })),
+            catchError(() => of({ item, product: null as Product | null })),
+          )
+        : of({ item, product: null as Product | null }),
     );
 
     return forkJoin(productRequests).pipe(
@@ -196,13 +221,14 @@ export class PosCartService {
 
           // If product was found from API, use it; otherwise create a stub
           const cartProduct: Product = product || {
-            id: item.product_id.toString(),
+            id: item.product_id?.toString() || this.generateCustomProductId(),
             name: item.product_name,
             sku: item.variant_sku || '',
             price: Number(item.unit_price),
-            final_price: Number(item.unit_price),
+            final_price: Number(item.final_unit_price || item.unit_price),
             category: '',
             stock: 9999,
+            track_inventory: false,
             minStock: 0,
             isActive: true,
             createdAt: new Date(),
@@ -221,10 +247,15 @@ export class PosCartService {
             product: cartProduct,
             quantity,
             unitPrice,
-            finalPrice: totalPrice / quantity,
-            totalPrice,
+            finalPrice: Number(item.final_unit_price || totalPrice / quantity),
+            totalPrice: Number(item.final_unit_price || totalPrice / quantity) * quantity,
             taxAmount,
             addedAt: new Date(),
+            itemType: item.item_type === 'custom' || !item.product_id ? 'custom' : 'product',
+            description: item.description || undefined,
+            originalFinalPrice: Number(item.catalog_final_price || item.final_unit_price || totalPrice / quantity),
+            isPriceOverridden: item.is_price_overridden === true,
+            priceOverrideReason: item.price_override_reason || undefined,
           } as CartItem;
         });
 
@@ -301,7 +332,7 @@ export class PosCartService {
         // Remove previously auto-applied promotion discounts
         const manualDiscounts = currentState.appliedDiscounts.filter(d => !d.is_auto_applied);
 
-        // Calculate cart total for eligibility
+        // Calculate cart total for order-level eligibility
         const subtotal = this.calculateSubtotal(currentState.items);
 
         // Apply eligible auto-apply promotions
@@ -312,23 +343,23 @@ export class PosCartService {
           // Check min purchase
           if (promo.min_purchase_amount && subtotal < Number(promo.min_purchase_amount)) continue;
 
-          // Check scope eligibility
-          if (promo.scope === 'product') {
-            const promoProductIds = (promo.promotion_products || []).map((pp: any) => pp.product_id);
-            const hasProduct = currentState.items.some(item => promoProductIds.includes(Number(item.product.id)));
-            if (!hasProduct) continue;
-          }
+          const applicableTotal = this.calculatePromotionApplicableTotal(
+            promo,
+            currentState.items,
+          );
+          if (applicableTotal <= 0) continue;
 
           // Calculate discount
           let discountAmount = 0;
           if (promo.type === 'percentage') {
-            discountAmount = subtotal * (Number(promo.value) / 100);
+            discountAmount = applicableTotal * (Number(promo.value) / 100);
           } else {
-            discountAmount = Math.min(Number(promo.value), subtotal);
+            discountAmount = Math.min(Number(promo.value), applicableTotal);
           }
 
-          if (promo.max_discount_amount) {
-            discountAmount = Math.min(discountAmount, Number(promo.max_discount_amount));
+          const maxDiscountAmount = this.toOptionalNumber(promo.max_discount_amount);
+          if (maxDiscountAmount !== null && maxDiscountAmount > 0) {
+            discountAmount = Math.min(discountAmount, maxDiscountAmount);
           }
 
           promoDiscounts.push({
@@ -495,6 +526,133 @@ export class PosCartService {
     return item ? item.quantity : 0;
   }
 
+  private processAddCustomItem(request: AddCustomItemRequest): CartState {
+    const currentState = this.cartState();
+    const quantity = Number(request.quantity || 1);
+    const finalPrice = Number(request.finalPrice || 0);
+
+    if (!request.name?.trim()) {
+      throw new Error('El ítem personalizado requiere una descripción.');
+    }
+    if (quantity <= 0) {
+      throw new Error('La cantidad debe ser mayor a 0.');
+    }
+    if (finalPrice < 0) {
+      throw new Error('El precio no puede ser negativo.');
+    }
+
+    const taxRate = this.calculateTaxCategoryRate(request.taxCategory);
+    const unitPrice = taxRate > 0 ? finalPrice / (1 + taxRate) : finalPrice;
+    const taxAmount = (finalPrice - unitPrice) * quantity;
+    const customProduct: Product = {
+      id: this.generateCustomProductId(),
+      name: request.name.trim(),
+      sku: '',
+      price: unitPrice,
+      final_price: finalPrice,
+      cost: 0,
+      category: 'Personalizado',
+      stock: 999999,
+      track_inventory: false,
+      minStock: 0,
+      image: '',
+      image_url: '',
+      description: request.description || '',
+      isActive: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      tax_assignments: request.taxCategory
+        ? [
+            {
+              product_id: 0,
+              tax_category_id: request.taxCategory.id,
+              tax_categories: request.taxCategory as any,
+            },
+          ]
+        : [],
+      has_variants: false,
+      product_variants: [],
+      pricing_type: 'unit',
+    };
+
+    const customItem: CartItem = {
+      id: this.generateItemId(),
+      itemType: 'custom',
+      product: customProduct,
+      quantity,
+      unitPrice: this.roundMoney(unitPrice),
+      finalPrice: this.roundMoney(finalPrice),
+      totalPrice: this.roundMoney(finalPrice * quantity),
+      taxAmount: this.roundMoney(taxAmount),
+      taxCategoryId: request.taxCategory?.id ?? null,
+      taxRate,
+      description: request.description?.trim() || undefined,
+      addedAt: new Date(),
+    };
+
+    const updatedItems = [customItem, ...currentState.items];
+    return {
+      ...currentState,
+      items: updatedItems,
+      summary: this.calculateSummary(
+        updatedItems,
+        currentState.appliedDiscounts,
+      ),
+      updatedAt: new Date(),
+    };
+  }
+
+  private processUpdateCartItemPrice(
+    request: UpdateCartItemPriceRequest,
+  ): CartState {
+    const currentState = this.cartState();
+    const itemIndex = currentState.items.findIndex(
+      (item) => item.id === request.itemId,
+    );
+
+    if (itemIndex === -1) {
+      throw new Error('Item not found in cart');
+    }
+    if (request.finalPrice < 0) {
+      throw new Error('El precio no puede ser negativo.');
+    }
+
+    const item = currentState.items[itemIndex];
+    const taxRate = item.taxRate ?? this.calculateRateSum(item.product);
+    const finalPrice = this.roundMoney(Number(request.finalPrice || 0));
+    const unitPrice = taxRate > 0 ? finalPrice / (1 + taxRate) : finalPrice;
+    const multiplier = item.is_weight_product && item.weight
+      ? item.weight
+      : item.quantity;
+    const taxAmount = (finalPrice - unitPrice) * multiplier;
+
+    const updatedItems = [...currentState.items];
+    updatedItems[itemIndex] = {
+      ...item,
+      unitPrice: this.roundMoney(unitPrice),
+      finalPrice,
+      totalPrice: this.roundMoney(finalPrice * multiplier),
+      taxAmount: this.roundMoney(taxAmount),
+      originalFinalPrice: item.originalFinalPrice ?? item.finalPrice,
+      isPriceOverridden:
+        item.itemType === 'custom'
+          ? false
+          : Math.abs(finalPrice - (item.originalFinalPrice ?? item.finalPrice)) >=
+            0.01,
+      priceOverrideReason: request.reason?.trim() || item.priceOverrideReason,
+    };
+
+    return {
+      ...currentState,
+      items: updatedItems,
+      summary: this.calculateSummary(
+        updatedItems,
+        currentState.appliedDiscounts,
+      ),
+      updatedAt: new Date(),
+    };
+  }
+
   /**
    * Process add to cart
    */
@@ -550,11 +708,13 @@ export class PosCartService {
       const taxMultiplier = isWeightProduct ? weight : quantity;
       const newItem: CartItem = {
         id: this.generateItemId(),
+        itemType: 'product',
         product: request.product,
         quantity: quantity,
         unitPrice: basePrice,
         taxAmount: this.calculateItemTaxWithBase(request.product, basePrice, taxMultiplier),
         finalPrice: finalUnitPrice,
+        originalFinalPrice: finalUnitPrice,
         totalPrice: itemTotalPrice,
         addedAt: new Date(),
         notes: request.notes,
@@ -742,6 +902,53 @@ export class PosCartService {
     return items.reduce((sum, item) => sum + item.totalPrice, 0);
   }
 
+  private calculatePromotionApplicableTotal(promo: any, items: CartItem[]): number {
+    if (promo.scope === 'product') {
+      const promoProductIds = (promo.promotion_products || [])
+        .map((pp: any) => Number(pp.product_id))
+        .filter((id: number) => Number.isFinite(id));
+
+      return items
+        .filter((item) => promoProductIds.includes(Number(item.product.id)))
+        .reduce((sum, item) => sum + item.totalPrice, 0);
+    }
+
+    if (promo.scope === 'category') {
+      const promoCategoryIds = (promo.promotion_categories || [])
+        .map((pc: any) => Number(pc.category_id))
+        .filter((id: number) => Number.isFinite(id));
+
+      return items
+        .filter((item) =>
+          this.getItemCategoryIds(item).some((categoryId) =>
+            promoCategoryIds.includes(categoryId),
+          ),
+        )
+        .reduce((sum, item) => sum + item.totalPrice, 0);
+    }
+
+    return this.calculateSubtotal(items);
+  }
+
+  private getItemCategoryIds(item: CartItem): number[] {
+    const product = item.product as any;
+    const categoryIds = Array.isArray(product.category_ids)
+      ? product.category_ids
+      : product.category_id
+        ? [product.category_id]
+        : [];
+
+    return categoryIds
+      .map((categoryId: string | number) => Number(categoryId))
+      .filter((categoryId: number) => Number.isFinite(categoryId));
+  }
+
+  private toOptionalNumber(value: unknown): number | null {
+    if (value === null || value === undefined || value === '') return null;
+    const numericValue = Number(value);
+    return Number.isFinite(numericValue) ? numericValue : null;
+  }
+
   /**
    * Calculate tax for a single item
    */
@@ -790,6 +997,21 @@ export class PosCartService {
         return rateSum + assignmentRate;
       }, 0) || 0
     );
+  }
+
+  private calculateTaxCategoryRate(
+    taxCategory?: { tax_rates?: Array<{ rate: string | number }> } | null,
+  ): number {
+    return (
+      taxCategory?.tax_rates?.reduce(
+        (sum, rate) => sum + Number(rate.rate || 0),
+        0,
+      ) || 0
+    );
+  }
+
+  private roundMoney(value: number): number {
+    return Math.round((Number(value || 0) + Number.EPSILON) * 100) / 100;
   }
 
   /**
@@ -946,6 +1168,12 @@ export class PosCartService {
    */
   private generateItemId(): string {
     return 'ITEM_' + Date.now() + '_' + Math.random().toString(36).slice(2, 9);
+  }
+
+  private generateCustomProductId(): string {
+    return (
+      'custom-' + Date.now() + '-' + Math.random().toString(36).slice(2, 9)
+    );
   }
 
   /**

--- a/apps/frontend/src/app/private/modules/store/pos/services/pos-order.service.ts
+++ b/apps/frontend/src/app/private/modules/store/pos/services/pos-order.service.ts
@@ -21,7 +21,7 @@ import {
 
 // Re-export types for component usage
 export type { ProcessPaymentRequest, PosOrder } from '../models/order.model';
-import { CartState, CartDiscount } from '../models/cart.model';
+import { CartItem, CartState, CartDiscount } from '../models/cart.model';
 import { PosCustomer } from '../models/customer.model';
 import { PosCashRegisterService } from './pos-cash-register.service';
 
@@ -82,23 +82,11 @@ export class PosOrderService {
       customer_email: cartState.customer?.email || 'cliente@general.com',
       customer_phone: cartState.customer?.phone || '',
       store_id: this.getStoreId(),
-      items: cartState.items.map((item) => ({
-        product_id: parseInt(item.product.id),
-        product_name: item.product.name,
-        product_sku: item.product.sku,
-        quantity: item.quantity,
-        unit_price: Number(item.unitPrice.toFixed(2)),
-        total_price: Number(item.totalPrice.toFixed(2)),
-        cost: item.product.cost,
-        product_variant_id: item.variant_id || null,
-        variant_sku: item.variant_sku || null,
-        variant_attributes: item.variant_attributes || null,
-        weight: item.weight || undefined,
-        weight_unit: item.weight_unit || undefined,
-      })),
+      items: this.mapCartItemsForPos(cartState),
       subtotal: Number(cartState.summary.subtotal.toFixed(2)),
       tax_amount: Number(cartState.summary.taxAmount.toFixed(2)),
       discount_amount: Number(cartState.summary.discountAmount.toFixed(2)),
+      promotion_ids: this.extractPromotionIds(cartState),
       total_amount: Number(cartState.summary.total.toFixed(2)),
       requires_payment: false,
       cash_register_session_id: activeSession?.id ?? undefined,
@@ -245,6 +233,9 @@ export class PosOrderService {
       subtotal: Number((request.subtotal || 0).toFixed(2)),
       tax_amount: Number((request.taxAmount || 0).toFixed(2)),
       discount_amount: Number((request.discountAmount || 0).toFixed(2)),
+      promotion_ids: this.extractPromotionIdsFromDiscounts(
+        (request as any).discounts,
+      ),
       total_amount: Number(request.amount.toFixed(2)),
       requires_payment: true,
       store_payment_method_id: parseInt(request.paymentMethod.id),
@@ -969,20 +960,7 @@ export class PosOrderService {
    */
   updateOrderItems(orderId: string, cartState: CartState): Observable<any> {
     const dto = {
-      items: cartState.items.map((item) => ({
-        product_id: parseInt(item.product.id),
-        product_name: item.product.name,
-        variant_sku: item.variant_sku || item.product.sku || undefined,
-        quantity: item.quantity,
-        unit_price: Number(item.unitPrice.toFixed(2)),
-        total_price: Number(item.totalPrice.toFixed(2)),
-        tax_rate: this.calculateItemTaxRate(item),
-        tax_amount_item: item.taxAmount > 0 ? Number((item.taxAmount / item.quantity).toFixed(5)) : undefined,
-        product_variant_id: item.variant_id || null,
-        variant_attributes: item.variant_attributes || null,
-        weight: item.weight || undefined,
-        weight_unit: item.weight_unit || undefined,
-      })),
+      items: this.mapCartItemsForPos(cartState),
       subtotal: Number(cartState.summary.subtotal.toFixed(2)),
       tax_amount: Number(cartState.summary.taxAmount.toFixed(2)),
       discount_amount: Number(cartState.summary.discountAmount.toFixed(2)),
@@ -1015,11 +993,78 @@ export class PosOrderService {
     return this.storeContextService.getStoreIdOrThrow();
   }
 
+  private mapCartItemsForPos(cartState: CartState): any[] {
+    return cartState.items.map((item) => this.mapCartItemForPos(item));
+  }
+
+  private mapCartItemForPos(item: CartItem): any {
+    const isCustomItem =
+      item.itemType === 'custom' || item.product.id.startsWith('custom-');
+    const lineUnits = item.is_weight_product && item.weight
+      ? item.weight
+      : item.quantity;
+    const categoryIds = this.getProductCategoryIds(item);
+    return {
+      item_type: isCustomItem ? 'custom' : 'product',
+      product_id: isCustomItem ? null : parseInt(item.product.id, 10),
+      category_id: isCustomItem ? undefined : categoryIds[0],
+      category_ids: isCustomItem ? undefined : categoryIds,
+      product_name: item.product.name,
+      description: item.description || item.notes || item.product.description || undefined,
+      product_sku: isCustomItem ? undefined : item.product.sku,
+      quantity: item.quantity,
+      unit_price: Number(item.unitPrice.toFixed(2)),
+      final_unit_price: Number(item.finalPrice.toFixed(2)),
+      total_price: Number((item.finalPrice * lineUnits).toFixed(2)),
+      tax_rate: item.taxRate ?? this.calculateItemTaxRate(item),
+      tax_amount_item:
+        item.taxAmount > 0 && lineUnits > 0
+          ? Number((item.taxAmount / lineUnits).toFixed(2))
+          : undefined,
+      tax_category_id: item.taxCategoryId || undefined,
+      cost: isCustomItem ? undefined : item.product.cost,
+      product_variant_id: isCustomItem ? null : item.variant_id || null,
+      variant_sku: isCustomItem ? null : item.variant_sku || null,
+      variant_attributes: isCustomItem ? null : item.variant_attributes || null,
+      weight: item.weight || undefined,
+      weight_unit: item.weight_unit || undefined,
+      price_override_reason: item.isPriceOverridden
+        ? item.priceOverrideReason
+        : undefined,
+    };
+  }
+
+  private getProductCategoryIds(item: CartItem): number[] {
+    const product = item.product as any;
+    const rawCategoryIds = Array.isArray(product.category_ids)
+      ? product.category_ids
+      : product.category_id
+        ? [product.category_id]
+        : [];
+
+    return rawCategoryIds
+      .map((categoryId: string | number) => Number(categoryId))
+      .filter((categoryId: number) => Number.isFinite(categoryId));
+  }
+
   private extractCouponId(cartState: CartState): number | undefined {
     return cartState.appliedCoupon?.id;
   }
 
   private extractCouponCode(cartState: CartState): string | undefined {
     return cartState.appliedCoupon?.code;
+  }
+
+  private extractPromotionIds(cartState: CartState): number[] {
+    return this.extractPromotionIdsFromDiscounts(cartState.appliedDiscounts);
+  }
+
+  private extractPromotionIdsFromDiscounts(
+    discounts?: CartDiscount[],
+  ): number[] {
+    return (discounts || [])
+      .filter((discount) => discount.promotion_id && !discount.coupon_id)
+      .map((discount) => Number(discount.promotion_id))
+      .filter((promotionId) => Number.isFinite(promotionId));
   }
 }

--- a/apps/frontend/src/app/private/modules/store/pos/services/pos-payment.service.ts
+++ b/apps/frontend/src/app/private/modules/store/pos/services/pos-payment.service.ts
@@ -5,7 +5,7 @@ import { catchError, map, timeout, delay } from 'rxjs/operators';
 import { environment } from '../../../../../../environments/environment';
 import { StoreContextService } from '../../../../../core/services/store-context.service';
 import { PosCashRegisterService } from './pos-cash-register.service';
-import { CartState } from '../models/cart.model';
+import { CartItem, CartState } from '../models/cart.model';
 import {
   PaymentMethod,
   PaymentRequest,
@@ -111,6 +111,90 @@ export class PosPaymentService {
    */
   private getRegisterId(): string | null {
     return this.cashRegisterService.getRegisterId();
+  }
+
+  private mapCartItemsForPos(cartState: CartState): any[] {
+    return cartState.items.map((item) => this.mapCartItemForPos(item));
+  }
+
+  private getAppliedPromotionIds(cartState: CartState): number[] {
+    return cartState.appliedDiscounts
+      .filter((discount) => discount.promotion_id && !discount.coupon_id)
+      .map((discount) => Number(discount.promotion_id))
+      .filter((promotionId) => Number.isFinite(promotionId));
+  }
+
+  private mapCartItemForPos(item: CartItem): any {
+    const isCustomItem =
+      item.itemType === 'custom' || item.product.id.startsWith('custom-');
+    const lineUnits = item.is_weight_product && item.weight
+      ? item.weight
+      : item.quantity;
+    const taxRate = item.taxRate ?? this.calculateItemTaxRate(item);
+    const categoryIds = this.getProductCategoryIds(item);
+
+    return {
+      item_type: isCustomItem ? 'custom' : 'product',
+      product_id: isCustomItem ? null : parseInt(item.product.id, 10),
+      category_id: isCustomItem ? undefined : categoryIds[0],
+      category_ids: isCustomItem ? undefined : categoryIds,
+      product_name: item.product.name,
+      description: item.description || item.notes || item.product.description || undefined,
+      product_sku: isCustomItem ? undefined : item.product.sku,
+      quantity: item.quantity,
+      unit_price: Number(item.unitPrice.toFixed(2)),
+      final_unit_price: Number(item.finalPrice.toFixed(2)),
+      total_price: Number((item.finalPrice * lineUnits).toFixed(2)),
+      tax_rate: taxRate,
+      tax_amount_item:
+        item.taxAmount > 0 && lineUnits > 0
+          ? Number((item.taxAmount / lineUnits).toFixed(2))
+          : undefined,
+      tax_category_id: item.taxCategoryId || undefined,
+      cost:
+        !isCustomItem && item.product.cost
+          ? parseFloat(item.product.cost.toString())
+          : undefined,
+      product_variant_id: isCustomItem ? null : item.variant_id || null,
+      variant_sku: isCustomItem ? null : item.variant_sku || null,
+      variant_attributes: isCustomItem ? null : item.variant_attributes || null,
+      weight: item.weight || undefined,
+      weight_unit: item.weight_unit || undefined,
+      price_override_reason: item.isPriceOverridden
+        ? item.priceOverrideReason
+        : undefined,
+    };
+  }
+
+  private getProductCategoryIds(item: CartItem): number[] {
+    const product = item.product as any;
+    const rawCategoryIds = Array.isArray(product.category_ids)
+      ? product.category_ids
+      : product.category_id
+        ? [product.category_id]
+        : [];
+
+    return rawCategoryIds
+      .map((categoryId: string | number) => Number(categoryId))
+      .filter((categoryId: number) => Number.isFinite(categoryId));
+  }
+
+  private calculateItemTaxRate(item: CartItem): number | undefined {
+    const product = item.product;
+    if (!product?.tax_assignments?.length) return undefined;
+    const rateSum = product.tax_assignments.reduce(
+      (sum: number, assignment: any) => {
+        const assignmentRate =
+          assignment.tax_categories?.tax_rates?.reduce(
+            (rateTotal: number, rate: any) =>
+              rateTotal + parseFloat(rate.rate || '0'),
+            0,
+          ) || 0;
+        return sum + assignmentRate;
+      },
+      0,
+    );
+    return rateSum || undefined;
   }
 
   getPaymentMethods(): Observable<PaymentMethod[]> {
@@ -293,22 +377,7 @@ export class PosPaymentService {
     // Build sale data with conditional customer fields
     const sale_data: any = {
       store_id: this.getStoreId(),
-      items: cartState.items.map((item) => ({
-        product_id: parseInt(item.product.id),
-        product_name: item.product.name,
-        product_sku: item.product.sku,
-        quantity: item.quantity,
-        unit_price: Number(parseFloat(item.unitPrice.toString()).toFixed(2)),
-        total_price: Number(parseFloat(item.totalPrice.toString()).toFixed(2)),
-        cost: item.product.cost
-          ? parseFloat(item.product.cost.toString())
-          : undefined,
-        product_variant_id: item.variant_id || null,
-        variant_sku: item.variant_sku || null,
-        variant_attributes: item.variant_attributes || null,
-        weight: item.weight || undefined,
-        weight_unit: item.weight_unit || undefined,
-      })),
+      items: this.mapCartItemsForPos(cartState),
       subtotal: Number(
         parseFloat(cartState.summary.subtotal.toString()).toFixed(2),
       ),
@@ -318,6 +387,7 @@ export class PosPaymentService {
       discount_amount: Number(
         parseFloat(cartState.summary.discountAmount.toString()).toFixed(2),
       ),
+      promotion_ids: this.getAppliedPromotionIds(cartState),
       total_amount: Number(
         parseFloat(cartState.summary.total.toString()).toFixed(2),
       ),
@@ -437,22 +507,7 @@ export class PosPaymentService {
       customer_email: cartState.customer.email,
       customer_phone: cartState.customer.phone,
       store_id: this.getStoreId(),
-      items: cartState.items.map((item) => ({
-        product_id: parseInt(item.product.id),
-        product_name: item.product.name,
-        product_sku: item.product.sku,
-        quantity: item.quantity,
-        unit_price: Number(parseFloat(item.unitPrice.toString()).toFixed(2)),
-        total_price: Number(parseFloat(item.totalPrice.toString()).toFixed(2)),
-        cost: item.product.cost
-          ? parseFloat(item.product.cost.toString())
-          : undefined,
-        product_variant_id: item.variant_id || null,
-        variant_sku: item.variant_sku || null,
-        variant_attributes: item.variant_attributes || null,
-        weight: item.weight || undefined,
-        weight_unit: item.weight_unit || undefined,
-      })),
+      items: this.mapCartItemsForPos(cartState),
       subtotal: Number(
         parseFloat(cartState.summary.subtotal.toString()).toFixed(2),
       ),
@@ -462,6 +517,7 @@ export class PosPaymentService {
       discount_amount: Number(
         parseFloat(cartState.summary.discountAmount.toString()).toFixed(2),
       ),
+      promotion_ids: this.getAppliedPromotionIds(cartState),
       total_amount: totalWithShipping,
       // Shipping fields
       delivery_type: shippingData.deliveryType,
@@ -566,20 +622,7 @@ export class PosPaymentService {
       customer_email: cartState.customer.email,
       customer_phone: cartState.customer.phone,
       store_id: this.getStoreId(),
-      items: cartState.items.map((item) => ({
-        product_id: parseInt(item.product.id),
-        product_name: item.product.name,
-        product_sku: item.product.sku,
-        quantity: item.quantity,
-        unit_price: Number(parseFloat(item.unitPrice.toString()).toFixed(2)),
-        total_price: Number(parseFloat(item.totalPrice.toString()).toFixed(2)),
-        cost: item.product.cost
-          ? parseFloat(item.product.cost.toString())
-          : undefined,
-        product_variant_id: item.variant_id || null,
-        variant_sku: item.variant_sku || null,
-        variant_attributes: item.variant_attributes || null,
-      })),
+      items: this.mapCartItemsForPos(cartState),
       subtotal: Number(
         parseFloat(cartState.summary.subtotal.toString()).toFixed(2),
       ),
@@ -589,6 +632,7 @@ export class PosPaymentService {
       discount_amount: Number(
         parseFloat(cartState.summary.discountAmount.toString()).toFixed(2),
       ),
+      promotion_ids: this.getAppliedPromotionIds(cartState),
       total_amount: Number(
         parseFloat(cartState.summary.total.toString()).toFixed(2),
       ),
@@ -658,20 +702,7 @@ export class PosPaymentService {
       customer_email: cartState.customer.email,
       customer_phone: cartState.customer.phone,
       store_id: this.getStoreId(),
-      items: cartState.items.map((item) => ({
-        product_id: parseInt(item.product.id),
-        product_name: item.product.name,
-        product_sku: item.product.sku,
-        quantity: item.quantity,
-        unit_price: Number(parseFloat(item.unitPrice.toString()).toFixed(2)),
-        total_price: Number(parseFloat(item.totalPrice.toString()).toFixed(2)),
-        cost: item.product.cost
-          ? parseFloat(item.product.cost.toString())
-          : undefined,
-        product_variant_id: item.variant_id || null,
-        variant_sku: item.variant_sku || null,
-        variant_attributes: item.variant_attributes || null,
-      })),
+      items: this.mapCartItemsForPos(cartState),
       subtotal: Number(
         parseFloat(cartState.summary.subtotal.toString()).toFixed(2),
       ),
@@ -681,6 +712,7 @@ export class PosPaymentService {
       discount_amount: Number(
         parseFloat(cartState.summary.discountAmount.toString()).toFixed(2),
       ),
+      promotion_ids: this.getAppliedPromotionIds(cartState),
       total_amount: Number(
         parseFloat(cartState.summary.total.toString()).toFixed(2),
       ),
@@ -749,23 +781,11 @@ export class PosPaymentService {
       customer_email: cartState.customer.email,
       customer_phone: cartState.customer.phone,
       store_id: this.getStoreId(),
-      items: cartState.items.map((item) => ({
-        product_id: parseInt(item.product.id),
-        product_name: item.product.name,
-        product_sku: item.product.sku,
-        quantity: item.quantity,
-        unit_price: Number(item.unitPrice.toFixed(2)),
-        total_price: Number(item.totalPrice.toFixed(2)),
-        cost: item.product.cost,
-        product_variant_id: item.variant_id || null,
-        variant_sku: item.variant_sku || null,
-        variant_attributes: item.variant_attributes || null,
-        weight: item.weight || undefined,
-        weight_unit: item.weight_unit || undefined,
-      })),
+      items: this.mapCartItemsForPos(cartState),
       subtotal: Number(cartState.summary.subtotal.toFixed(2)),
       tax_amount: Number(cartState.summary.taxAmount.toFixed(2)),
       discount_amount: Number(cartState.summary.discountAmount.toFixed(2)),
+      promotion_ids: this.getAppliedPromotionIds(cartState),
       total_amount: Number(cartState.summary.total.toFixed(2)),
       requires_payment: false,
       ...(register_id ? { register_id } : {}),

--- a/apps/frontend/src/app/private/modules/store/pos/services/pos-product.service.ts
+++ b/apps/frontend/src/app/private/modules/store/pos/services/pos-product.service.ts
@@ -16,7 +16,10 @@ export interface Product {
   cost?: number;
   is_on_sale?: boolean;
   sale_price?: number | null;
+  allow_pos_price_override?: boolean;
   category: string;
+  category_id?: number | null;
+  category_ids?: number[];
   brand?: string;
   stock: number;
   track_inventory?: boolean;
@@ -339,6 +342,13 @@ export class PosProductService {
         }),
       );
 
+      const categories = Array.isArray(product.categories)
+        ? product.categories
+        : product.product_categories?.map((pc: any) => pc.categories || pc.category || pc) || [];
+      const categoryIds = categories
+        .map((category: any) => Number(category?.id))
+        .filter((id: number) => Number.isFinite(id));
+
       const transformed = {
         id: product.id?.toString() || '',
         name: product.name || '',
@@ -347,11 +357,11 @@ export class PosProductService {
         final_price: parseFloat(
           product.final_price || product.base_price || product.price || 0,
         ),
+        allow_pos_price_override: product.allow_pos_price_override === true,
         cost: product.cost_price ? parseFloat(product.cost_price) : undefined,
-        category:
-          product.product_categories && product.product_categories.length > 0
-            ? product.product_categories[0].name
-            : product.category?.name || 'Sin categoría',
+        category: categories[0]?.name || product.category?.name || 'Sin categoría',
+        category_id: categoryIds[0] ?? null,
+        category_ids: categoryIds,
         brand: product.brands?.name || '',
         stock: totalStock,
         track_inventory: product.track_inventory,

--- a/apps/frontend/src/app/private/modules/store/products/components/product-create-modal.component.ts
+++ b/apps/frontend/src/app/private/modules/store/products/components/product-create-modal.component.ts
@@ -135,6 +135,7 @@ export class ProductCreateModalComponent {
       category_ids: [[]],
       brand_ids: [[]],
       tax_category_ids: [[] as number[]],
+      allow_pos_price_override: [false],
       state: [ProductState.ACTIVE],
     });
   }
@@ -143,6 +144,7 @@ export class ProductCreateModalComponent {
     this.productForm.reset({
       base_price: 0,
       tax_category_ids: [],
+      allow_pos_price_override: false,
       state: ProductState.ACTIVE,
     });
   }
@@ -157,6 +159,7 @@ export class ProductCreateModalComponent {
       category_ids: val.category_ids || [],
       brand_ids: val.brand_ids || [],
       tax_category_ids: val.tax_category_ids || [],
+      allow_pos_price_override: !!val.allow_pos_price_override,
       state: val.state || 'active',
     };
 
@@ -208,6 +211,7 @@ export class ProductCreateModalComponent {
       tax_category_ids: (prod.product_tax_assignments || []).map(
         (ta: any) => ta.tax_category_id,
       ),
+      allow_pos_price_override: prod.allow_pos_price_override === true,
       state: prod.state || ProductState.ACTIVE,
     });
   }
@@ -329,6 +333,7 @@ export class ProductCreateModalComponent {
       category_ids: val.category_ids || [],
       brand_id: val.brand_ids?.[0] ? Number(val.brand_ids[0]) : null,
       tax_category_ids: val.tax_category_ids || [],
+      allow_pos_price_override: !!val.allow_pos_price_override,
       state: val.state,
     };
 

--- a/apps/frontend/src/app/private/modules/store/products/components/product-create-modal/product-create-modal.component.html
+++ b/apps/frontend/src/app/private/modules/store/products/components/product-create-modal/product-create-modal.component.html
@@ -127,6 +127,24 @@
         <small class="text-xs text-gray-400 mt-0.5 block">Opcional</small>
       </div>
 
+      <label
+        class="flex items-start justify-between gap-3 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2"
+      >
+        <span class="min-w-0">
+          <span class="block text-sm font-semibold text-gray-700">
+            Precio editable en POS
+          </span>
+          <span class="block text-xs text-gray-500">
+            Solo usuarios autorizados podrán cambiar el precio al venderlo.
+          </span>
+        </span>
+        <input
+          type="checkbox"
+          formControlName="allow_pos_price_override"
+          class="mt-1 h-4 w-4 accent-primary"
+        />
+      </label>
+
       <!-- Advanced Link -->
       <div class="pt-2">
         <button

--- a/apps/frontend/src/app/private/modules/store/products/interfaces/product.interface.ts
+++ b/apps/frontend/src/app/private/modules/store/products/interfaces/product.interface.ts
@@ -41,6 +41,7 @@ export interface Product {
   is_on_sale?: boolean;
   sale_price?: number;
   available_for_ecommerce?: boolean;
+  allow_pos_price_override?: boolean;
   sku?: string;
   stock_quantity?: number;
   track_inventory?: boolean;
@@ -214,6 +215,7 @@ export interface CreateProductDto {
   is_on_sale?: boolean;
   sale_price?: number;
   available_for_ecommerce?: boolean;
+  allow_pos_price_override?: boolean;
   sku?: string;
   stock_quantity?: number;
   track_inventory?: boolean;
@@ -266,6 +268,7 @@ export interface UpdateProductDto {
   stock_quantity?: number;
   track_inventory?: boolean;
   available_for_ecommerce?: boolean;
+  allow_pos_price_override?: boolean;
   weight?: number;
   dimensions?: {
     length: number;

--- a/apps/frontend/src/app/private/modules/store/products/pages/product-create-page/product-create-page.component.html
+++ b/apps/frontend/src/app/private/modules/store/products/pages/product-create-page/product-create-page.component.html
@@ -210,7 +210,6 @@
               [options]="pricingTypeOptions"
               formControlName="pricing_type"
               placeholder="Seleccionar tipo"
-              [disabled]="isService"
               tooltipText="Define si el producto se vende por unidad o por peso (kg). Afecta cómo se interpretan los precios."
             >
             </app-selector>
@@ -219,7 +218,7 @@
               <app-multi-selector
                 class="flex-1"
                 label="Impuestos Aplicables"
-                [options]="taxCategoryOptions"
+                [options]="taxCategoryOptions()"
                 formControlName="tax_category_ids"
                 placeholder="Seleccionar impuestos..."
                 tooltipText="Impuestos que se suman al precio base en facturación y checkout (IVA, INC, retenciones)."
@@ -524,6 +523,13 @@
               formControlName="available_for_ecommerce"
               label="Disponible en E-commerce"
               description="Visible en tu tienda online"
+            >
+            </app-setting-toggle>
+
+            <app-setting-toggle
+              formControlName="allow_pos_price_override"
+              label="Precio editable en POS"
+              description="Permite que usuarios autorizados vendan este producto con precio negociado"
             >
             </app-setting-toggle>
 

--- a/apps/frontend/src/app/private/modules/store/products/pages/product-create-page/product-create-page.component.ts
+++ b/apps/frontend/src/app/private/modules/store/products/pages/product-create-page/product-create-page.component.ts
@@ -1,4 +1,5 @@
 import {
+  afterNextRender,
   Component,
   computed,
   effect,
@@ -455,7 +456,7 @@ export class ProductCreatePageComponent {
   isReleasingReservations = false;
   categoryOptions: MultiSelectorOption[] = [];
   brandOptions: SelectorOption[] = [];
-  taxCategoryOptions: MultiSelectorOption[] = [];
+  readonly taxCategoryOptions = signal<MultiSelectorOption[]>([]);
   stateOptions: SelectorOption[] = [
     { value: ProductState.ACTIVE, label: 'Activo' },
     { value: ProductState.INACTIVE, label: 'Inactivo' },
@@ -531,6 +532,25 @@ export class ProductCreatePageComponent {
     }
   }
 
+  private syncPricingTypeControlState(isService: boolean): void {
+    const pricingTypeControl = this.productForm.get('pricing_type');
+    if (!pricingTypeControl) return;
+
+    if (isService) {
+      if (pricingTypeControl.value !== 'unit') {
+        pricingTypeControl.setValue('unit', { emitEvent: false });
+      }
+      if (pricingTypeControl.enabled) {
+        pricingTypeControl.disable({ emitEvent: false });
+      }
+      return;
+    }
+
+    if (pricingTypeControl.disabled) {
+      pricingTypeControl.enable({ emitEvent: false });
+    }
+  }
+
   // Variants State
   hasVariants = false;
   variantAttributes: VariantAttribute[] = [];
@@ -593,6 +613,13 @@ export class ProductCreatePageComponent {
     this.productForm.statusChanges
       .pipe(takeUntilDestroyed())
       .subscribe(() => this.formUpdateTrigger.update((v) => v + 1));
+    this.productForm
+      .get('product_type')
+      ?.valueChanges.pipe(takeUntilDestroyed())
+      .subscribe((productType) => {
+        this.syncPricingTypeControlState(productType === 'service');
+      });
+    this.syncPricingTypeControlState(this.isService);
 
     // Auto-cargar proveedores cuando se activa requires_booking (o al entrar en edit con el flag ya activo)
     effect(() => {
@@ -608,8 +635,10 @@ export class ProductCreatePageComponent {
 
     // Asegurar que la moneda esté cargada
     this.currencyService.loadCurrency();
-    this.loadCategoriesAndBrands();
-    this.loadDataCollectionTemplates();
+    afterNextRender(() => {
+      this.loadCategoriesAndBrands();
+      this.loadDataCollectionTemplates();
+    });
 
     // Verificar draft del modal de creación rápida
     const navState = history.state;
@@ -636,6 +665,7 @@ export class ProductCreatePageComponent {
       base_price: draft.base_price || 0,
       stock_quantity: draft.stock_quantity || 0,
       track_inventory: draft.track_inventory ?? true,
+      allow_pos_price_override: draft.allow_pos_price_override ?? false,
       sku: draft.sku || '',
       category_ids: draft.category_ids || [],
       brand_ids: draft.brand_id ? [draft.brand_id] : [],
@@ -712,6 +742,7 @@ export class ProductCreatePageComponent {
       is_on_sale: [false],
       sale_price: [0, [Validators.min(0)]],
       available_for_ecommerce: [true],
+      allow_pos_price_override: [false],
       sku: ['', [Validators.maxLength(100)]],
       stock_quantity: [0, [Validators.min(0)]],
       track_inventory: [true],
@@ -863,6 +894,7 @@ export class ProductCreatePageComponent {
       is_on_sale: product.is_on_sale || false,
       sale_price: product.sale_price || 0,
       available_for_ecommerce: product.available_for_ecommerce !== false,
+      allow_pos_price_override: product.allow_pos_price_override === true,
       sku: product.sku,
       stock_quantity: product.stock_quantity,
       track_inventory: product.track_inventory !== false,
@@ -984,18 +1016,20 @@ export class ProductCreatePageComponent {
     this.taxesService.getTaxCategories().subscribe({
       next: (taxCategories: TaxCategory[]) => {
         this.allTaxCategories = taxCategories;
-        this.taxCategoryOptions = taxCategories.map((cat: TaxCategory) => {
-          // Extraer la tasa del primer tax_rate si no existe en el nivel superior
-          const rawRate = cat.rate ?? cat.tax_rates?.[0]?.rate ?? 0;
-          const rate = parseFloat(String(rawRate));
-          const finalRate = isNaN(rate) ? 0 : rate;
+        this.taxCategoryOptions.set(
+          taxCategories.map((cat: TaxCategory) => {
+            // Extraer la tasa del primer tax_rate si no existe en el nivel superior
+            const rawRate = cat.rate ?? cat.tax_rates?.[0]?.rate ?? 0;
+            const rate = parseFloat(String(rawRate));
+            const finalRate = isNaN(rate) ? 0 : rate;
 
-          return {
-            value: cat.id,
-            label: `${cat.name} (${(finalRate * 100).toFixed(0)}%)`,
-            description: cat.description,
-          };
-        });
+            return {
+              value: cat.id,
+              label: `${cat.name} (${(finalRate * 100).toFixed(0)}%)`,
+              description: cat.description,
+            };
+          }),
+        );
       },
       error: (error: any) => {
         console.error('Error loading tax categories:', error);
@@ -1889,7 +1923,7 @@ export class ProductCreatePageComponent {
     }
 
     this.isSubmitting.set(true);
-    const formValue = this.productForm.value;
+    const formValue = this.productForm.getRawValue();
 
     // Prepare Images
     const images: CreateProductImageDto[] = this.imageUrls.map(
@@ -1912,6 +1946,7 @@ export class ProductCreatePageComponent {
       is_on_sale: !!formValue.is_on_sale,
       sale_price: Number(formValue.sale_price),
       available_for_ecommerce: !!formValue.available_for_ecommerce,
+      allow_pos_price_override: !!formValue.allow_pos_price_override,
       sku: formValue.sku || undefined,
       track_inventory: isServiceType ? false : !!formValue.track_inventory,
       stock_quantity: isServiceType

--- a/apps/frontend/src/app/private/modules/store/quotations/components/quotation-list/quotation-list.component.ts
+++ b/apps/frontend/src/app/private/modules/store/quotations/components/quotation-list/quotation-list.component.ts
@@ -242,6 +242,10 @@ export class QuotationListComponent {
       icon: 'arrow-right-circle',
       variant: 'success',
       action: (item: Quotation) => this.convert.emit(item),
+      tooltip: (item: Quotation) =>
+        item.status === 'accepted'
+          ? 'Convertir a orden'
+          : 'Primero acepta la cotización para convertirla en orden',
       show: (item: Quotation) =>
         ['draft', 'sent', 'accepted'].includes(item.status),
     },

--- a/apps/frontend/src/app/private/modules/store/quotations/pages/quotation-detail/quotation-detail.component.ts
+++ b/apps/frontend/src/app/private/modules/store/quotations/pages/quotation-detail/quotation-detail.component.ts
@@ -2,7 +2,7 @@ import { Component, DestroyRef, inject, signal, computed } from '@angular/core';
 import { DatePipe } from '@angular/common';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { Observable } from 'rxjs';
+import { finalize, Observable } from 'rxjs';
 import { QuotationsService } from '../../services/quotations.service';
 import { QuotationPrintService } from '../../services/quotation-print.service';
 import { Quotation, QuotationStatus } from '../../interfaces/quotation.interface';
@@ -22,6 +22,7 @@ import type {
   TimelineStep,
 } from '../../../../../../shared/components';
 import { CurrencyPipe } from '../../../../../../shared/pipes';
+import { extractApiErrorMessage } from '../../../../../../core/utils/api-error-handler';
 
 const STATUS_LABELS: Record<QuotationStatus, string> = {
   draft: 'Borrador',
@@ -272,6 +273,40 @@ const STATUS_BADGE_COLORS: Record<QuotationStatus, StickyHeaderBadgeColor> = {
                   No hay acciones disponibles
                 </div>
               }
+
+              @if (canProcessAll()) {
+                <div class="mt-4 pt-4 border-t border-border">
+                  <label class="flex items-start gap-3 p-3 bg-amber-50 rounded-xl border border-amber-200 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      [checked]="processAllEnabled()"
+                      (change)="processAllEnabled.set($any($event.target).checked)"
+                      class="mt-0.5"
+                    />
+                    <div>
+                      <p class="text-sm font-bold text-amber-800">Procesar cotización completa</p>
+                      <p class="text-xs text-text-secondary mt-0.5">
+                        Ejecuta en cadena los pasos pendientes: enviar al correo del cliente, aceptar y convertir en orden.
+                        Si algún paso falla, podrás reintentar desde el último estado completado.
+                      </p>
+                    </div>
+                  </label>
+
+                  @if (processAllEnabled()) {
+                    <app-button
+                      variant="outline-warning"
+                      [fullWidth]="true"
+                      customClasses="mt-2"
+                      [disabled]="actionLoading() !== null"
+                      [loading]="actionLoading() === 'process-all'"
+                      (clicked)="onProcessAll()"
+                    >
+                      <app-icon slot="icon" name="zap" size="16"></app-icon>
+                      Confirmar y procesar todo
+                    </app-button>
+                  }
+                </div>
+              }
             </app-card>
 
             <!-- Payment Summary -->
@@ -333,6 +368,7 @@ export class QuotationDetailComponent {
   readonly quotation = signal<Quotation | null>(null);
   readonly loading = signal(true);
   readonly actionLoading = signal<string | null>(null);
+  readonly processAllEnabled = signal(false);
 
   readonly statusLabel = computed(() => {
     const q = this.quotation();
@@ -408,6 +444,11 @@ export class QuotationDetailComponent {
 
   readonly visibleActions = computed(() => {
     return this.headerActions().filter(a => a.visible);
+  });
+
+  readonly canProcessAll = computed(() => {
+    const q = this.quotation();
+    return !!q && ['draft', 'sent', 'accepted'].includes(q.status);
   });
 
   readonly timelineSteps = computed<TimelineStep[]>(() => {
@@ -603,6 +644,12 @@ export class QuotationDetailComponent {
   }
 
   private async onConvert(): Promise<void> {
+    const blockedMessage = this.getConvertBlockedMessage();
+    if (blockedMessage) {
+      this.toastService.error(blockedMessage);
+      return;
+    }
+
     const confirmed = await this.dialogService.confirm({
       title: 'Convertir a orden',
       message: '¿Deseas convertir esta cotización directamente en una orden de venta? La cotización quedará marcada como convertida.',
@@ -629,7 +676,46 @@ export class QuotationDetailComponent {
         },
         error: (err) => {
           this.actionLoading.set(null);
-          this.toastService.error(err.message || 'Error al duplicar la cotización');
+          this.toastService.error(extractApiErrorMessage(err));
+        },
+      });
+  }
+
+  async onProcessAll(): Promise<void> {
+    const q = this.quotation();
+    if (!q) return;
+
+    const blockedMessage = this.getProcessAllBlockedMessage(q);
+    if (blockedMessage) {
+      this.toastService.error(blockedMessage);
+      return;
+    }
+
+    const confirmed = await this.dialogService.confirm({
+      title: 'Procesar cotización completa',
+      message: this.getProcessAllConfirmMessage(q),
+      confirmText: 'Procesar todo',
+      cancelText: 'Cancelar',
+      confirmVariant: 'primary',
+    });
+    if (!confirmed) return;
+
+    this.actionLoading.set('process-all');
+    this.quotationsService
+      .processCompleteQuotation(q)
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        finalize(() => this.actionLoading.set(null)),
+      )
+      .subscribe({
+        next: (result) => {
+          this.quotation.set(result);
+          this.quotationsService.invalidateCache();
+          this.processAllEnabled.set(false);
+          this.toastService.success('Cotización procesada y convertida a orden exitosamente');
+        },
+        error: (err) => {
+          this.toastService.error(extractApiErrorMessage(err));
         },
       });
   }
@@ -652,8 +738,54 @@ export class QuotationDetailComponent {
         },
         error: (err: any) => {
           this.actionLoading.set(null);
-          this.toastService.error(err.message || 'Error al realizar la acción');
+          this.toastService.error(extractApiErrorMessage(err));
         },
       });
+  }
+
+  private getConvertBlockedMessage(): string | null {
+    const q = this.quotation();
+    if (!q || q.status === 'accepted') {
+      return null;
+    }
+
+    if (q.status === 'draft') {
+      return 'Antes de convertirla en orden, envía la cotización y márcala como aceptada.';
+    }
+
+    if (q.status === 'sent') {
+      return 'Antes de convertirla en orden, márcala como aceptada cuando el cliente la apruebe.';
+    }
+
+    return 'Solo las cotizaciones aceptadas pueden convertirse en orden.';
+  }
+
+  private getProcessAllBlockedMessage(q: Quotation): string | null {
+    if (!['draft', 'sent', 'accepted'].includes(q.status)) {
+      return 'Solo las cotizaciones en borrador, enviadas o aceptadas pueden procesarse en este flujo.';
+    }
+
+    if (!q.customer_id) {
+      return 'Asigna un cliente a esta cotización antes de procesarla completa.';
+    }
+
+    if (q.status === 'draft' && !q.customer?.email) {
+      return 'Agrega un correo al cliente antes de enviar y procesar esta cotización.';
+    }
+
+    return null;
+  }
+
+  private getProcessAllConfirmMessage(q: Quotation): string {
+    const steps: string[] = [];
+    if (q.status === 'draft') {
+      steps.push('enviar la cotización al correo del cliente');
+    }
+    if (q.status === 'draft' || q.status === 'sent') {
+      steps.push('marcarla como aceptada');
+    }
+    steps.push('convertirla en orden');
+
+    return `Se ejecutará en cadena: ${steps.join(', ')}. Si un paso falla, podrás reintentar desde el último estado completado.`;
   }
 }

--- a/apps/frontend/src/app/private/modules/store/quotations/quotations.component.ts
+++ b/apps/frontend/src/app/private/modules/store/quotations/quotations.component.ts
@@ -4,6 +4,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { StatsComponent } from '../../../../shared/components/stats/stats.component';
 import { ToastService } from '../../../../shared/components/toast/toast.service';
 import { DialogService } from '../../../../shared/components/dialog/dialog.service';
+import { extractApiErrorMessage } from '../../../../core/utils/api-error-handler';
 import { QuotationsService } from './services/quotations.service';
 import { QuotationListComponent } from './components/quotation-list/quotation-list.component';
 import {
@@ -166,7 +167,7 @@ export class QuotationsComponent {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: () => { this.toastService.success('Cotización enviada'); this.refresh(); },
-        error: () => this.toastService.error('Error al enviar cotización'),
+        error: (err) => this.showQuotationError(err, 'Error al enviar cotización'),
       });
   }
 
@@ -175,7 +176,7 @@ export class QuotationsComponent {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: () => { this.toastService.success('Cotización aceptada'); this.refresh(); },
-        error: () => this.toastService.error('Error al aceptar cotización'),
+        error: (err) => this.showQuotationError(err, 'Error al aceptar cotización'),
       });
   }
 
@@ -184,7 +185,7 @@ export class QuotationsComponent {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: () => { this.toastService.success('Cotización rechazada'); this.refresh(); },
-        error: () => this.toastService.error('Error al rechazar cotización'),
+        error: (err) => this.showQuotationError(err, 'Error al rechazar cotización'),
       });
   }
 
@@ -202,11 +203,17 @@ export class QuotationsComponent {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: () => { this.toastService.success('Cotización cancelada'); this.refresh(); },
-        error: () => this.toastService.error('Error al cancelar cotización'),
+        error: (err) => this.showQuotationError(err, 'Error al cancelar cotización'),
       });
   }
 
   async onConvert(q: Quotation): Promise<void> {
+    const blockedMessage = this.getConvertBlockedMessage(q);
+    if (blockedMessage) {
+      this.toastService.error(blockedMessage);
+      return;
+    }
+
     const confirmed = await this.dialogService.confirm({
       title: 'Convertir a orden',
       message: `¿Convertir la cotización ${q.quotation_number} en una orden de venta?`,
@@ -219,7 +226,7 @@ export class QuotationsComponent {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: () => { this.toastService.success('Cotización convertida a orden'); this.refresh(); },
-        error: () => this.toastService.error('Error al convertir cotización'),
+        error: (err) => this.showQuotationError(err, 'Error al convertir cotización'),
       });
   }
 
@@ -228,7 +235,7 @@ export class QuotationsComponent {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: () => { this.toastService.success('Cotización duplicada'); this.refresh(); },
-        error: () => this.toastService.error('Error al duplicar cotización'),
+        error: (err) => this.showQuotationError(err, 'Error al duplicar cotización'),
       });
   }
 
@@ -246,7 +253,7 @@ export class QuotationsComponent {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: () => { this.toastService.success('Cotización eliminada'); this.refresh(); },
-        error: () => this.toastService.error('Error al eliminar cotización'),
+        error: (err) => this.showQuotationError(err, 'Error al eliminar cotización'),
       });
   }
 
@@ -264,5 +271,26 @@ export class QuotationsComponent {
     this.quotationsService.invalidateCache();
     this.loadStats();
     this.loadQuotations();
+  }
+
+  private getConvertBlockedMessage(q: Quotation): string | null {
+    if (q.status === 'accepted') {
+      return null;
+    }
+
+    if (q.status === 'draft') {
+      return 'Antes de convertirla en orden, envía la cotización y márcala como aceptada.';
+    }
+
+    if (q.status === 'sent') {
+      return 'Antes de convertirla en orden, márcala como aceptada cuando el cliente la apruebe.';
+    }
+
+    return 'Solo las cotizaciones aceptadas pueden convertirse en orden.';
+  }
+
+  private showQuotationError(error: any, fallback: string): void {
+    const message = extractApiErrorMessage(error);
+    this.toastService.error(message || fallback);
   }
 }

--- a/apps/frontend/src/app/private/modules/store/quotations/services/quotations.service.ts
+++ b/apps/frontend/src/app/private/modules/store/quotations/services/quotations.service.ts
@@ -1,8 +1,9 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable, throwError } from 'rxjs';
-import { catchError, map, shareReplay, tap } from 'rxjs/operators';
+import { Observable, of, throwError } from 'rxjs';
+import { catchError, concatMap, map, shareReplay, tap } from 'rxjs/operators';
 import { environment } from '../../../../../../environments/environment';
+import { extractApiErrorMessage } from '../../../../../core/utils/api-error-handler';
 import {
   Quotation,
   QuotationQuery,
@@ -134,6 +135,20 @@ export class QuotationsService {
     );
   }
 
+  processCompleteQuotation(quotation: Quotation): Observable<Quotation> {
+    let flow$: Observable<Quotation> = of(quotation);
+
+    if (quotation.status === 'draft') {
+      flow$ = flow$.pipe(concatMap(() => this.sendQuotation(quotation.id)));
+    }
+
+    if (quotation.status === 'draft' || quotation.status === 'sent') {
+      flow$ = flow$.pipe(concatMap(() => this.acceptQuotation(quotation.id)));
+    }
+
+    return flow$.pipe(concatMap(() => this.convertToOrder(quotation.id)));
+  }
+
   duplicateQuotation(id: number): Observable<Quotation> {
     return this.http.post<any>(`${this.apiUrl}/store/quotations/${id}/duplicate`, {}).pipe(
       map((r) => r.data || r),
@@ -147,6 +162,6 @@ export class QuotationsService {
   }
 
   private extractErrorMessage(error: any): string {
-    return error?.error?.message || error?.message || 'Error desconocido';
+    return extractApiErrorMessage(error);
   }
 }

--- a/apps/frontend/src/app/private/modules/store/settings/general/services/store-settings.service.ts
+++ b/apps/frontend/src/app/private/modules/store/settings/general/services/store-settings.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable, throwError } from 'rxjs';
-import { map, catchError, tap } from 'rxjs/operators';
+import { Observable, of, throwError } from 'rxjs';
+import { map, catchError, tap, finalize, shareReplay } from 'rxjs/operators';
 import { environment } from '../../../../../../../environments/environment';
 import { Store } from '@ngrx/store';
 import {
@@ -34,6 +34,10 @@ export interface StoreFiscalDataRequestOptions {
   store_id?: number | null;
 }
 
+export interface StoreSettingsRequestOptions {
+  forceRefresh?: boolean;
+}
+
 @Injectable({
   providedIn: 'root',
 })
@@ -42,27 +46,46 @@ export class StoreSettingsService {
   private store = inject(Store);
   private currencyFormatService = inject(CurrencyFormatService);
   private readonly api_base_url = `${environment.apiUrl}/store`;
+  private readonly settings_cache_ttl_ms = 60 * 1000;
+  private settings_cache: ApiResponse<StoreSettings> | null = null;
+  private settings_cache_time = 0;
+  private settings_request$?: Observable<ApiResponse<StoreSettings>>;
 
-  getSettings(): Observable<ApiResponse<StoreSettings>> {
-    return this.http
-      .get<ApiResponse<StoreSettings>>(
-        `${this.api_base_url}/settings`,
-      )
+  getSettings(
+    options: StoreSettingsRequestOptions = {},
+  ): Observable<ApiResponse<StoreSettings>> {
+    const now = Date.now();
+    if (
+      !options.forceRefresh &&
+      this.settings_cache &&
+      now - this.settings_cache_time < this.settings_cache_ttl_ms
+    ) {
+      return of(this.settings_cache);
+    }
+
+    if (!options.forceRefresh && this.settings_request$) {
+      return this.settings_request$;
+    }
+
+    const request$ = this.http
+      .get<ApiResponse<StoreSettings>>(`${this.api_base_url}/settings`)
       .pipe(
+        map((response) => response || { success: true, data: null }),
         tap((response) => {
-          const store_settings = response?.data;
-          if (!store_settings) return;
-
-          this.store.dispatch(
-            AuthActions.updateStoreSettings({ store_settings }),
-          );
-          if (store_settings.general?.currency) {
-            this.currencyFormatService.refresh();
+          this.cacheSettingsResponse(response);
+          this.publishStoreSettings(response);
+        }),
+        catchError((error) => this.handleSettingsReadError(error)),
+        finalize(() => {
+          if (this.settings_request$ === request$) {
+            this.settings_request$ = undefined;
           }
         }),
-        map((response) => response || { success: true, data: null }),
-        catchError(this.handleError)
+        shareReplay({ bufferSize: 1, refCount: false }),
       );
+
+    this.settings_request$ = request$;
+    return request$;
   }
 
   saveSettingsNow(
@@ -73,13 +96,16 @@ export class StoreSettingsService {
 
   resetToDefault(): Observable<ApiResponse<StoreSettings>> {
     return this.http
-      .post<ApiResponse<StoreSettings>>(
-        `${this.api_base_url}/settings/reset`,
-        {},
-      )
+      .post<
+        ApiResponse<StoreSettings>
+      >(`${this.api_base_url}/settings/reset`, {})
       .pipe(
         map((response) => response || { success: true, data: null }),
-        catchError(this.handleError)
+        tap((response) => {
+          this.cacheSettingsResponse(response);
+          this.publishStoreSettings(response);
+        }),
+        catchError(this.handleError),
       );
   }
 
@@ -87,12 +113,12 @@ export class StoreSettingsService {
     options?: StoreFiscalDataRequestOptions,
   ): Observable<ApiResponse<StoreFiscalData>> {
     return this.http
-      .get<ApiResponse<StoreFiscalData> | { fiscal_data?: StoreFiscalData }>(
-        this.fiscalDataUrl(options),
-      )
+      .get<
+        ApiResponse<StoreFiscalData> | { fiscal_data?: StoreFiscalData }
+      >(this.fiscalDataUrl(options))
       .pipe(
         map((response) => this.mapFiscalDataResponse(response)),
-        catchError(this.handleError)
+        catchError(this.handleError),
       );
   }
 
@@ -101,50 +127,55 @@ export class StoreSettingsService {
     options?: StoreFiscalDataRequestOptions,
   ): Observable<ApiResponse<StoreFiscalData>> {
     return this.http
-      .patch<ApiResponse<StoreFiscalData> | { fiscal_data?: StoreFiscalData }>(
-        this.fiscalDataUrl(options),
-        dto,
-      )
+      .patch<
+        ApiResponse<StoreFiscalData> | { fiscal_data?: StoreFiscalData }
+      >(this.fiscalDataUrl(options), dto)
       .pipe(
         map((response) => this.mapFiscalDataResponse(response)),
-        catchError(this.handleError)
+        catchError(this.handleError),
       );
   }
 
   getSystemTemplates(): Observable<ApiResponse<any[]>> {
     return this.http
-      .get<ApiResponse<any[]>>(
-        `${this.api_base_url}/settings/templates`,
-      )
+      .get<ApiResponse<any[]>>(`${this.api_base_url}/settings/templates`)
       .pipe(
         map((response) => response || { success: true, data: [] }),
-        catchError(this.handleError)
+        catchError(this.handleError),
       );
   }
 
   applyTemplate(template_name: string): Observable<ApiResponse<StoreSettings>> {
     return this.http
-      .post<ApiResponse<StoreSettings>>(
-        `${this.api_base_url}/settings/apply-template`,
-        { template_name },
-      )
+      .post<
+        ApiResponse<StoreSettings>
+      >(`${this.api_base_url}/settings/apply-template`, { template_name })
       .pipe(
         map((response) => response || { success: true, data: null }),
-        catchError(this.handleError)
+        tap((response) => {
+          this.cacheSettingsResponse(response);
+          this.publishStoreSettings(response);
+        }),
+        catchError(this.handleError),
       );
   }
 
-  uploadStoreLogo(file: File): Observable<{ key: string; url: string; thumbKey?: string; thumbUrl?: string }> {
+  uploadStoreLogo(
+    file: File,
+  ): Observable<{
+    key: string;
+    url: string;
+    thumbKey?: string;
+    thumbUrl?: string;
+  }> {
     const formData = new FormData();
     formData.append('file', file);
     formData.append('entityType', 'store_logos');
 
-    return this.http
-      .post<any>(`${environment.apiUrl}/upload`, formData)
-      .pipe(
-        map((response) => response.data ?? response),
-        catchError(this.handleError)
-      );
+    return this.http.post<any>(`${environment.apiUrl}/upload`, formData).pipe(
+      map((response) => response.data ?? response),
+      catchError(this.handleError),
+    );
   }
 
   uploadStoreFavicon(file: File): Observable<{ key: string; url: string }> {
@@ -152,34 +183,34 @@ export class StoreSettingsService {
     formData.append('file', file);
     formData.append('entityType', 'store_favicons');
 
-    return this.http
-      .post<any>(`${environment.apiUrl}/upload`, formData)
-      .pipe(
-        map((response) => response.data ?? response),
-        catchError(this.handleError)
-      );
+    return this.http.post<any>(`${environment.apiUrl}/upload`, formData).pipe(
+      map((response) => response.data ?? response),
+      catchError(this.handleError),
+    );
   }
 
   /**
    * Obtiene el estado de validación del horario del POS
    * Incluye información sobre si el usuario es admin
    */
-  getScheduleStatus(): Observable<ApiResponse<{
-    isWithinBusinessHours: boolean;
-    currentDay: string;
-    currentTime: string;
-    openTime?: string;
-    closeTime?: string;
-    nextOpenTime?: string;
-    message?: string;
-    isAdmin: boolean;
-    canBypass: boolean;
-  }>> {
+  getScheduleStatus(): Observable<
+    ApiResponse<{
+      isWithinBusinessHours: boolean;
+      currentDay: string;
+      currentTime: string;
+      openTime?: string;
+      closeTime?: string;
+      nextOpenTime?: string;
+      message?: string;
+      isAdmin: boolean;
+      canBypass: boolean;
+    }>
+  > {
     return this.http
       .get<ApiResponse<any>>(`${this.api_base_url}/settings/schedule-status`)
       .pipe(
         map((response) => response || { success: true, data: null }),
-        catchError(this.handleError)
+        catchError(this.handleError),
       );
   }
 
@@ -187,23 +218,58 @@ export class StoreSettingsService {
     settings: Partial<StoreSettings>,
   ): Observable<ApiResponse<StoreSettings>> {
     return this.http
-      .patch<ApiResponse<StoreSettings>>(
-        `${this.api_base_url}/settings`,
-        settings,
-      )
+      .patch<
+        ApiResponse<StoreSettings>
+      >(`${this.api_base_url}/settings`, settings)
       .pipe(
+        map((response) => response || { success: true, data: null }),
         tap((response) => {
+          this.cacheSettingsResponse(response);
+
           const store_settings = response?.data;
           if (!store_settings) return;
 
-          this.store.dispatch(AuthActions.updateStoreSettingsSuccess({ store_settings }));
-          if (store_settings.general?.currency) {
-            this.currencyFormatService.refresh();
-          }
+          this.store.dispatch(
+            AuthActions.updateStoreSettingsSuccess({ store_settings }),
+          );
+          this.syncCurrencyFromSettings(store_settings);
         }),
-        map((response) => response || { success: true, data: null }),
-        catchError(this.handleError)
+        catchError(this.handleError),
       );
+  }
+
+  private cacheSettingsResponse(response: ApiResponse<StoreSettings>): void {
+    this.settings_cache = response;
+    this.settings_cache_time = Date.now();
+  }
+
+  private publishStoreSettings(response: ApiResponse<StoreSettings>): void {
+    const store_settings = response?.data;
+    if (!store_settings) return;
+
+    this.store.dispatch(AuthActions.updateStoreSettings({ store_settings }));
+    this.syncCurrencyFromSettings(store_settings);
+  }
+
+  private syncCurrencyFromSettings(store_settings: StoreSettings): void {
+    const currencyCode = store_settings.general?.currency;
+    if (!currencyCode) return;
+
+    void this.currencyFormatService.loadCurrencyForCode(currencyCode);
+  }
+
+  private handleSettingsReadError(
+    error: any,
+  ): Observable<ApiResponse<StoreSettings>> {
+    if (this.settings_cache) {
+      console.warn(
+        'StoreSettingsService: using cached settings after read error',
+        error,
+      );
+      return of(this.settings_cache);
+    }
+
+    return this.handleError(error);
   }
 
   private fiscalDataUrl(options?: StoreFiscalDataRequestOptions): string {

--- a/apps/frontend/src/app/shared/components/notifications-dropdown/notifications-dropdown.component.ts
+++ b/apps/frontend/src/app/shared/components/notifications-dropdown/notifications-dropdown.component.ts
@@ -6,7 +6,9 @@ import {
   computed,
   signal,
 } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { Router } from '@angular/router';
+import { map, timer } from 'rxjs';
 import { IconComponent } from '../icon/icon.component';
 import {
   NotificationsFacade,
@@ -93,6 +95,10 @@ export class NotificationsDropdownComponent {
   private router = inject(Router);
 
   readonly isOpen = signal(false);
+  private readonly relativeTimeNow = toSignal(
+    timer(0, 60_000).pipe(map(() => Date.now())),
+    { initialValue: Date.now() },
+  );
 
   // Signal-based properties from facade
   readonly notifications = this.notifFacade.notifications;
@@ -190,8 +196,7 @@ export class NotificationsDropdownComponent {
   formatTime(dateStr: string): string {
     try {
       const date = new Date(dateStr);
-      const now = new Date();
-      const diff = now.getTime() - date.getTime();
+      const diff = this.relativeTimeNow() - date.getTime();
       const minutes = Math.floor(diff / 60000);
       const hours = Math.floor(diff / 3600000);
 

--- a/apps/frontend/src/app/shared/components/selector/selector.component.ts
+++ b/apps/frontend/src/app/shared/components/selector/selector.component.ts
@@ -68,7 +68,7 @@ export type SelectorVariant = 'default' | 'outline' | 'filled';
           <select
             [id]="id()"
             [class]="selectClasses"
-            [disabled]="disabled()"
+            [disabled]="isDisabled()"
             [required]="required()"
             [ngModel]="selectedValue()"
             (ngModelChange)="onModelChange($event)"
@@ -122,6 +122,7 @@ export class SelectorComponent implements ControlValueAccessor {
   readonly errorText = input<string>('');
   readonly required = input<boolean>(false);
   readonly disabled = input<boolean>(false);
+  readonly disabledState = signal(false);
   readonly size = input<SelectorSize>('md');
   readonly variant = input<SelectorVariant>('default');
   readonly styleVariant = input<FormStyleVariant>('modern');
@@ -151,8 +152,12 @@ export class SelectorComponent implements ControlValueAccessor {
     this.onTouched = fn;
   }
 
-  setDisabledState(_isDisabled: boolean): void {
-    // disabled is managed via input() signal — no action needed
+  setDisabledState(isDisabled: boolean): void {
+    this.disabledState.set(isDisabled);
+  }
+
+  isDisabled(): boolean {
+    return this.disabled() || this.disabledState();
   }
 
   onModelChange(value: string | number | null): void {
@@ -189,7 +194,7 @@ export class SelectorComponent implements ControlValueAccessor {
         'uppercase',
         'tracking-[0.05em]',
         'text-[var(--color-text-muted)]',
-        this.disabled() ? 'opacity-50 cursor-not-allowed' : '',
+        this.isDisabled() ? 'opacity-50 cursor-not-allowed' : '',
       ]
         .filter(Boolean)
         .join(' ');
@@ -199,7 +204,7 @@ export class SelectorComponent implements ControlValueAccessor {
       ...baseClasses,
       'text-sm',
       'text-[var(--color-text-primary)]',
-      this.disabled() ? 'opacity-50 cursor-not-allowed' : '',
+      this.isDisabled() ? 'opacity-50 cursor-not-allowed' : '',
     ]
       .filter(Boolean)
       .join(' ');
@@ -291,7 +296,7 @@ export class SelectorComponent implements ControlValueAccessor {
     return [
       'selector-placeholder',
       this.size() && `selector-placeholder-${this.size()}`,
-      this.disabled() ? 'selector-placeholder-disabled' : '',
+      this.isDisabled() ? 'selector-placeholder-disabled' : '',
     ]
       .filter(Boolean)
       .join(' ');

--- a/apps/frontend/src/app/shared/components/settings-modal/settings-modal.component.ts
+++ b/apps/frontend/src/app/shared/components/settings-modal/settings-modal.component.ts
@@ -337,25 +337,8 @@ export class SettingsModalComponent {
   filteredStandaloneModules: any[] = [];
 
   constructor() {
-    // Initialize panel_ui controls for ORG_ADMIN
-    const orgAdminControls: any = {};
-    APP_MODULES.ORG_ADMIN.forEach((module) => {
-      orgAdminControls[module.key] = [false]; // Default to false
-    });
-
-    // Initialize panel_ui controls for STORE_ADMIN (all modules including submodules)
-    const storeAdminControls: any = {};
-    APP_MODULES.STORE_ADMIN.forEach((module) => {
-      // For parent modules, initialize with true
-      // For child modules, also initialize with true (all enabled by default now)
-      storeAdminControls[module.key] = [false];
-      // Also initialize children if they exist
-      if (module.isParent && module.children) {
-        module.children.forEach((child) => {
-          storeAdminControls[child.key] = [false];
-        });
-      }
-    });
+    const orgAdminControls = this.createPanelUiControls('ORG_ADMIN');
+    const storeAdminControls = this.createPanelUiControls('STORE_ADMIN');
 
     this.settingsForm = this.fb.group({
       app: ['ORG_ADMIN', Validators.required],
@@ -484,6 +467,52 @@ export class SettingsModalComponent {
     });
 
     return modules;
+  }
+
+  private createPanelUiControls(appType: string): Record<string, [boolean]> {
+    const controls: Record<string, [boolean]> = {};
+    this.getAllModulesForAppType(appType).forEach((module: any) => {
+      controls[module.key] = [false];
+    });
+    return controls;
+  }
+
+  private buildPanelUiPatch(appType: string, config: any): Record<string, boolean> {
+    const defaults = this.defaultPanelUi?.[appType] || {};
+    const patch: Record<string, boolean> = {};
+
+    this.getAllModulesForAppType(appType).forEach((module: any) => {
+      const isNewKey =
+        !config.panel_ui?.[appType]?.hasOwnProperty(module.key) &&
+        !config.panel_ui?.hasOwnProperty(module.key);
+      const defaultValue = defaults[module.key] ?? false;
+      patch[module.key] = isNewKey
+        ? defaultValue
+        : (config.panel_ui?.[appType]?.[module.key] ??
+          config.panel_ui?.[module.key] ??
+          false);
+    });
+
+    return patch;
+  }
+
+  private syncChildControlStates(appType: string, patch: Record<string, boolean>): void {
+    APP_MODULES[appType as keyof typeof APP_MODULES]?.forEach((module: any) => {
+      if (!module.isParent || !module.children) return;
+
+      const parentEnabled = patch[module.key] === true;
+      module.children.forEach((child: any) => {
+        const childControl = this.settingsForm.get(
+          `panel_ui.${appType}.${child.key}`,
+        );
+        if (!childControl) return;
+        if (parentEnabled) {
+          childControl.enable({ emitEvent: false });
+        } else {
+          childControl.disable({ emitEvent: false });
+        }
+      });
+    });
   }
 
   /**
@@ -639,51 +668,8 @@ export class SettingsModalComponent {
       },
     };
 
-    // Update ORG_ADMIN modules
-    const orgDefaults = this.defaultPanelUi?.['ORG_ADMIN'] || {};
-    APP_MODULES.ORG_ADMIN.forEach((module) => {
-      const isNewKey =
-        !config.panel_ui?.ORG_ADMIN?.hasOwnProperty(module.key) &&
-        !config.panel_ui?.hasOwnProperty(module.key);
-      const defaultValue = orgDefaults[module.key] ?? false;
-      const currentValue = isNewKey
-        ? defaultValue
-        : (config.panel_ui?.ORG_ADMIN?.[module.key] ??
-          config.panel_ui?.[module.key] ??
-          false);
-      patchObj.panel_ui.ORG_ADMIN[module.key] = currentValue;
-    });
-
-    // Update STORE_ADMIN modules (including children)
-    const storeDefaults = this.defaultPanelUi?.['STORE_ADMIN'] || {};
-    APP_MODULES.STORE_ADMIN.forEach((module: any) => {
-      const isNewKey =
-        !config.panel_ui?.STORE_ADMIN?.hasOwnProperty(module.key) &&
-        !config.panel_ui?.hasOwnProperty(module.key);
-      const defaultValue = storeDefaults[module.key] ?? false;
-      const currentValue = isNewKey
-        ? defaultValue
-        : (config.panel_ui?.STORE_ADMIN?.[module.key] ??
-          config.panel_ui?.[module.key] ??
-          false);
-      patchObj.panel_ui.STORE_ADMIN[module.key] = currentValue;
-
-      // Also handle children if they exist
-      if (module.isParent && module.children) {
-        module.children.forEach((child: any) => {
-          const isChildNew =
-            !config.panel_ui?.STORE_ADMIN?.hasOwnProperty(child.key) &&
-            !config.panel_ui?.hasOwnProperty(child.key);
-          const childDefault = storeDefaults[child.key] ?? false;
-          const childValue = isChildNew
-            ? childDefault
-            : (config.panel_ui?.STORE_ADMIN?.[child.key] ??
-              config.panel_ui?.[child.key] ??
-              false);
-          patchObj.panel_ui.STORE_ADMIN[child.key] = childValue;
-        });
-      }
-    });
+    patchObj.panel_ui.ORG_ADMIN = this.buildPanelUiPatch('ORG_ADMIN', config);
+    patchObj.panel_ui.STORE_ADMIN = this.buildPanelUiPatch('STORE_ADMIN', config);
 
     // Update preferences
     const prefs = config.preferences || { language: 'es', theme: 'default' };
@@ -694,22 +680,8 @@ export class SettingsModalComponent {
     this.settingsForm.patchValue(patchObj);
 
     // Sync disabled state of child controls based on each parent's value
-    APP_MODULES.STORE_ADMIN.forEach((module: any) => {
-      if (!module.isParent || !module.children) return;
-      const parentEnabled =
-        patchObj.panel_ui.STORE_ADMIN[module.key] === true;
-      module.children.forEach((child: any) => {
-        const childControl = this.settingsForm.get(
-          `panel_ui.STORE_ADMIN.${child.key}`,
-        );
-        if (!childControl) return;
-        if (parentEnabled) {
-          childControl.enable({ emitEvent: false });
-        } else {
-          childControl.disable({ emitEvent: false });
-        }
-      });
-    });
+    this.syncChildControlStates('ORG_ADMIN', patchObj.panel_ui.ORG_ADMIN);
+    this.syncChildControlStates('STORE_ADMIN', patchObj.panel_ui.STORE_ADMIN);
   }
 
   getModulesForAppType(appType: string): any[] {
@@ -730,6 +702,7 @@ export class SettingsModalComponent {
     this.moduleSearchTerm = '';
     this.currentAppType = appType;
     this.settingsForm.patchValue({ app: appType });
+    this.recomputeFilteredModules();
   }
 
   selectTheme(theme: string) {

--- a/apps/frontend/src/app/shared/pipes/currency/currency.pipe.ts
+++ b/apps/frontend/src/app/shared/pipes/currency/currency.pipe.ts
@@ -55,11 +55,15 @@ export class CurrencyFormatService {
   private readonly http = inject(HttpClient);
   private readonly tenantFacade = inject(TenantFacade);
   private readonly CACHE_TTL = 5 * 60 * 1000; // 5 minutos
+  private readonly CURRENCIES_CACHE_TTL = 30 * 60 * 1000; // 30 minutos
 
   // Signals para estado reactivo
   private currentCurrencySignal = signal<Currency | null>(null);
   private loadingSignal = signal<boolean>(false);
   private lastFetchTime = 0;
+  private activeCurrencies: Currency[] | null = null;
+  private activeCurrenciesFetchTime = 0;
+  private activeCurrenciesPromise: Promise<Currency[] | null> | null = null;
 
   // Signals públicos de solo lectura
   readonly currentCurrency = this.currentCurrencySignal.asReadonly();
@@ -116,6 +120,11 @@ export class CurrencyFormatService {
         return null;
       }
 
+      const cachedCurrencyCode = this.getCurrencyCodeFromAuthState();
+      if (cachedCurrencyCode) {
+        return this.loadCurrencyForCode(cachedCurrencyCode, force);
+      }
+
       const storeId = this.tenantFacade.getCurrentStoreId();
       if (!storeId) {
         return null;
@@ -136,34 +145,89 @@ export class CurrencyFormatService {
 
       const currencyCode = settingsResponse.data.general.currency;
 
-      const currencyResponse = await firstValueFrom(
-        this.http.get<{ success: boolean; data: Currency[]; message?: string }>(
-          `${environment.apiUrl}/public/currencies/active`,
-        ),
-      );
-
-      if (!currencyResponse.success || !currencyResponse.data) {
-        return null;
-      }
-
-      const currency = currencyResponse.data.find(
-        (c: Currency) => c.code === currencyCode,
-      );
-
-      if (!currency) {
-        return null;
-      }
-
-      this.currentCurrencySignal.set(currency);
-      this.lastFetchTime = Date.now();
-
-      return currency;
+      return this.loadCurrencyForCode(currencyCode, force);
     } catch (error) {
       console.error('[CurrencyFormat] Error fetching currency:', error);
       return null;
     } finally {
       this.loadingSignal.set(false);
     }
+  }
+
+  async loadCurrencyForCode(
+    currencyCode: string,
+    force = false,
+  ): Promise<Currency | null> {
+    if (!currencyCode) {
+      return null;
+    }
+
+    const current = this.currentCurrency();
+    if (
+      !force &&
+      current?.code === currencyCode &&
+      Date.now() - this.lastFetchTime < this.CACHE_TTL
+    ) {
+      return current;
+    }
+
+    const currencies = await this.loadActiveCurrencies(force);
+    if (!currencies) {
+      return null;
+    }
+
+    const currency = currencies.find((c: Currency) => c.code === currencyCode);
+    if (!currency) {
+      return null;
+    }
+
+    this.currentCurrencySignal.set(currency);
+    this.lastFetchTime = Date.now();
+
+    return currency;
+  }
+
+  private async loadActiveCurrencies(
+    force = false,
+  ): Promise<Currency[] | null> {
+    if (
+      !force &&
+      this.activeCurrencies &&
+      Date.now() - this.activeCurrenciesFetchTime < this.CURRENCIES_CACHE_TTL
+    ) {
+      return this.activeCurrencies;
+    }
+
+    if (this.activeCurrenciesPromise) {
+      return this.activeCurrenciesPromise;
+    }
+
+    this.activeCurrenciesPromise = firstValueFrom(
+      this.http.get<{ success: boolean; data: Currency[]; message?: string }>(
+        `${environment.apiUrl}/public/currencies/active`,
+      ),
+    )
+      .then((currencyResponse) => {
+        if (!currencyResponse.success || !currencyResponse.data) {
+          return null;
+        }
+
+        this.activeCurrencies = currencyResponse.data;
+        this.activeCurrenciesFetchTime = Date.now();
+        return this.activeCurrencies;
+      })
+      .catch((error) => {
+        console.error(
+          '[CurrencyFormat] Error fetching active currencies:',
+          error,
+        );
+        return this.activeCurrencies;
+      })
+      .finally(() => {
+        this.activeCurrenciesPromise = null;
+      });
+
+    return this.activeCurrenciesPromise;
   }
 
   /**
@@ -181,19 +245,37 @@ export class CurrencyFormatService {
     }
   }
 
+  private getCurrencyCodeFromAuthState(): string | null {
+    try {
+      if (typeof localStorage === 'undefined') return null;
+      const authState = localStorage.getItem('vendix_auth_state');
+      if (!authState) return null;
+      const parsed = JSON.parse(authState);
+      return parsed?.store_settings?.general?.currency ?? null;
+    } catch {
+      return null;
+    }
+  }
+
   private getLocaleForStyle(style?: string): string {
     switch (style) {
-      case 'dot_comma':   return 'de-DE';
-      case 'space_comma': return 'fr-FR';
+      case 'dot_comma':
+        return 'de-DE';
+      case 'space_comma':
+        return 'fr-FR';
       case 'comma_dot':
-      default:            return 'en-US';
+      default:
+        return 'en-US';
     }
   }
 
   /**
    * Formatea un monto con la moneda actual
    */
-  format(amount: number | string | null | undefined, decimals?: number): string {
+  format(
+    amount: number | string | null | undefined,
+    decimals?: number,
+  ): string {
     const num = Number(amount) || 0;
     const currency = this.currentCurrency();
     if (!currency) {
@@ -238,7 +320,9 @@ export class CurrencyFormatService {
     } else if (Math.abs(num) >= 1_000) {
       formatted = `${(num / 1_000).toFixed(1)}K`;
     } else {
-      formatted = Math.round(num).toLocaleString(this.getLocaleForStyle(currency?.format_style));
+      formatted = Math.round(num).toLocaleString(
+        this.getLocaleForStyle(currency?.format_style),
+      );
     }
 
     return position === 'before'


### PR DESCRIPTION
## Summary
- POS supports per-product price override at sale time with audit trail
- POS supports custom (catalog-free) items with free-form description
- SaaS domain root provisioning + custom domain SSL/CORS hardening
- Store settings persistence + ecommerce hydration fixes
- CI scoped to changed apps; module refactors across coupons, promotions, quotations, customers

## ⚠️ DATABASE MIGRATION
> **ATTENTION**: Run migrations before deployment.

\`\`\`sql
ALTER TABLE "products"
  ADD COLUMN IF NOT EXISTS "allow_pos_price_override" BOOLEAN NOT NULL DEFAULT false;

ALTER TABLE "order_items"
  ADD COLUMN IF NOT EXISTS "catalog_unit_price" DECIMAL(12, 2),
  ADD COLUMN IF NOT EXISTS "catalog_final_price" DECIMAL(12, 2),
  ADD COLUMN IF NOT EXISTS "final_unit_price" DECIMAL(12, 2),
  ADD COLUMN IF NOT EXISTS "is_price_overridden" BOOLEAN NOT NULL DEFAULT false,
  ADD COLUMN IF NOT EXISTS "price_override_reason" VARCHAR(500),
  ADD COLUMN IF NOT EXISTS "price_overridden_by_user_id" INTEGER,
  ADD COLUMN IF NOT EXISTS "description" TEXT;
\`\`\`

**Migration safety:**
- All columns nullable or defaulted — no backfill required
- Idempotent (`IF NOT EXISTS`)
- No destructive operations, no FK cascade risk

## Included Commits
- feat: add POS custom items, price override, and module refactors
- fix: show tenant names in public pages
- fix: allow active custom domain cors origins
- fix: keep validated apex routing complete
- fix: explain domain provisioning wait states
- fix: clarify pending certificate dns state
- fix: clarify domain certificate setup flow
- chore: add site verification files
- feat: add SaaS domain root provisioning
- feat: improve custom domain setup flow
- feat: improve custom domain ssl provisioning
- fix: hydrate store settings on environment switch
- fix: correct sharp import for image uploads
- ci: scope checks to changed apps
- ci: run checks only on pull requests
- docs: document scoped Prisma unique query errors
- fix: restore ecommerce settings persistence
- fix: harden store settings persistence

## Test Plan
- [ ] Run `prisma migrate deploy` in staging; verify `_prisma_migrations` row added
- [ ] POS: toggle `allow_pos_price_override` on a product and override price during sale
- [ ] POS: add custom item with description and complete order
- [ ] Verify `order_items` rows store `catalog_unit_price`, `final_unit_price`, `is_price_overridden`, `price_overridden_by_user_id`
- [ ] Verify coupons + promotions still apply correctly in POS
- [ ] Custom domain: provision new domain, confirm CORS allows active origins
- [ ] Store settings: confirm persistence + hydration on environment switch
- [ ] Sanity check ecommerce checkout end-to-end