### PR TITLE
fix(backend): hotfix TS2339 in products.service blocking EC2 deploy

### DIFF
--- a/apps/backend/src/domains/store/products/products.service.ts
+++ b/apps/backend/src/domains/store/products/products.service.ts
@@ -1746,9 +1746,10 @@ export class ProductsService {
               where: { product_id: id },
               include: { product_images: { select: { image_url: true } } },
             });
-            const existingVariantMap = new Map(
-              allExistingVariants.map((v) => [v.id, v]),
-            );
+            const existingVariantMap = new Map<
+              number,
+              (typeof allExistingVariants)[number]
+            >(allExistingVariants.map((v) => [v.id, v]));
 
             // Detect simple → variant transition
             const isTransitionToVariants =


### PR DESCRIPTION
## Summary

Hotfix para desbloquear deploy backend a EC2 que falló tras merge de #282.

## Causa

\`new Map(allExistingVariants.map((v) => [v.id, v]))\` deja al Map como \`Map<unknown, unknown>\`. Cuando \`existingVariantMap.get(variantId)\` retorna \`{}\`, los accesos a \`previousVariantState.image_id\` y \`previousVariantState.product_images.image_url\` fallan con TS2339 durante \`nest build\` en el Dockerfile.

## Fix

Tipar el Map explícitamente:

\`\`\`ts
new Map<number, (typeof allExistingVariants)[number]>(
  allExistingVariants.map((v) => [v.id, v]),
)
\`\`\`

Preserva la forma del payload (incluyendo el \`include: { product_images: ... }\`).

## Por qué no lo cazó CI

El workflow CI corre Detect Changes + Zoneless Audit + Mobile Typecheck. El backend TS solo se compila en \`npm run build\` durante el Dockerfile del deploy a EC2. Gap conocido — vale agregar typecheck del backend a CI en otro PR.

## Test plan

- [x] \`npx tsc --noEmit\` en \`apps/backend\` local pasa.
- [ ] Deploy a EC2 completa build y push a ECR.
- [ ] Health check del backend responde 200 post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)