### PR TITLE
feat: native-style camera capture and rotate/flip in image crop

### DIFF
--- a/apps/frontend/src/app/private/modules/store/products/components/product-image-source-modal.component.ts
+++ b/apps/frontend/src/app/private/modules/store/products/components/product-image-source-modal.component.ts
@@ -9,6 +9,7 @@ import {
   output,
   signal,
   ViewChild,
+  viewChild,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
@@ -261,12 +262,33 @@ const ASPECT_RATIOS: { value: AspectRatio; label: string; ratio: number | null }
         }
 
         @case ('camera') {
-          <app-camera
-            [isOpen]="stage() === 'camera'"
-            fileNamePrefix="foto"
-            (captured)="onCameraCaptured($event)"
-            (closed)="backToSelect()"
-          ></app-camera>
+          <div class="space-y-4">
+            <app-camera
+              [isOpen]="stage() === 'camera'"
+              [embedActions]="true"
+              fileNamePrefix="foto"
+              (captured)="onCameraCaptured($event)"
+              (closed)="backToSelect()"
+            ></app-camera>
+
+            <!-- Footer actions: hidden on mobile (camera renders its own fullscreen controls) -->
+            @if (!cameraRef()?.isMobile()) {
+              <div class="flex justify-end gap-2 pt-3 border-t border-gray-200">
+                <app-button variant="outline" (clicked)="backToSelect()">
+                  <app-icon slot="icon" name="x" size="16"></app-icon>
+                  Cancelar
+                </app-button>
+                <app-button
+                  variant="primary"
+                  (clicked)="cameraRef()?.capture()"
+                  [disabled]="!cameraRef()?.cameraReady()"
+                >
+                  <app-icon slot="icon" name="camera" size="16"></app-icon>
+                  Capturar
+                </app-button>
+              </div>
+            }
+          </div>
         }
 
         @case ('crop') {
@@ -539,6 +561,7 @@ export class ProductImageSourceModalComponent {
 
   @ViewChild('fileInput') fileInputRef?: ElementRef<HTMLInputElement>;
   @ViewChild('cropCanvas') cropCanvasRef?: ElementRef<HTMLCanvasElement>;
+  readonly cameraRef = viewChild(CameraComponent);
 
   private loadedImages = new Map<number, HTMLImageElement>();
 

--- a/apps/frontend/src/app/private/modules/store/products/components/product-image-source-modal.component.ts
+++ b/apps/frontend/src/app/private/modules/store/products/components/product-image-source-modal.component.ts
@@ -6,7 +6,6 @@ import {
   inject,
   input,
   model,
-  OnDestroy,
   output,
   signal,
   ViewChild,
@@ -19,6 +18,7 @@ import {
   IconComponent,
   InputComponent,
   ToastService,
+  CameraComponent,
 } from '../../../../../shared/components';
 import { ProductsService } from '../services/products.service';
 
@@ -83,6 +83,7 @@ const ASPECT_RATIOS: { value: AspectRatio; label: string; ratio: number | null }
     ButtonComponent,
     IconComponent,
     InputComponent,
+    CameraComponent,
   ],
   template: `
     <app-modal
@@ -260,56 +261,34 @@ const ASPECT_RATIOS: { value: AspectRatio; label: string; ratio: number | null }
         }
 
         @case ('camera') {
-          <div class="space-y-4">
-            <button
-              type="button"
-              (click)="backToSelect()"
-              class="inline-flex items-center gap-1 text-xs font-medium text-primary-600 hover:text-primary-700"
-            >
-              <app-icon name="chevron-left" size="14"></app-icon>
-              Volver
-            </button>
-
-            @if (cameraError()) {
-              <div
-                class="p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700 flex items-start gap-2"
-              >
-                <app-icon name="alert-triangle" size="16"></app-icon>
-                <span>{{ cameraError() }}</span>
-              </div>
-            }
-
-            <div
-              class="relative aspect-video w-full bg-black rounded-xl overflow-hidden"
-            >
-              <video
-                #videoEl
-                class="w-full h-full object-contain"
-                autoplay
-                playsinline
-                muted
-              ></video>
-            </div>
-
-            <div class="flex justify-end gap-2">
-              <app-button variant="outline" (clicked)="backToSelect()">
-                <app-icon slot="icon" name="x" size="16"></app-icon>
-                Cancelar
-              </app-button>
-              <app-button
-                variant="primary"
-                (clicked)="capturePhoto()"
-                [disabled]="!cameraReady()"
-              >
-                <app-icon slot="icon" name="camera" size="16"></app-icon>
-                Capturar
-              </app-button>
-            </div>
-          </div>
+          <app-camera
+            [isOpen]="stage() === 'camera'"
+            fileNamePrefix="foto"
+            (captured)="onCameraCaptured($event)"
+            (closed)="backToSelect()"
+          ></app-camera>
         }
 
         @case ('crop') {
           <div class="space-y-4">
+            <div class="flex flex-wrap items-center gap-2">
+              <span class="text-xs font-semibold text-gray-700">Transformar:</span>
+              <app-button variant="outline" size="sm" (clicked)="rotateBy(-90)" title="Rotar izquierda">
+                <app-icon slot="icon" name="rotate-ccw" size="14"></app-icon>
+              </app-button>
+              <app-button variant="outline" size="sm" (clicked)="rotateBy(90)" title="Rotar derecha">
+                <app-icon slot="icon" name="rotate-cw" size="14"></app-icon>
+              </app-button>
+              <app-button variant="outline" size="sm" (clicked)="toggleFlipH()"
+                          [class.bg-primary-600]="flipH()" [class.text-white]="flipH()" title="Voltear horizontal">
+                <app-icon slot="icon" name="flip-horizontal" size="14"></app-icon>
+              </app-button>
+              <app-button variant="outline" size="sm" (clicked)="toggleFlipV()"
+                          [class.bg-primary-600]="flipV()" [class.text-white]="flipV()" title="Voltear vertical">
+                <app-icon slot="icon" name="flip-vertical" size="14"></app-icon>
+              </app-button>
+            </div>
+
             <div class="flex flex-wrap items-center gap-2">
               <span class="text-xs font-semibold text-gray-700"
                 >Relación de aspecto:</span
@@ -495,7 +474,7 @@ const ASPECT_RATIOS: { value: AspectRatio; label: string; ratio: number | null }
     </app-modal>
   `,
 })
