### PR TITLE
fix: filtrar marcas del ecommerce por store_id

### DIFF
--- a/apps/backend/src/domains/ecommerce/catalog/catalog.service.ts
+++ b/apps/backend/src/domains/ecommerce/catalog/catalog.service.ts
@@ -368,9 +368,12 @@ export class CatalogService {
   }
 
   async getBrands() {
+    const store_id = RequestContextService.getStoreId();
+
     const brands = await this.prisma.brands.findMany({
       where: {
         state: 'active',
+        store_id,
       },
       orderBy: { name: 'asc' },
       select: {


### PR DESCRIPTION
## Resumen

Las marcas creadas desde una tienda se visualizaban en el catálogo ecommerce de otras tiendas, porque el endpoint `GET /ecommerce/catalog/brands` no filtraba por `store_id`.

## Causa

`EcommercePrismaService` expone `brands` como modelo global (`this.baseClient.brands`) sin auto-scope de tienda. El query solo filtraba por `state: 'active'`.

## Cambio

Agregar filtro `store_id` en `CatalogService.getBrands()` usando `RequestContextService.getStoreId()`, siguiendo el mismo patrón de `getProducts()` y `getPublicConfig()`.

## Archivo modificado

- `apps/backend/src/domains/ecommerce/catalog/catalog.service.ts`