### PR TITLE
feat: modo horarios continuo/personalizado en POS

### DIFF
--- a/apps/backend/src/domains/store/settings/defaults/default-store-settings.ts
+++ b/apps/backend/src/domains/store/settings/defaults/default-store-settings.ts
@@ -81,6 +81,7 @@ export function getDefaultStoreSettings(): StoreSettings {
       allow_anonymous_sales: true,
       anonymous_sales_as_default: true,
       business_hours: getDefaultBusinessHours(),
+      schedule_mode: 'continuous',
       enable_schedule_validation: false,
       offline_mode_enabled: false,
       require_cash_drawer_open: false,

--- a/apps/backend/src/domains/store/settings/dto/settings-schemas.dto.ts
+++ b/apps/backend/src/domains/store/settings/dto/settings-schemas.dto.ts
@@ -304,6 +304,11 @@ export class PosSettingsDto {
   @IsBoolean()
   enable_schedule_validation?: boolean;
 
+  @ApiProperty({ enum: ['continuous', 'custom'], example: 'continuous', required: false })
+  @IsOptional()
+  @IsIn(['continuous', 'custom'])
+  schedule_mode?: 'continuous' | 'custom';
+
   @ApiProperty({ example: false, required: false })
   @IsOptional()
   @IsBoolean()

--- a/apps/backend/src/domains/store/settings/interfaces/store-settings.interface.ts
+++ b/apps/backend/src/domains/store/settings/interfaces/store-settings.interface.ts
@@ -344,6 +344,7 @@ export interface PosSettings {
   allow_anonymous_sales: boolean;
   anonymous_sales_as_default: boolean;
   business_hours: Record<string, BusinessHours>;
+  schedule_mode?: 'continuous' | 'custom';
   enable_schedule_validation: boolean;
   offline_mode_enabled: boolean;
   require_cash_drawer_open: boolean;
@@ -381,9 +382,15 @@ export interface ReceiptsSettings {
   receipt_footer: string;
 }
 
+export interface BusinessHoursBlock {
+  open: string;
+  close: string;
+}
+
 export interface BusinessHours {
   open: string;
   close: string;
+  blocks?: BusinessHoursBlock[];
 }
 
 // ============================================================================

--- a/apps/backend/src/domains/store/settings/migrations/settings-migrator.service.ts
+++ b/apps/backend/src/domains/store/settings/migrations/settings-migrator.service.ts
@@ -4,7 +4,7 @@ import { Injectable, Logger } from '@nestjs/common';
  * Current schema version for store_settings JSON.
  * Bump when adding a new migration entry to MIGRATIONS.
  */
-export const CURRENT_SCHEMA_VERSION = 1;
+export const CURRENT_SCHEMA_VERSION = 2;
 
 export interface SettingsMigration {
   from: number;
@@ -36,6 +36,16 @@ export const MIGRATIONS: SettingsMigration[] = [
       // Drop legacy `app` block — branding is the source of truth.
       if (raw && raw.app !== undefined) {
         delete raw.app;
+      }
+      return raw;
+    },
+  },
+  {
+    from: 1,
+    to: 2,
+    apply: (raw: any) => {
+      if (raw?.pos && !raw.pos.schedule_mode) {
+        raw.pos.schedule_mode = 'continuous';
       }
       return raw;
     },

--- a/apps/backend/src/domains/store/settings/schedule-validation.service.ts
+++ b/apps/backend/src/domains/store/settings/schedule-validation.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, ForbiddenException, Logger } from '@nestjs/common';
 import { StorePrismaService } from '../../../prisma/services/store-prisma.service';
 import { RequestContextService } from '@common/context/request-context.service';
-import { BusinessHours } from './interfaces/store-settings.interface';
+import { BusinessHours, BusinessHoursBlock } from './interfaces/store-settings.interface';
 import { mergeStoreSettingsWithDefaults } from './defaults/default-store-settings';
 
 export interface ScheduleValidationResult {
@@ -10,6 +10,7 @@ export interface ScheduleValidationResult {
   currentTime: string;
   openTime?: string;
   closeTime?: string;
+  activeBlocks?: BusinessHoursBlock[];
   nextOpenTime?: string;
   message?: string;
 }
@@ -118,7 +119,61 @@ export class ScheduleValidationService {
       };
     }
 
-    // Verificar si está cerrado
+    // Custom mode: multiple blocks per day
+    if (todayHours.blocks && todayHours.blocks.length > 0) {
+      const allClosed = todayHours.blocks.every(
+        (b) => b.open === 'closed' || b.close === 'closed',
+      );
+      if (allClosed) {
+        const nextOpen = this.getNextOpenDay(businessHours, day, curMinutes);
+        return {
+          isWithinBusinessHours: false,
+          currentDay: this.getCurrentDayNameSpanish(currentDayName),
+          currentTime,
+          nextOpenTime: nextOpen,
+          activeBlocks: todayHours.blocks,
+          message: `El establecimiento está cerrado hoy (${this.getCurrentDayNameSpanish(currentDayName)}). Horario próximo: ${nextOpen}`,
+        };
+      }
+
+      let withinAnyBlock = false;
+      for (const block of todayHours.blocks) {
+        if (
+          block.open !== 'closed' &&
+          block.close !== 'closed' &&
+          this.isTimeWithinRange(currentTime, block.open, block.close)
+        ) {
+          withinAnyBlock = true;
+          break;
+        }
+      }
+
+      const blocksText = this.formatBlocks(todayHours.blocks);
+
+      if (withinAnyBlock) {
+        return {
+          isWithinBusinessHours: true,
+          currentDay: this.getCurrentDayNameSpanish(currentDayName),
+          currentTime,
+          activeBlocks: todayHours.blocks.filter(
+            (b) => b.open !== 'closed' && b.close !== 'closed',
+          ),
+          message: `Horario de atención: ${blocksText}`,
+        };
+      }
+
+      const nextOpen = this.getNextOpenDay(businessHours, day, curMinutes);
+      return {
+        isWithinBusinessHours: false,
+        currentDay: this.getCurrentDayNameSpanish(currentDayName),
+        currentTime,
+        activeBlocks: todayHours.blocks,
+        nextOpenTime: nextOpen,
+        message: `El horario de atención es: ${blocksText}. Fuera de horario. Próxima apertura: ${nextOpen}`,
+      };
+    }
+
+    // Continuous mode: single open/close block (original logic)
     if (todayHours.open === 'closed' || todayHours.close === 'closed') {
       const nextOpen = this.getNextOpenDay(businessHours, day, curMinutes);
       return {
@@ -132,7 +187,6 @@ export class ScheduleValidationService {
       };
     }
 
-    // Validar horario
     const isWithin = this.isTimeWithinRange(
       currentTime,
       todayHours.open,
@@ -282,6 +336,13 @@ export class ScheduleValidationService {
     return `${hours}:${minutes}`;
   }
 
+  private formatBlocks(blocks: BusinessHoursBlock[]): string {
+    return blocks
+      .filter((b) => b.open !== 'closed' && b.close !== 'closed')
+      .map((b) => `${b.open} - ${b.close}`)
+      .join(', ');
+  }
+
   private isTimeWithinRange(
     current: string,
     open: string,
@@ -329,15 +390,27 @@ export class ScheduleValidationService {
     // First check if today opens later (before opening hour)
     const todayName = dayNames[currentDay];
     const todayHours = businessHours[todayName];
-    if (
-      todayHours &&
-      todayHours.open !== 'closed' &&
-      todayHours.close !== 'closed'
-    ) {
-      const [openH, openM] = todayHours.open.split(':').map(Number);
-      const openMinutes = openH * 60 + openM;
-      if (currentMinutes < openMinutes) {
-        return `Hoy ${todayHours.open} - ${todayHours.close}`;
+
+    if (todayHours) {
+      if (todayHours.blocks && todayHours.blocks.length > 0) {
+        for (const block of todayHours.blocks) {
+          if (block.open !== 'closed' && block.close !== 'closed') {
+            const [openH, openM] = block.open.split(':').map(Number);
+            const openMinutes = openH * 60 + openM;
+            if (currentMinutes < openMinutes) {
+              return `Hoy ${this.formatBlocks(todayHours.blocks)}`;
+            }
+          }
+        }
+      } else if (
+        todayHours.open !== 'closed' &&
+        todayHours.close !== 'closed'
+      ) {
+        const [openH, openM] = todayHours.open.split(':').map(Number);
+        const openMinutes = openH * 60 + openM;
+        if (currentMinutes < openMinutes) {
+          return `Hoy ${todayHours.open} - ${todayHours.close}`;
+        }
       }
     }
 
@@ -347,7 +420,16 @@ export class ScheduleValidationService {
       const dayName = dayNames[dayIndex];
       const hours = businessHours[dayName];
 
-      if (hours && hours.open !== 'closed' && hours.close !== 'closed') {
+      if (!hours) continue;
+
+      if (hours.blocks && hours.blocks.length > 0) {
+        const hasOpen = hours.blocks.some(
+          (b) => b.open !== 'closed' && b.close !== 'closed',
+        );
+        if (hasOpen) {
+          return `${spanishDays[dayName]} ${this.formatBlocks(hours.blocks)}`;
+        }
+      } else if (hours.open !== 'closed' && hours.close !== 'closed') {
         return `${spanishDays[dayName]} ${hours.open} - ${hours.close}`;
       }
     }

--- a/apps/frontend/src/app/core/models/store-settings.interface.ts
+++ b/apps/frontend/src/app/core/models/store-settings.interface.ts
@@ -162,6 +162,7 @@ export interface PosSettings {
   allow_anonymous_sales: boolean;
   anonymous_sales_as_default: boolean;
   business_hours: Record<string, BusinessHours>;
+  schedule_mode?: 'continuous' | 'custom';
   enable_schedule_validation: boolean;
   show_onscreen_keypad: boolean;
   require_cash_drawer_open: boolean;
@@ -210,9 +211,15 @@ export interface ReceiptsSettings {
   receipt_footer: string;
 }
 
+export interface BusinessHoursBlock {
+  open: string;
+  close: string;
+}
+
 export interface BusinessHours {
   open: string;
   close: string;
+  blocks?: BusinessHoursBlock[];
 }
 
 export interface ApiResponse<T> {

--- a/apps/frontend/src/app/private/modules/store/pos/components/pos-header-dropdown.component.ts
+++ b/apps/frontend/src/app/private/modules/store/pos/components/pos-header-dropdown.component.ts
@@ -7,6 +7,7 @@ import {
 } from '@angular/core';
 import { NgClass, DatePipe } from '@angular/common';
 import { IconComponent } from '../../../../../shared/components/icon/icon.component';
+import type { BusinessHours } from '../../../../../core/models/store-settings.interface';
 import { CashRegisterSession } from '../services/pos-cash-register.service';
 import { PosCustomer } from '../models/customer.model';
 
@@ -132,7 +133,7 @@ import { PosCustomer } from '../models/customer.model';
                       isWithinHours() ? 'text-green-600/70' : 'text-red-500/70'
                     "
                   >
-                    {{ todayHours()!.open }} – {{ todayHours()!.close }}
+                    {{ formatHoursText() }}
                   </span>
                 }
               </div>
@@ -212,7 +213,7 @@ export class PosHeaderDropdownComponent {
   readonly scheduleEnabled = input<boolean>(false);
   readonly isWithinHours = input<boolean>(false);
   readonly isDayClosed = input<boolean>(false);
-  readonly todayHours = input<{ open: string; close: string } | null>(null);
+  readonly todayHours = input<BusinessHours | null>(null);
   readonly cashSession = input<CashRegisterSession | null>(null);
   readonly showCashOpenButton = input<boolean>(false);
 
@@ -242,5 +243,17 @@ export class PosHeaderDropdownComponent {
 
   toggleDropdown(): void {
     this.isOpen.update(v => !v);
+  }
+
+  formatHoursText(): string {
+    const hours = this.todayHours();
+    if (!hours) return '';
+    if (hours.blocks && hours.blocks.length > 0) {
+      return hours.blocks
+        .filter(b => b.open !== 'closed' && b.close !== 'closed')
+        .map(b => `${b.open} – ${b.close}`)
+        .join(', ');
+    }
+    return `${hours.open} – ${hours.close}`;
   }
 }

--- a/apps/frontend/src/app/private/modules/store/pos/components/pos-payment-interface.component.ts
+++ b/apps/frontend/src/app/private/modules/store/pos/components/pos-payment-interface.component.ts
@@ -1483,7 +1483,7 @@ export class PosPaymentInterfaceComponent {
   readonly showOnscreenKeypad = computed(
     () => this.settingsFacade.pos()?.show_onscreen_keypad !== false,
   );
-  readonly businessHours = computed<Record<string, { open: string; close: string }>>(
+  readonly businessHours = computed<Record<string, { open: string; close: string; blocks?: Array<{ open: string; close: string }> }>>(
     () => (this.settingsFacade.pos()?.business_hours as any) ?? {},
   );
   readonly defaultPaymentForm = computed<'contado' | 'credito'>(
@@ -1736,11 +1736,23 @@ export class PosPaymentInterfaceComponent {
       return true;
     }
 
-    if (todayHours.open === 'closed' || todayHours.close === 'closed') {
+    const currentTime = now.getHours() * 60 + now.getMinutes();
+
+    // Custom mode: multiple blocks
+    if (todayHours.blocks && todayHours.blocks.length > 0) {
+      for (const block of todayHours.blocks) {
+        if (block.open === 'closed' || block.close === 'closed') continue;
+        const [oH, oM] = block.open.split(':').map(Number);
+        const [cH, cM] = block.close.split(':').map(Number);
+        if (currentTime >= oH * 60 + oM && currentTime <= cH * 60 + cM) return true;
+      }
       return false;
     }
 
-    const currentTime = now.getHours() * 60 + now.getMinutes();
+    // Continuous mode
+    if (todayHours.open === 'closed' || todayHours.close === 'closed') {
+      return false;
+    }
 
     const [openHour, openMinute] = todayHours.open.split(':').map(Number);
     const [closeHour, closeMinute] = todayHours.close.split(':').map(Number);

--- a/apps/frontend/src/app/private/modules/store/pos/components/pos-payment-interface.component.ts
+++ b/apps/frontend/src/app/private/modules/store/pos/components/pos-payment-interface.component.ts
@@ -51,6 +51,7 @@ import {
 import { CartState } from '../models/cart.model';
 import { PosCustomer } from '../models/customer.model';
 import { StoreSettingsFacade } from '../../../../../core/store/store-settings/store-settings.facade';
+import type { BusinessHours } from '../../../../../core/models/store-settings.interface';
 
 interface PaymentState {
   selectedMethod: PaymentMethod | null;
@@ -1483,7 +1484,7 @@ export class PosPaymentInterfaceComponent {
   readonly showOnscreenKeypad = computed(
     () => this.settingsFacade.pos()?.show_onscreen_keypad !== false,
   );
-  readonly businessHours = computed<Record<string, { open: string; close: string; blocks?: Array<{ open: string; close: string }> }>>(
+  readonly businessHours = computed<Record<string, BusinessHours>>(
     () => (this.settingsFacade.pos()?.business_hours as any) ?? {},
   );
   readonly defaultPaymentForm = computed<'contado' | 'credito'>(

--- a/apps/frontend/src/app/private/modules/store/pos/components/pos-schedule-indicator.component.ts
+++ b/apps/frontend/src/app/private/modules/store/pos/components/pos-schedule-indicator.component.ts
@@ -1,6 +1,7 @@
 
 import { Component, input, output } from '@angular/core';
 import { IconComponent } from '../../../../../shared/components/icon/icon.component';
+import type { BusinessHours } from '../../../../../core/models/store-settings.interface';
 
 @Component({
   selector: 'app-pos-schedule-indicator',
@@ -101,7 +102,7 @@ import { IconComponent } from '../../../../../shared/components/icon/icon.compon
 })
 export class PosScheduleIndicatorComponent {
   readonly isWithinHours = input<boolean>(false);
-  readonly todayHours = input<{ open: string; close: string } | null>(null);
+  readonly todayHours = input<BusinessHours | null>(null);
   readonly isDayClosed = input<boolean>(false);
   readonly enabled = input<boolean>(false);
 
@@ -110,6 +111,12 @@ export class PosScheduleIndicatorComponent {
   hoursText(): string {
     const hours = this.todayHours();
     if (!hours) return '';
+    if (hours.blocks && hours.blocks.length > 0) {
+      return hours.blocks
+        .filter(b => b.open !== 'closed' && b.close !== 'closed')
+        .map(b => `${b.open} – ${b.close}`)
+        .join(', ');
+    }
     return `${hours.open} – ${hours.close}`;
   }
 }

--- a/apps/frontend/src/app/private/modules/store/pos/components/pos-schedule-modal.component.ts
+++ b/apps/frontend/src/app/private/modules/store/pos/components/pos-schedule-modal.component.ts
@@ -5,6 +5,7 @@ import {
   ModalComponent,
   IconComponent,
 } from '../../../../../shared/components';
+import type { BusinessHours } from '../../../../../core/models/store-settings.interface';
 
 @Component({
   selector: 'app-pos-schedule-modal',
@@ -122,7 +123,7 @@ import {
 })
 export class PosScheduleModalComponent {
   readonly isOpen = input<boolean>(false);
-  readonly businessHours = input<Record<string, { open: string; close: string }>>({});
+  readonly businessHours = input<Record<string, BusinessHours>>({});
   readonly isWithinHours = input<boolean>(false);
   readonly todayKey = input<string>('');
 
@@ -141,12 +142,22 @@ export class PosScheduleModalComponent {
 
   isDayClosed(key: string): boolean {
     const hours = this.businessHours()[key];
-    return !hours || !hours.open || !hours.close;
+    if (!hours) return true;
+    if (hours.blocks && hours.blocks.length > 0) {
+      return hours.blocks.every(b => b.open === 'closed' || b.close === 'closed');
+    }
+    return !hours.open || !hours.close || hours.open === 'closed';
   }
 
   getDayHours(key: string): string {
     const hours = this.businessHours()[key];
     if (!hours) return 'Cerrado';
+    if (hours.blocks && hours.blocks.length > 0) {
+      return hours.blocks
+        .filter(b => b.open !== 'closed' && b.close !== 'closed')
+        .map(b => `${b.open} – ${b.close}`)
+        .join(', ');
+    }
     return `${hours.open} – ${hours.close}`;
   }
 

--- a/apps/frontend/src/app/private/modules/store/pos/components/pos-schedule-modal.component.ts
+++ b/apps/frontend/src/app/private/modules/store/pos/components/pos-schedule-modal.component.ts
@@ -146,7 +146,7 @@ export class PosScheduleModalComponent {
     if (hours.blocks && hours.blocks.length > 0) {
       return hours.blocks.every(b => b.open === 'closed' || b.close === 'closed');
     }
-    return !hours.open || !hours.close || hours.open === 'closed';
+    return !hours.open || !hours.close || hours.open === 'closed' || hours.close === 'closed';
   }
 
   getDayHours(key: string): string {

--- a/apps/frontend/src/app/private/modules/store/pos/pos.component.ts
+++ b/apps/frontend/src/app/private/modules/store/pos/pos.component.ts
@@ -56,6 +56,7 @@ import { PosMobileFooterComponent } from './components/pos-mobile-footer.compone
 import { PosCartModalComponent } from './components/pos-cart-modal.component';
 import { PosShippingModalComponent } from './components/pos-shipping-modal/pos-shipping-modal.component';
 import { StoreSettingsService } from '../settings/general/services/store-settings.service';
+import type { BusinessHours } from '../../../../core/models/store-settings.interface';
 import { QuotationsService } from '../quotations/services/quotations.service';
 import { LayawayApiService } from '../layaway/services/layaway.service';
 import { LayawayConfigModalComponent } from './components/layaway-config-modal/layaway-config-modal.component';
@@ -867,14 +868,19 @@ export class PosComponent {
     }
   }
 
-  get todaySchedule(): { open: string; close: string } | null {
+  get todaySchedule(): BusinessHours | null {
     const hours = this.businessHours()[this.todayKey];
-    if (!hours || !hours.open || !hours.close) return null;
+    if (!hours) return null;
     return hours;
   }
 
   get isTodayClosed(): boolean {
-    return this.todaySchedule === null;
+    const schedule = this.todaySchedule;
+    if (!schedule) return true;
+    if (schedule.blocks && schedule.blocks.length > 0) {
+      return schedule.blocks.every(b => b.open === 'closed' || b.close === 'closed');
+    }
+    return !schedule.open || !schedule.close || schedule.open === 'closed';
   }
 
   // Customer Queue
@@ -903,7 +909,7 @@ export class PosComponent {
 
   // Store settings for schedule validation
   enableScheduleValidation = signal(false);
-  businessHours = signal<Record<string, { open: string; close: string }>>({});
+  businessHours = signal<Record<string, BusinessHours>>({});
 
   // Admin bypass for schedule validation
   isAdmin = signal(false);
@@ -2244,11 +2250,25 @@ export class PosComponent {
       return true;
     }
 
-    if (todayHours.open === 'closed' || todayHours.close === 'closed') {
+    const currentTime = hours * 60 + minutes;
+
+    // Custom mode: multiple blocks
+    if (todayHours.blocks && todayHours.blocks.length > 0) {
+      for (const block of todayHours.blocks) {
+        if (block.open === 'closed' || block.close === 'closed') continue;
+        const [oH, oM] = block.open.split(':').map(Number);
+        const [cH, cM] = block.close.split(':').map(Number);
+        const openTime = oH * 60 + oM;
+        const closeTime = cH * 60 + cM;
+        if (currentTime >= openTime && currentTime <= closeTime) return true;
+      }
       return false;
     }
 
-    const currentTime = hours * 60 + minutes;
+    // Continuous mode: single block
+    if (todayHours.open === 'closed' || todayHours.close === 'closed') {
+      return false;
+    }
 
     const [openHour, openMinute] = todayHours.open.split(':').map(Number);
     const [closeHour, closeMinute] = todayHours.close.split(':').map(Number);
@@ -2284,14 +2304,22 @@ export class PosComponent {
 
     const todayName = dayNames[day];
     const todayHours = this.businessHours()?.[todayName];
-    if (
-      todayHours &&
-      todayHours.open !== 'closed' &&
-      todayHours.close !== 'closed'
-    ) {
-      const [openH, openM] = todayHours.open.split(':').map(Number);
-      if (curMinutes < openH * 60 + openM) {
-        return `Hoy ${todayHours.open} - ${todayHours.close}`;
+
+    if (todayHours) {
+      if (todayHours.blocks && todayHours.blocks.length > 0) {
+        for (const block of todayHours.blocks) {
+          if (block.open !== 'closed' && block.close !== 'closed') {
+            const [openH, openM] = block.open.split(':').map(Number);
+            if (curMinutes < openH * 60 + openM) {
+              return `Hoy ${this.formatBlocksForDisplay(todayHours.blocks)}`;
+            }
+          }
+        }
+      } else if (todayHours.open !== 'closed' && todayHours.close !== 'closed') {
+        const [openH, openM] = todayHours.open.split(':').map(Number);
+        if (curMinutes < openH * 60 + openM) {
+          return `Hoy ${todayHours.open} - ${todayHours.close}`;
+        }
       }
     }
 
@@ -2299,12 +2327,26 @@ export class PosComponent {
       const dayIndex = (day + i) % 7;
       const dayName = dayNames[dayIndex];
       const bh = this.businessHours()?.[dayName];
-      if (bh && bh.open !== 'closed' && bh.close !== 'closed') {
+      if (!bh) continue;
+
+      if (bh.blocks && bh.blocks.length > 0) {
+        const hasOpen = bh.blocks.some(b => b.open !== 'closed' && b.close !== 'closed');
+        if (hasOpen) {
+          return `${spanishDays[dayName]} ${this.formatBlocksForDisplay(bh.blocks)}`;
+        }
+      } else if (bh.open !== 'closed' && bh.close !== 'closed') {
         return `${spanishDays[dayName]} ${bh.open} - ${bh.close}`;
       }
     }
 
     return 'Consultar configuración';
+  }
+
+  private formatBlocksForDisplay(blocks: Array<{ open: string; close: string }>): string {
+    return blocks
+      .filter(b => b.open !== 'closed' && b.close !== 'closed')
+      .map(b => `${b.open} - ${b.close}`)
+      .join(', ');
   }
 
   private initCashRegisterSession(): void {

--- a/apps/frontend/src/app/private/modules/store/pos/pos.component.ts
+++ b/apps/frontend/src/app/private/modules/store/pos/pos.component.ts
@@ -880,7 +880,7 @@ export class PosComponent {
     if (schedule.blocks && schedule.blocks.length > 0) {
       return schedule.blocks.every(b => b.open === 'closed' || b.close === 'closed');
     }
-    return !schedule.open || !schedule.close || schedule.open === 'closed';
+    return !schedule.open || !schedule.close || schedule.open === 'closed' || schedule.close === 'closed';
   }
 
   // Customer Queue

--- a/apps/frontend/src/app/private/modules/store/settings/general/components/pos-settings-form/pos-settings-form.component.html
+++ b/apps/frontend/src/app/private/modules/store/settings/general/components/pos-settings-form/pos-settings-form.component.html
@@ -286,7 +286,7 @@
           @if (isCustomMode()) {
             Personalizado: define múltiples bloques horarios por día
           } @else {
-            Continuo: un solo bloque de apertura y cierre por día
+            Continuo: un solo bloque de apertura y cierre por día. Los horarios se configuran desde el módulo de configuración general.
           }
         </p>
       </div>
@@ -356,26 +356,45 @@
                 </button>
               </div>
               @if (!isCustomDayClosed(day.key)) {
-                <div class="day-times">
-                  <div class="time-field">
-                    <label class="time-label">Apertura</label>
-                    <input
-                      type="time"
-                      [value]="getDayBlocks(day.key)[0]?.open || '08:00'"
-                      (change)="onBlockTimeChange(day.key, 0, 'open', $any($event).target.value)"
-                      class="time-input"
-                    />
-                  </div>
-                  <span class="time-separator">—</span>
-                  <div class="time-field">
-                    <label class="time-label">Cierre</label>
-                    <input
-                      type="time"
-                      [value]="getDayBlocks(day.key)[0]?.close || '18:00'"
-                      (change)="onBlockTimeChange(day.key, 0, 'close', $any($event).target.value)"
-                      class="time-input"
-                    />
-                  </div>
+                <div class="blocks-container">
+                  @for (block of getDayBlocks(day.key); track $index) {
+                    <div class="block-row">
+                      <span class="block-label">Bloque {{ $index + 1 }}</span>
+                      <div class="time-field">
+                        <input
+                          type="time"
+                          [value]="block.open"
+                          (change)="onBlockTimeChange(day.key, $index, 'open', $any($event).target.value)"
+                          class="time-input"
+                        />
+                      </div>
+                      <span class="time-separator">—</span>
+                      <div class="time-field">
+                        <input
+                          type="time"
+                          [value]="block.close"
+                          (change)="onBlockTimeChange(day.key, $index, 'close', $any($event).target.value)"
+                          class="time-input"
+                        />
+                      </div>
+                      @if (getDayBlocks(day.key).length > 1) {
+                        <button
+                          type="button"
+                          class="remove-block-btn"
+                          (click)="removeBlock(day.key, $index)"
+                          title="Eliminar bloque"
+                        >×</button>
+                      }
+                    </div>
+                  }
+                  @if (canAddBlock(day.key)) {
+                    <button
+                      type="button"
+                      class="add-block-btn"
+                      (click)="addBlock(day.key)"
+                      title="Agregar bloque horario"
+                    >+</button>
+                  }
                 </div>
               } @else {
                 <span class="day-closed-label">Cerrado</span>

--- a/apps/frontend/src/app/private/modules/store/settings/general/components/pos-settings-form/pos-settings-form.component.html
+++ b/apps/frontend/src/app/private/modules/store/settings/general/components/pos-settings-form/pos-settings-form.component.html
@@ -274,57 +274,116 @@
           (changed)="onFieldChange()"
         ></app-setting-toggle>
       </div>
-      <div class="grid grid-cols-1 gap-3">
-        @for (day of daysOfWeek; track day.key) {
-          <div class="day-row">
-            <div class="day-row-top">
-              <span class="day-label">{{ day.label }}</span>
-              <button
-                type="button"
-                (click)="toggleDayStatus(day.key)"
-                class="day-toggle-btn"
-                [class.day-toggle-btn--close]="!isDayClosed(day.key)"
-                [class.day-toggle-btn--open]="isDayClosed(day.key)"
-              >
-                {{ isDayClosed(day.key) ? "Abrir" : "Cerrar" }}
-              </button>
-            </div>
-            @if (!isDayClosed(day.key)) {
-              <div class="day-times">
-                <div class="time-field">
-                  <label class="time-label">Apertura</label>
-                  <input
-                    type="time"
-                    [value]="
-                      form.get('business_hours')?.value[day.key]?.open || ''
-                    "
-                    (change)="
-                      onTimeChange(day.key, 'open', $any($event).target.value)
-                    "
-                    class="time-input"
-                  />
-                </div>
-                <span class="time-separator">—</span>
-                <div class="time-field">
-                  <label class="time-label">Cierre</label>
-                  <input
-                    type="time"
-                    [value]="
-                      form.get('business_hours')?.value[day.key]?.close || ''
-                    "
-                    (change)="
-                      onTimeChange(day.key, 'close', $any($event).target.value)
-                    "
-                    class="time-input"
-                  />
-                </div>
-              </div>
-            } @else {
-              <span class="day-closed-label">Cerrado</span>
-            }
-          </div>
-        }
+      <div class="mb-4">
+        <app-selector
+          [formControl]="scheduleModeControl"
+          label="Tipo de Horario"
+          [options]="scheduleModeOptions"
+          (valueChange)="onScheduleModeChange()"
+          size="sm"
+        ></app-selector>
+        <p class="text-[10px] text-text-muted mt-1">
+          @if (isCustomMode()) {
+            Personalizado: define múltiples bloques horarios por día
+          } @else {
+            Continuo: un solo bloque de apertura y cierre por día
+          }
+        </p>
       </div>
+
+      <!-- Continuous Mode -->
+      @if (!isCustomMode()) {
+        <div class="grid grid-cols-1 gap-3">
+          @for (day of daysOfWeek; track day.key) {
+            <div class="day-row">
+              <div class="day-row-top">
+                <span class="day-label">{{ day.label }}</span>
+                <button
+                  type="button"
+                  (click)="toggleDayStatus(day.key)"
+                  class="day-toggle-btn"
+                  [class.day-toggle-btn--close]="!isDayClosed(day.key)"
+                  [class.day-toggle-btn--open]="isDayClosed(day.key)"
+                >
+                  {{ isDayClosed(day.key) ? "Abrir" : "Cerrar" }}
+                </button>
+              </div>
+              @if (!isDayClosed(day.key)) {
+                <div class="day-times">
+                  <div class="time-field">
+                    <label class="time-label">Apertura</label>
+                    <input
+                      type="time"
+                      [value]="form.get('business_hours')?.value[day.key]?.open || ''"
+                      disabled
+                      class="time-input"
+                    />
+                  </div>
+                  <span class="time-separator">—</span>
+                  <div class="time-field">
+                    <label class="time-label">Cierre</label>
+                    <input
+                      type="time"
+                      [value]="form.get('business_hours')?.value[day.key]?.close || ''"
+                      disabled
+                      class="time-input"
+                    />
+                  </div>
+                </div>
+              } @else {
+                <span class="day-closed-label">Cerrado</span>
+              }
+            </div>
+          }
+        </div>
+      }
+
+      <!-- Custom Mode (multi-block per day) -->
+      @if (isCustomMode()) {
+        <div class="grid grid-cols-1 gap-3">
+          @for (day of daysOfWeek; track day.key) {
+            <div class="day-row">
+              <div class="day-row-top">
+                <span class="day-label">{{ day.label }}</span>
+                <button
+                  type="button"
+                  (click)="toggleCustomDayStatus(day.key)"
+                  class="day-toggle-btn"
+                  [class.day-toggle-btn--close]="!isCustomDayClosed(day.key)"
+                  [class.day-toggle-btn--open]="isCustomDayClosed(day.key)"
+                >
+                  {{ isCustomDayClosed(day.key) ? "Abrir" : "Cerrar" }}
+                </button>
+              </div>
+              @if (!isCustomDayClosed(day.key)) {
+                <div class="day-times">
+                  <div class="time-field">
+                    <label class="time-label">Apertura</label>
+                    <input
+                      type="time"
+                      [value]="getDayBlocks(day.key)[0]?.open || '08:00'"
+                      (change)="onBlockTimeChange(day.key, 0, 'open', $any($event).target.value)"
+                      class="time-input"
+                    />
+                  </div>
+                  <span class="time-separator">—</span>
+                  <div class="time-field">
+                    <label class="time-label">Cierre</label>
+                    <input
+                      type="time"
+                      [value]="getDayBlocks(day.key)[0]?.close || '18:00'"
+                      (change)="onBlockTimeChange(day.key, 0, 'close', $any($event).target.value)"
+                      class="time-input"
+                    />
+                  </div>
+                </div>
+              } @else {
+                <span class="day-closed-label">Cerrado</span>
+              }
+            </div>
+          }
+        </div>
+      }
     </div>
   </div>
   }

--- a/apps/frontend/src/app/private/modules/store/settings/general/components/pos-settings-form/pos-settings-form.component.scss
+++ b/apps/frontend/src/app/private/modules/store/settings/general/components/pos-settings-form/pos-settings-form.component.scss
@@ -3,8 +3,6 @@
 }
 
 // ─── Day Row (mobile-first) ────────────────────────────
-// Mobile: stacked — day name + toggle on top, times below
-// Desktop: single row, compact to fit in CSS column (~50vw)
 
 .day-row {
   background: #fff;
@@ -63,7 +61,6 @@
   cursor: pointer;
   transition: all 200ms ease;
 
-  // Expand touch target without visual size (mobile)
   @media (max-width: 767px) {
     min-height: 44px;
     padding: 6px 12px;
@@ -92,12 +89,12 @@
   align-items: flex-end;
   gap: 6px;
   flex: 1;
-  min-width: 0; // Prevent overflow
+  min-width: 0;
 }
 
 .time-field {
   flex: 1;
-  min-width: 0; // Prevent overflow
+  min-width: 0;
   display: flex;
   flex-direction: column;
   gap: 4px;
@@ -117,7 +114,7 @@
 
 .time-input {
   width: 100%;
-  min-width: 0; // Prevent flex overflow
+  min-width: 0;
   padding: 8px 6px;
   min-height: 36px;
   font-size: 13px;
@@ -128,11 +125,10 @@
   cursor: pointer;
   transition: border-color 200ms ease, box-shadow 200ms ease;
 
-  // Mobile: larger for touch
   @media (max-width: 767px) {
     padding: 10px 10px;
     min-height: 44px;
-    font-size: 16px; // Prevent iOS zoom
+    font-size: 16px;
     border-radius: 10px;
   }
 
@@ -141,6 +137,11 @@
     border-color: #3b82f6;
     box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.12);
     background: #fff;
+  }
+
+  &:disabled {
+    opacity: 0.7;
+    cursor: not-allowed;
   }
 }
 
@@ -156,4 +157,87 @@
   font-weight: 500;
   font-style: italic;
   color: #ef4444;
+}
+
+// ─── Custom Mode Blocks ──────────────────────────────
+
+.blocks-container {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: 100%;
+}
+
+.block-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.block-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: #6b7280;
+  min-width: 56px;
+  flex-shrink: 0;
+}
+
+.remove-block-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  border: 1px solid #fecaca;
+  background: #fef2f2;
+  color: #dc2626;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: all 150ms ease;
+
+  @media (max-width: 767px) {
+    width: 36px;
+    height: 36px;
+  }
+
+  &:active {
+    transform: scale(0.92);
+  }
+
+  &:hover {
+    background: #fee2e2;
+  }
+}
+
+.add-block-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  border: 1px solid #bbf7d0;
+  background: #f0fdf4;
+  color: #16a34a;
+  font-size: 18px;
+  font-weight: 700;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: all 150ms ease;
+
+  @media (max-width: 767px) {
+    width: 36px;
+    height: 36px;
+  }
+
+  &:active {
+    transform: scale(0.92);
+  }
+
+  &:hover {
+    background: #dcfce7;
+  }
 }

--- a/apps/frontend/src/app/private/modules/store/settings/general/components/pos-settings-form/pos-settings-form.component.ts
+++ b/apps/frontend/src/app/private/modules/store/settings/general/components/pos-settings-form/pos-settings-form.component.ts
@@ -4,9 +4,11 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ReactiveFormsModule, FormGroup, FormControl } from '@angular/forms';
 import { InputComponent } from '../../../../../../../shared/components/input/input.component';
 import { SettingToggleComponent } from '../../../../../../../shared/components/setting-toggle/setting-toggle.component';
+import { SelectorComponent, SelectorOption } from '../../../../../../../shared/components/selector/selector.component';
 import {
   PosSettings,
   BusinessHours,
+  BusinessHoursBlock,
   ScaleSettings,
   ScaleDeviceConfig,
 } from '../../../../../../../core/models/store-settings.interface';
@@ -16,7 +18,7 @@ import { ToastService } from '../../../../../../../shared/components/toast/toast
 @Component({
   selector: 'app-pos-settings-form',
   standalone: true,
-  imports: [ReactiveFormsModule, SettingToggleComponent],
+  imports: [ReactiveFormsModule, SettingToggleComponent, SelectorComponent],
   templateUrl: './pos-settings-form.component.html',
   styleUrls: ['./pos-settings-form.component.scss'],
 })
@@ -50,6 +52,7 @@ export class PosSettingsForm implements OnInit {
     allow_anonymous_sales: new FormControl<boolean | null>(null),
     anonymous_sales_as_default: new FormControl<boolean | null>(null),
     business_hours: new FormControl<Record<string, BusinessHours> | null>(null),
+    schedule_mode: new FormControl<'continuous' | 'custom'>('continuous'),
     enable_schedule_validation: new FormControl<boolean | null>(null),
     show_onscreen_keypad: new FormControl<boolean | null>(null),
     require_cash_drawer_open: new FormControl<boolean | null>(null),
@@ -96,6 +99,13 @@ export class PosSettingsForm implements OnInit {
     { key: 'sunday', label: 'Domingo' },
   ];
 
+  scheduleModeOptions: SelectorOption[] = [
+    { value: 'continuous', label: 'Continuo' },
+    { value: 'custom', label: 'Personalizado' },
+  ];
+
+  readonly MAX_BLOCKS_PER_DAY = 5;
+
   // Typed getters for FormControls
   get allowAnonymousSalesControl(): FormControl<boolean> {
     return this.form.get('allow_anonymous_sales') as FormControl<boolean>;
@@ -137,6 +147,14 @@ export class PosSettingsForm implements OnInit {
 
   get enableScheduleValidationControl(): FormControl<boolean> {
     return this.form.get('enable_schedule_validation') as FormControl<boolean>;
+  }
+
+  get scheduleModeControl(): FormControl<'continuous' | 'custom'> {
+    return this.form.get('schedule_mode') as FormControl<'continuous' | 'custom'>;
+  }
+
+  isCustomMode(): boolean {
+    return this.scheduleModeControl.value === 'custom';
   }
 
   get scaleEnabledControl(): FormControl<boolean> {
@@ -341,5 +359,107 @@ export class PosSettingsForm implements OnInit {
       this.form.get('business_hours')?.setValue(hours);
       this.onBusinessHoursChange();
     }
+  }
+
+  onScheduleModeChange() {
+    const mode = this.scheduleModeControl.value;
+    const hours = { ...this.form.get('business_hours')?.value };
+    if (!hours) return;
+
+    if (mode === 'custom') {
+      for (const day of this.daysOfWeek) {
+        const dayHours = hours[day.key];
+        if (!dayHours) continue;
+        if (dayHours.open === 'closed') {
+          hours[day.key] = { ...dayHours, blocks: [] };
+        } else {
+          hours[day.key] = {
+            ...dayHours,
+            blocks: [
+              { open: dayHours.open, close: dayHours.close },
+              { open: '14:00', close: '18:00' },
+            ],
+          };
+        }
+      }
+    } else {
+      for (const day of this.daysOfWeek) {
+        const dayHours = hours[day.key];
+        if (!dayHours) continue;
+        const { blocks, ...rest } = dayHours as BusinessHours;
+        if (blocks && blocks.length > 0) {
+          hours[day.key] = { ...rest, open: blocks[0].open, close: blocks[0].close };
+        } else {
+          hours[day.key] = { ...rest };
+        }
+      }
+    }
+
+    this.form.get('business_hours')?.setValue(hours);
+    this.onBusinessHoursChange();
+  }
+
+  getDayBlocks(day: string): BusinessHoursBlock[] {
+    const hours = this.form.get('business_hours')?.value;
+    return hours?.[day]?.blocks ? [...hours[day].blocks] : [];
+  }
+
+  addBlock(day: string) {
+    const hours = { ...this.form.get('business_hours')?.value };
+    if (!hours?.[day]) return;
+
+    const currentBlocks = hours[day].blocks ? [...hours[day].blocks] : [];
+    if (currentBlocks.length >= this.MAX_BLOCKS_PER_DAY) return;
+
+    currentBlocks.push({ open: '09:00', close: '17:00' });
+    hours[day] = { ...hours[day], blocks: currentBlocks };
+    this.form.get('business_hours')?.setValue(hours);
+    this.onBusinessHoursChange();
+  }
+
+  removeBlock(day: string, index: number) {
+    const hours = { ...this.form.get('business_hours')?.value };
+    if (!hours?.[day]?.blocks) return;
+
+    const currentBlocks = [...hours[day].blocks];
+    currentBlocks.splice(index, 1);
+    hours[day] = { ...hours[day], blocks: currentBlocks };
+    this.form.get('business_hours')?.setValue(hours);
+    this.onBusinessHoursChange();
+  }
+
+  onBlockTimeChange(day: string, blockIndex: number, field: 'open' | 'close', value: string) {
+    const hours = { ...this.form.get('business_hours')?.value };
+    if (!hours?.[day]?.blocks?.[blockIndex]) return;
+
+    const currentBlocks = [...hours[day].blocks];
+    currentBlocks[blockIndex] = { ...currentBlocks[blockIndex], [field]: value };
+    hours[day] = { ...hours[day], blocks: currentBlocks };
+    this.form.get('business_hours')?.setValue(hours);
+    this.onBusinessHoursChange();
+  }
+
+  isCustomDayClosed(day: string): boolean {
+    const hours = this.form.get('business_hours')?.value;
+    const blocks = hours?.[day]?.blocks;
+    return !blocks || blocks.length === 0;
+  }
+
+  toggleCustomDayStatus(day: string) {
+    const hours = { ...this.form.get('business_hours')?.value };
+    if (!hours?.[day]) return;
+
+    if (this.isCustomDayClosed(day)) {
+      hours[day] = { ...hours[day], blocks: [{ open: '08:00', close: '12:00' }, { open: '14:00', close: '18:00' }] };
+    } else {
+      hours[day] = { ...hours[day], blocks: [] };
+    }
+    this.form.get('business_hours')?.setValue(hours);
+    this.onBusinessHoursChange();
+  }
+
+  canAddBlock(day: string): boolean {
+    const blocks = this.getDayBlocks(day);
+    return blocks.length < this.MAX_BLOCKS_PER_DAY;
   }
 }


### PR DESCRIPTION
## Summary

- Agregar selector de modo de horario (Continuo/Personalizado) en configuración POS
- Modo continuo: horarios de solo lectura con un bloque por día
- Modo personalizado: horarios editables por día con bloque de apertura y cierre
- Extender `BusinessHours` con `blocks?` opcional para soportar múltiples bloques horarios
- Agregar `schedule_mode` a `PosSettings` con migración v1→v2
- Actualizar validación backend para soportar múltiples bloques por día
- Actualizar componentes de visualización (indicator, modal, dropdown, payment interface)

## Archivos modificados

**Backend:**
- Interfaces, DTO, defaults y migración de settings
- `ScheduleValidationService` con soporte multi-bloque

**Frontend:**
- Formulario POS con selector de modo y editor condicional
- Componentes de display actualizados para múltiples bloques

## Test plan

- [ ] Verificar que el selector "Tipo de Horario" aparece en Configuración > POS
- [ ] Modo continuo: inputs deshabilitados, no editables
- [ ] Modo personalizado: inputs editables, se puede abrir/cerrar días
- [ ] Cambiar entre modos y verificar que los datos se convierten correctamente
- [ ] Verificar que el indicador de horarios en POS muestra correctamente
- [ ] Verificar que el backend valida correctamente múltiples bloques