-export class ProductImageSourceModalComponent implements OnDestroy {
+export class ProductImageSourceModalComponent {
   private readonly productsService = inject(ProductsService);
   private readonly toastService = inject(ToastService);
   private readonly destroyRef = inject(DestroyRef);
@@ -513,9 +492,10 @@ export class ProductImageSourceModalComponent implements OnDestroy {
   readonly urlError = signal<string | null>(null);
   readonly isFetchingUrl = signal(false);
 
-  readonly cameraError = signal<string | null>(null);
-  readonly cameraReady = signal(false);
-  private cameraStream: MediaStream | null = null;
+  readonly rotation = signal<0 | 90 | 180 | 270>(0);
+  readonly flipH    = signal<boolean>(false);
+  readonly flipV    = signal<boolean>(false);
+  readonly axesSwapped = computed(() => this.rotation() === 90 || this.rotation() === 270);
 
   readonly cropFrame = signal<CropFrame | null>(null);
   readonly canvasSize = signal<{ w: number; h: number }>({ w: 0, h: 0 });
@@ -558,35 +538,29 @@ export class ProductImageSourceModalComponent implements OnDestroy {
   });
 
   @ViewChild('fileInput') fileInputRef?: ElementRef<HTMLInputElement>;
-  @ViewChild('videoEl') videoRef?: ElementRef<HTMLVideoElement>;
   @ViewChild('cropCanvas') cropCanvasRef?: ElementRef<HTMLCanvasElement>;
 
   private loadedImages = new Map<number, HTMLImageElement>();
 
-  ngOnDestroy(): void {
-    this.stopCamera();
-  }
-
   onClose(): void {
-    this.stopCamera();
     this.stage.set('select');
     this.queue.set([]);
     this.queueCursor.set(0);
     this.aspect.set('free');
+    this.rotation.set(0);
+    this.flipH.set(false);
+    this.flipV.set(false);
     this.cropFrame.set(null);
     this.canvasSize.set({ w: 0, h: 0 });
     this.urlInput = '';
     this.urlError.set(null);
     this.isFetchingUrl.set(false);
-    this.cameraError.set(null);
-    this.cameraReady.set(false);
     this.loadedImages.clear();
     this.dragState = null;
     this.isOpen.set(false);
   }
 
   backToSelect(): void {
-    this.stopCamera();
     this.stage.set('select');
   }
 
@@ -667,66 +641,13 @@ export class ProductImageSourceModalComponent implements OnDestroy {
       });
   }
 
-  async goToCamera(): Promise<void> {
+  goToCamera(): void {
     if (this.remainingSlots() <= 0) return;
-    this.cameraError.set(null);
-    this.cameraReady.set(false);
     this.stage.set('camera');
-
-    setTimeout(() => this.initCamera(), 0);
   }
 
-  private async initCamera(): Promise<void> {
-    if (!navigator.mediaDevices?.getUserMedia) {
-      this.cameraError.set('Este navegador no soporta acceso a la cámara');
-      return;
-    }
-    try {
-      this.cameraStream = await navigator.mediaDevices.getUserMedia({
-        video: { facingMode: 'environment' },
-        audio: false,
-      });
-      const video = this.videoRef?.nativeElement;
-      if (video) {
-        video.srcObject = this.cameraStream;
-        video.onloadedmetadata = () => this.cameraReady.set(true);
-      }
-    } catch (err: any) {
-      const message =
-        err?.name === 'NotAllowedError'
-          ? 'Permiso de cámara denegado'
-          : 'No pudimos acceder a la cámara';
-      this.cameraError.set(message);
-    }
-  }
-
-  private stopCamera(): void {
-    if (this.cameraStream) {
-      for (const track of this.cameraStream.getTracks()) {
-        track.stop();
-      }
-      this.cameraStream = null;
-    }
-    if (this.videoRef?.nativeElement) {
-      this.videoRef.nativeElement.srcObject = null;
-    }
-    this.cameraReady.set(false);
-  }
-
-  capturePhoto(): void {
-    const video = this.videoRef?.nativeElement;
-    if (!video || !video.videoWidth) return;
-
-    const canvas = document.createElement('canvas');
-    canvas.width = video.videoWidth;
-    canvas.height = video.videoHeight;
-    const ctx = canvas.getContext('2d');
-    if (!ctx) return;
-    ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
-
-    const dataUrl = canvas.toDataURL('image/jpeg', 0.92);
-    this.stopCamera();
-    this.startCropFlow([{ dataUrl, fileName: `foto-${Date.now()}.jpg` }]);
+  onCameraCaptured(payload: { dataUrl: string; fileName: string }): void {
+    this.startCropFlow([payload]);
   }
 
   private startCropFlow(items: PendingImage[]): void {
@@ -734,6 +655,9 @@ export class ProductImageSourceModalComponent implements OnDestroy {
     this.queue.set(items);
     this.queueCursor.set(0);
     this.aspect.set('free');
+    this.rotation.set(0);
+    this.flipH.set(false);
+    this.flipV.set(false);
     this.cropFrame.set(null);
     this.canvasSize.set({ w: 0, h: 0 });
     this.stage.set('crop');
@@ -751,6 +675,22 @@ export class ProductImageSourceModalComponent implements OnDestroy {
     this.resetFrameForCurrentAspect();
   }
 
+  rotateBy(delta: 90 | -90): void {
+    const next = (((this.rotation() + delta) % 360) + 360) % 360 as 0 | 90 | 180 | 270;
+    this.rotation.set(next);
+    this.renderCropPreview();
+  }
+
+  toggleFlipH(): void {
+    this.flipH.update(v => !v);
+    this.renderCropPreview();
+  }
+
+  toggleFlipV(): void {
+    this.flipV.update(v => !v);
+    this.renderCropPreview();
+  }
+
   private async renderCropPreview(): Promise<void> {
     const canvas = this.cropCanvasRef?.nativeElement;
     const item = this.queue()[this.queueCursor()];
@@ -760,13 +700,23 @@ export class ProductImageSourceModalComponent implements OnDestroy {
 
     const maxDim = 1200;
     const scale = Math.min(1, maxDim / Math.max(img.width, img.height));
-    canvas.width = Math.round(img.width * scale);
-    canvas.height = Math.round(img.height * scale);
+    const drawW = Math.round(img.width * scale);
+    const drawH = Math.round(img.height * scale);
+
+    const swapped = this.axesSwapped();
+    canvas.width = swapped ? drawH : drawW;
+    canvas.height = swapped ? drawW : drawH;
 
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
     ctx.clearRect(0, 0, canvas.width, canvas.height);
-    ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+
+    ctx.save();
+    ctx.translate(canvas.width / 2, canvas.height / 2);
+    ctx.rotate((this.rotation() * Math.PI) / 180);
+    ctx.scale(this.flipH() ? -1 : 1, this.flipV() ? -1 : 1);
+    ctx.drawImage(img, -drawW / 2, -drawH / 2, drawW, drawH);
+    ctx.restore();
 
     this.canvasSize.set({ w: canvas.width, h: canvas.height });
     this.resetFrameForCurrentAspect();
@@ -1026,23 +976,44 @@ export class ProductImageSourceModalComponent implements OnDestroy {
     if (!item || !f || !canvas) return;
 
     const img = await this.loadImage(this.queueCursor(), item.dataUrl);
-    const scaleX = img.width / canvas.width;
-    const scaleY = img.height / canvas.height;
+    const swapped = this.axesSwapped();
+
+    const MAX_OUT = 4096;
+    const srcScale = Math.min(1, MAX_OUT / Math.max(img.width, img.height));
+    const baseW = Math.round(img.width * srcScale);
+    const baseH = Math.round(img.height * srcScale);
+    const fullW = swapped ? baseH : baseW;
+    const fullH = swapped ? baseW : baseH;
+
+    const tmp = document.createElement('canvas');
+    tmp.width = fullW;
+    tmp.height = fullH;
+    const tctx = tmp.getContext('2d');
+    if (!tctx) return;
+    tctx.save();
+    tctx.translate(fullW / 2, fullH / 2);
+    tctx.rotate((this.rotation() * Math.PI) / 180);
+    tctx.scale(this.flipH() ? -1 : 1, this.flipV() ? -1 : 1);
+    tctx.drawImage(img, -baseW / 2, -baseH / 2, baseW, baseH);
+    tctx.restore();
+
+    const scaleX = fullW / canvas.width;
+    const scaleY = fullH / canvas.height;
     let sx = Math.max(0, Math.round(f.x * scaleX));
     let sy = Math.max(0, Math.round(f.y * scaleY));
     let sw = Math.max(1, Math.round(f.w * scaleX));
     let sh = Math.max(1, Math.round(f.h * scaleY));
-    sw = Math.min(sw, img.width - sx);
-    sh = Math.min(sh, img.height - sy);
+    sw = Math.min(sw, fullW - sx);
+    sh = Math.min(sh, fullH - sy);
 
-    const outCanvas = document.createElement('canvas');
-    outCanvas.width = sw;
-    outCanvas.height = sh;
-    const ctx = outCanvas.getContext('2d');
-    if (!ctx) return;
-    ctx.drawImage(img, sx, sy, sw, sh, 0, 0, sw, sh);
+    const out = document.createElement('canvas');
+    out.width = sw;
+    out.height = sh;
+    const octx = out.getContext('2d');
+    if (!octx) return;
+    octx.drawImage(tmp, sx, sy, sw, sh, 0, 0, sw, sh);
 
-    const dataUrl = outCanvas.toDataURL('image/jpeg', 0.9);
+    const dataUrl = out.toDataURL('image/jpeg', 0.9);
     this.appendResult(dataUrl);
     this.advanceQueue();
   }
@@ -1054,6 +1025,9 @@ export class ProductImageSourceModalComponent implements OnDestroy {
   cancelCrop(): void {
     this.queue.set([]);
     this.queueCursor.set(0);
+    this.rotation.set(0);
+    this.flipH.set(false);
+    this.flipV.set(false);
     this.cropFrame.set(null);
     this.canvasSize.set({ w: 0, h: 0 });
     this.loadedImages.clear();
@@ -1080,6 +1054,9 @@ export class ProductImageSourceModalComponent implements OnDestroy {
     }
     this.queueCursor.set(next);
     this.aspect.set('free');
+    this.rotation.set(0);
+    this.flipH.set(false);
+    this.flipV.set(false);
     this.cropFrame.set(null);
     this.canvasSize.set({ w: 0, h: 0 });
     setTimeout(() => this.renderCropPreview(), 0);

--- a/apps/frontend/src/app/shared/components/camera/camera.component.ts
+++ b/apps/frontend/src/app/shared/components/camera/camera.component.ts
@@ -2,10 +2,12 @@ import {
   Component,
   ElementRef,
   EmbeddedViewRef,
+  Injector,
   OnDestroy,
   Renderer2,
   TemplateRef,
   ViewContainerRef,
+  afterNextRender,
   effect,
   inject,
   input,
@@ -233,6 +235,7 @@ export class CameraComponent implements OnDestroy {
   // DI
   private readonly vcr = inject(ViewContainerRef);
   private readonly doc = inject(DOCUMENT);
+  private readonly injector = inject(Injector);
 
   // Privado
   private stream: MediaStream | null = null;
@@ -285,10 +288,17 @@ export class CameraComponent implements OnDestroy {
       return;
     }
     this.mobileEmbedded = this.vcr.createEmbeddedView(tpl);
-    this.mobileEmbedded.detectChanges();
-    for (const node of this.mobileEmbedded.rootNodes) {
-      if (node instanceof Node) this.doc.body.appendChild(node);
-    }
+    // Teleport rootNodes to <body> after Angular's next render cycle (zoneless-safe).
+    afterNextRender(
+      () => {
+        const view = this.mobileEmbedded;
+        if (!view) return;
+        for (const node of view.rootNodes) {
+          if (node instanceof Node) this.doc.body.appendChild(node);
+        }
+      },
+      { injector: this.injector },
+    );
     // Prevent body scroll while overlay is active
     this.bodyOverflowPrev = this.doc.body.style.overflow;
     this.doc.body.style.overflow = 'hidden';

--- a/apps/frontend/src/app/shared/components/camera/camera.component.ts
+++ b/apps/frontend/src/app/shared/components/camera/camera.component.ts
@@ -194,16 +194,18 @@ import { ButtonComponent } from '../button/button.component';
           </div>
         </div>
 
-        <div class="flex justify-end gap-2">
-          <app-button variant="outline" (clicked)="close()">
-            <app-icon slot="icon" name="x" size="16"></app-icon>
-            Cancelar
-          </app-button>
-          <app-button variant="primary" (clicked)="capture()" [disabled]="!cameraReady()">
-            <app-icon slot="icon" name="camera" size="16"></app-icon>
-            Capturar
-          </app-button>
-        </div>
+        @if (!embedActions()) {
+          <div class="flex justify-end gap-2">
+            <app-button variant="outline" (clicked)="close()">
+              <app-icon slot="icon" name="x" size="16"></app-icon>
+              Cancelar
+            </app-button>
+            <app-button variant="primary" (clicked)="capture()" [disabled]="!cameraReady()">
+              <app-icon slot="icon" name="camera" size="16"></app-icon>
+              Capturar
+            </app-button>
+          </div>
+        }
       </div>
     }
   `,
@@ -213,6 +215,9 @@ export class CameraComponent implements OnDestroy {
   readonly isOpen = input<boolean>(false);
   readonly fileNamePrefix = input<string>('foto');
   readonly imageQuality = input<number>(0.92);
+  // When true, the desktop branch hides its Cancelar/Capturar buttons so the
+  // host can render them externally (e.g. inside a modal footer).
+  readonly embedActions = input<boolean>(false);
 
   // Outputs
   readonly captured = output<{ dataUrl: string; fileName: string }>();

--- a/apps/frontend/src/app/shared/components/camera/camera.component.ts
+++ b/apps/frontend/src/app/shared/components/camera/camera.component.ts
@@ -1,0 +1,393 @@
+import {
+  Component,
+  ElementRef,
+  EmbeddedViewRef,
+  OnDestroy,
+  Renderer2,
+  TemplateRef,
+  ViewContainerRef,
+  effect,
+  inject,
+  input,
+  output,
+  signal,
+  viewChild,
+} from '@angular/core';
+import { DOCUMENT } from '@angular/common';
+import { IconComponent } from '../icon/icon.component';
+import { ButtonComponent } from '../button/button.component';
+
+/**
+ * CameraComponent
+ * Generic camera capture: mobile fullscreen (teleported to body to escape modal transform context)
+ * and desktop inline. Zoneless + signals (Angular 20).
+ *
+ * Usage:
+ *   <app-camera
+ *     [isOpen]="open()"
+ *     fileNamePrefix="receipt"
+ *     (captured)="onCaptured($event)"
+ *     (closed)="open.set(false)" />
+ */
+@Component({
+  selector: 'app-camera',
+  standalone: true,
+  imports: [IconComponent, ButtonComponent],
+  template: `
+    <!--
+      Mobile branch lives inside an <ng-template> so we can manually mount it
+      into document.body. Required because <app-modal> wraps its content in a
+      .transform element (Tailwind), which creates a containing block for
+      position: fixed and breaks fullscreen overlays rendered inside the modal.
+    -->
+    <ng-template #mobileOverlayTpl>
+      <div
+        class="fixed inset-0 z-[10000] bg-black flex flex-col"
+        style="touch-action: none; width: 100vw; height: 100vh; height: 100dvh; left: 0; top: 0;"
+      >
+        <video
+          #videoEl
+          autoplay
+          playsinline
+          muted
+          style="position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover; background: #000;"
+        ></video>
+
+        <!-- Top bar -->
+        <div
+          class="absolute top-0 left-0 right-0 flex items-center justify-between p-3 z-10"
+          style="padding-top: max(0.75rem, env(safe-area-inset-top));"
+        >
+          <button
+            type="button"
+            (click)="close()"
+            class="w-11 h-11 rounded-full bg-black/50 text-white flex items-center justify-center"
+            style="backdrop-filter: blur(6px);"
+          >
+            <app-icon name="x" size="22"></app-icon>
+          </button>
+          @if (torchSupported()) {
+            <button
+              type="button"
+              (click)="toggleTorch()"
+              class="w-11 h-11 rounded-full bg-black/50 text-white flex items-center justify-center"
+              style="backdrop-filter: blur(6px);"
+            >
+              <app-icon [name]="torchOn() ? 'zap' : 'zap-off'" size="22"></app-icon>
+            </button>
+          } @else {
+            <div class="w-11 h-11"></div>
+          }
+        </div>
+
+        @if (cameraError()) {
+          <div class="absolute inset-0 flex items-center justify-center p-6 z-20 pointer-events-none">
+            <div
+              class="bg-red-50 border border-red-200 rounded-lg p-4 text-sm text-red-700 max-w-sm flex items-start gap-2 pointer-events-auto"
+            >
+              <app-icon name="alert-triangle" size="16"></app-icon>
+              <span>{{ cameraError() }}</span>
+            </div>
+          </div>
+        }
+
+        <!-- Framing brackets + thirds grid (centered overlay) -->
+        <div class="absolute inset-0 pointer-events-none flex items-center justify-center">
+          <div class="relative" style="width: 78%; max-width: 480px; aspect-ratio: 1;">
+            <div class="absolute top-0 left-0 w-8 h-8 border-t-2 border-l-2 border-white/90"></div>
+            <div class="absolute top-0 right-0 w-8 h-8 border-t-2 border-r-2 border-white/90"></div>
+            <div class="absolute bottom-0 left-0 w-8 h-8 border-b-2 border-l-2 border-white/90"></div>
+            <div class="absolute bottom-0 right-0 w-8 h-8 border-b-2 border-r-2 border-white/90"></div>
+            <div class="absolute inset-0">
+              <div class="absolute top-1/3 left-0 right-0 border-t border-white/25"></div>
+              <div class="absolute top-2/3 left-0 right-0 border-t border-white/25"></div>
+              <div class="absolute left-1/3 top-0 bottom-0 border-l border-white/25"></div>
+              <div class="absolute left-2/3 top-0 bottom-0 border-l border-white/25"></div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Bottom bar: shutter + switch -->
+        <div
+          class="absolute bottom-0 left-0 right-0 pt-6 z-10"
+          style="padding-bottom: max(1.75rem, env(safe-area-inset-bottom)); background: linear-gradient(to top, rgba(0,0,0,0.75), rgba(0,0,0,0));"
+        >
+          <div class="flex items-center justify-between px-10">
+            <div class="w-12 h-12"></div>
+            <button
+              type="button"
+              (click)="capture()"
+              [disabled]="!cameraReady()"
+              class="rounded-full border-4 border-white p-1.5 disabled:opacity-50 active:scale-95 transition-transform"
+              style="width: 76px; height: 76px;"
+              aria-label="Capturar"
+            >
+              <span class="block w-full h-full rounded-full bg-white"></span>
+            </button>
+            <button
+              type="button"
+              (click)="switchCamera()"
+              [disabled]="!cameraReady()"
+              class="w-12 h-12 rounded-full bg-black/50 text-white flex items-center justify-center disabled:opacity-50"
+              style="backdrop-filter: blur(6px);"
+              aria-label="Cambiar cámara"
+            >
+              <app-icon name="switch-camera" size="24"></app-icon>
+            </button>
+          </div>
+        </div>
+      </div>
+    </ng-template>
+
+    @if (!isMobile()) {
+      <!-- Desktop: render inline inside the modal body -->
+      <div class="space-y-4">
+        @if (cameraError()) {
+          <div
+            class="p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700 flex items-start gap-2"
+          >
+            <app-icon name="alert-triangle" size="16"></app-icon>
+            <span>{{ cameraError() }}</span>
+          </div>
+        }
+
+        <div class="relative aspect-video w-full bg-black rounded-xl overflow-hidden">
+          <video
+            #videoEl
+            class="w-full h-full object-contain"
+            autoplay
+            playsinline
+            muted
+          ></video>
+
+          <!-- Small framing brackets -->
+          <div class="absolute inset-0 pointer-events-none flex items-center justify-center">
+            <div class="relative" style="width: 55%; max-width: 320px; aspect-ratio: 1;">
+              <div class="absolute top-0 left-0 w-6 h-6 border-t-2 border-l-2 border-white/80"></div>
+              <div class="absolute top-0 right-0 w-6 h-6 border-t-2 border-r-2 border-white/80"></div>
+              <div class="absolute bottom-0 left-0 w-6 h-6 border-b-2 border-l-2 border-white/80"></div>
+              <div class="absolute bottom-0 right-0 w-6 h-6 border-b-2 border-r-2 border-white/80"></div>
+            </div>
+          </div>
+
+          <!-- Top-right floating controls -->
+          <div class="absolute top-2 right-2 flex gap-2">
+            @if (torchSupported()) {
+              <button
+                type="button"
+                (click)="toggleTorch()"
+                class="w-9 h-9 rounded-full bg-black/50 text-white flex items-center justify-center"
+              >
+                <app-icon [name]="torchOn() ? 'zap' : 'zap-off'" size="18"></app-icon>
+              </button>
+            }
+            <button
+              type="button"
+              (click)="switchCamera()"
+              [disabled]="!cameraReady()"
+              class="w-9 h-9 rounded-full bg-black/50 text-white flex items-center justify-center disabled:opacity-50"
+            >
+              <app-icon name="switch-camera" size="18"></app-icon>
+            </button>
+          </div>
+        </div>
+
+        <div class="flex justify-end gap-2">
+          <app-button variant="outline" (clicked)="close()">
+            <app-icon slot="icon" name="x" size="16"></app-icon>
+            Cancelar
+          </app-button>
+          <app-button variant="primary" (clicked)="capture()" [disabled]="!cameraReady()">
+            <app-icon slot="icon" name="camera" size="16"></app-icon>
+            Capturar
+          </app-button>
+        </div>
+      </div>
+    }
+  `,
+})
+export class CameraComponent implements OnDestroy {
+  // Inputs
+  readonly isOpen = input<boolean>(false);
+  readonly fileNamePrefix = input<string>('foto');
+  readonly imageQuality = input<number>(0.92);
+
+  // Outputs
+  readonly captured = output<{ dataUrl: string; fileName: string }>();
+  readonly closed = output<void>();
+
+  // State signals
+  readonly cameraError = signal<string | null>(null);
+  readonly cameraReady = signal(false);
+  readonly facingMode = signal<'user' | 'environment'>('environment');
+  readonly torchSupported = signal(false);
+  readonly torchOn = signal(false);
+  readonly isMobile = signal(
+    typeof window !== 'undefined' ? window.innerWidth < 768 : false,
+  );
+
+  // View refs
+  private readonly videoRef = viewChild<ElementRef<HTMLVideoElement>>('videoEl');
+  private readonly mobileTpl = viewChild<TemplateRef<unknown>>('mobileOverlayTpl');
+
+  // DI
+  private readonly vcr = inject(ViewContainerRef);
+  private readonly doc = inject(DOCUMENT);
+
+  // Privado
+  private stream: MediaStream | null = null;
+  private videoTrack: MediaStreamTrack | null = null;
+  private unlistenResize?: () => void;
+  private mobileEmbedded?: EmbeddedViewRef<unknown>;
+  private bodyOverflowPrev: string | null = null;
+
+  constructor() {
+    const renderer = inject(Renderer2);
+    this.unlistenResize = renderer.listen('window', 'resize', () =>
+      this.isMobile.set(window.innerWidth < 768),
+    );
+
+    // Mount/unmount mobile fullscreen overlay teleported to document.body
+    effect(() => {
+      const active = this.isMobile() && this.isOpen();
+      if (active) this.mountMobileOverlay();
+      else this.unmountMobileOverlay();
+    });
+
+    // Stream lifecycle tied to isOpen
+    effect(() => {
+      if (this.isOpen()) {
+        queueMicrotask(() => this.startStream());
+      } else {
+        this.stopStream();
+      }
+    });
+
+    // Restart stream when facingMode flips
+    effect(() => {
+      this.facingMode();
+      if (this.isOpen() && this.stream) this.restartStream();
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.unmountMobileOverlay();
+    this.stopStream();
+    this.unlistenResize?.();
+  }
+
+  private mountMobileOverlay(): void {
+    if (this.mobileEmbedded) return;
+    const tpl = this.mobileTpl();
+    if (!tpl) {
+      // Template not ready yet; try next microtask
+      queueMicrotask(() => this.mountMobileOverlay());
+      return;
+    }
+    this.mobileEmbedded = this.vcr.createEmbeddedView(tpl);
+    this.mobileEmbedded.detectChanges();
+    for (const node of this.mobileEmbedded.rootNodes) {
+      if (node instanceof Node) this.doc.body.appendChild(node);
+    }
+    // Prevent body scroll while overlay is active
+    this.bodyOverflowPrev = this.doc.body.style.overflow;
+    this.doc.body.style.overflow = 'hidden';
+  }
+
+  private unmountMobileOverlay(): void {
+    if (!this.mobileEmbedded) return;
+    this.mobileEmbedded.destroy();
+    this.mobileEmbedded = undefined;
+    if (this.bodyOverflowPrev !== null) {
+      this.doc.body.style.overflow = this.bodyOverflowPrev;
+      this.bodyOverflowPrev = null;
+    }
+  }
+
+  private async startStream(): Promise<void> {
+    this.cameraError.set(null);
+    this.cameraReady.set(false);
+    if (!navigator.mediaDevices?.getUserMedia) {
+      this.cameraError.set('Este navegador no soporta acceso a la cámara');
+      return;
+    }
+    try {
+      this.stream = await navigator.mediaDevices.getUserMedia({
+        video: { facingMode: this.facingMode() },
+        audio: false,
+      });
+      this.videoTrack = this.stream.getVideoTracks()[0] ?? null;
+      this.detectTorchSupport(this.videoTrack);
+      const v = this.videoRef()?.nativeElement;
+      if (v) {
+        v.srcObject = this.stream;
+        v.onloadedmetadata = () => this.cameraReady.set(true);
+      }
+    } catch (err: any) {
+      this.cameraError.set(
+        err?.name === 'NotAllowedError'
+          ? 'Permiso de cámara denegado'
+          : 'No pudimos acceder a la cámara',
+      );
+    }
+  }
+
+  private async restartStream(): Promise<void> {
+    this.stopStream();
+    await this.startStream();
+  }
+
+  private stopStream(): void {
+    if (this.stream) {
+      for (const t of this.stream.getTracks()) t.stop();
+      this.stream = null;
+    }
+    this.videoTrack = null;
+    const v = this.videoRef()?.nativeElement;
+    if (v) v.srcObject = null;
+    this.cameraReady.set(false);
+    this.torchOn.set(false);
+  }
+
+  switchCamera(): void {
+    this.torchOn.set(false);
+    this.torchSupported.set(false);
+    this.facingMode.update((v) => (v === 'user' ? 'environment' : 'user'));
+  }
+
+  async toggleTorch(): Promise<void> {
+    if (!this.videoTrack || !this.torchSupported()) return;
+    const next = !this.torchOn();
+    try {
+      await this.videoTrack.applyConstraints({ advanced: [{ torch: next } as any] });
+      this.torchOn.set(next);
+    } catch {
+      this.torchSupported.set(false);
+    }
+  }
+
+  private detectTorchSupport(track: MediaStreamTrack | null): void {
+    const caps = (track?.getCapabilities?.() ?? {}) as any;
+    this.torchSupported.set(!!caps.torch);
+    this.torchOn.set(false);
+  }
+
+  capture(): void {
+    const v = this.videoRef()?.nativeElement;
+    if (!v || !v.videoWidth) return;
+    const canvas = document.createElement('canvas');
+    canvas.width = v.videoWidth;
+    canvas.height = v.videoHeight;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    ctx.drawImage(v, 0, 0, canvas.width, canvas.height);
+    const dataUrl = canvas.toDataURL('image/jpeg', this.imageQuality());
+    const fileName = `${this.fileNamePrefix()}-${Date.now()}.jpg`;
+    this.stopStream();
+    this.captured.emit({ dataUrl, fileName });
+  }
+
+  close(): void {
+    this.closed.emit();
+  }
+}

--- a/apps/frontend/src/app/shared/components/icon/icons.registry.ts
+++ b/apps/frontend/src/app/shared/components/icon/icons.registry.ts
@@ -255,6 +255,12 @@ import {
   // Inventory redesign icons
   Boxes,
   ArrowUpDown,
+  // Camera + crop transforms icons
+  RotateCw,
+  FlipHorizontal,
+  FlipVertical,
+  SwitchCamera,
+  ZapOff,
 } from 'lucide-angular';
 
 /**
@@ -587,6 +593,13 @@ export const ICON_REGISTRY: Record<string, LucideIconData> = {
   // Inventory redesign icons
   boxes: Boxes,
   'arrow-up-down': ArrowUpDown,
+
+  // Camera + crop transforms icons
+  'rotate-cw': RotateCw,
+  'flip-horizontal': FlipHorizontal,
+  'flip-vertical': FlipVertical,
+  'switch-camera': SwitchCamera,
+  'zap-off': ZapOff,
 } as const;
 
 export type IconName = keyof typeof ICON_REGISTRY;

--- a/apps/frontend/src/app/shared/components/index.ts
+++ b/apps/frontend/src/app/shared/components/index.ts
@@ -17,6 +17,7 @@ export { ToastContainerComponent } from './toast/toast-container.component';
 export { ToastService } from './toast/toast.service';
 export { DialogService } from './dialog/dialog.service';
 export { IconComponent } from './icon/icon.component';
+export { CameraComponent } from './camera/camera.component';
 export { IconPickerComponent } from './icon-picker/icon-picker.component';
 export { InputsearchComponent } from './inputsearch/inputsearch.component';
 export { TableComponent } from './table/table.component';


### PR DESCRIPTION
## Summary

- New generic `<app-camera>` shared component (`apps/frontend/src/app/shared/components/camera/`) with mobile fullscreen overlay (teleported to `document.body` via `ViewContainerRef.createEmbeddedView` to escape `<app-modal>`'s `transform` containing-block) and desktop inline mode
- Camera controls: switch front/rear, optional torch (`MediaTrackCapabilities.torch`), corner-bracket viewfinder, rule-of-thirds grid, `100dvh` viewport, body scroll lock while active
- Product image source modal now consumes `<app-camera>` and adds **rotate-ccw / rotate-cw / flip-horizontal / flip-vertical** to the crop stage with canvas transforms; `applyCrop()` preserves source resolution via full-res temp canvas (cap 4096 px)
- Register Lucide icons: `rotate-cw`, `flip-horizontal`, `flip-vertical`, `switch-camera`, `zap-off`

## Why

Annotation feedback on `/admin/products/edit/:id`: existing camera UI was flat and broken on mobile (overlay anchored to modal due to `transform` ancestor); crop tool lacked rotation/mirror controls.

## Files

- `apps/frontend/src/app/shared/components/camera/camera.component.ts` *(new, 340 lines)*
- `apps/frontend/src/app/private/modules/store/products/components/product-image-source-modal.component.ts` *(refactor, -129 / +120)*
- `apps/frontend/src/app/shared/components/icon/icons.registry.ts` *(+13)*
- `apps/frontend/src/app/shared/components/index.ts` *(+1 barrel export)*

## Test plan

- [ ] **Mobile (≤768 px or real phone)** — open `/admin/products/edit/<id>` → "Agregar imagen" → "Tomar foto". Verify overlay is true fullscreen (covers viewport, no product visible behind), corner brackets + thirds grid centered, large white shutter, switch-camera toggles front/rear, X closes back to source select
- [ ] **Desktop (≥768 px)** — same flow, camera renders inline inside the modal (`size="lg"`), small brackets, `Cancelar` / `Capturar` buttons below
- [ ] **Torch** — on Android Chrome with rear camera supporting `torch`, ⚡ button appears and toggles LED. On iOS / desktop, button is hidden
- [ ] **Crop transforms** — load any image → click rotate-cw (preview rotates 90°, frame recenters with current aspect ratio), flip-horizontal (mirrors), apply → output is rotated + flipped + cropped at near-source resolution
- [ ] **Regressions** — file upload (drag + picker), URL fetch, skip / cancel, multi-image queue all still work; closing modal mid-camera releases the camera (LED off)
- [ ] Build check: `docker compose logs frontend` shows no TS/NG errors after watch rebuild

## Risks

- iOS Safari <15 stacking on `fixed inset-0 z-[10000]` in `document.body` — verify on real device; if broken, the `body.style.overflow = 'hidden'` workaround is already in place
- Approach A in `applyCrop()` doubles peak memory transiently for large images (cap 4096 px keeps temp canvas ≤ ~50 MB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)