### PR TITLE
Sync dev → main: customers module ES + DIAN doc types + mobile org stores + sales/promotion overhaul

### DIFF
--- a/apps/backend/src/common/constants/document-types.ts
+++ b/apps/backend/src/common/constants/document-types.ts
@@ -1,0 +1,63 @@
+/**
+ * Colombian DIAN document type catalog used for customer identification.
+ *
+ * Each code maps to a validation rule (regex + maxLength) and a Spanish label
+ * surfaced in validation error messages. Keep this file as the single source
+ * of truth for backend document validation.
+ */
+export const DOCUMENT_TYPE_CODES = [
+  'CC',
+  'CE',
+  'NIT',
+  'TI',
+  'RC',
+  'PA',
+  'PEP',
+  'PPT',
+  'DIE',
+  'NUIP',
+] as const;
+
+export type DocumentTypeCode = (typeof DOCUMENT_TYPE_CODES)[number];
+
+export interface DocumentTypeRule {
+  regex: RegExp;
+  maxLength: number;
+  label: string; // Spanish label, also used in error messages
+}
+
+export const DOCUMENT_TYPE_RULES: Record<DocumentTypeCode, DocumentTypeRule> = {
+  CC: { regex: /^\d{6,10}$/, maxLength: 10, label: 'Cédula de Ciudadanía' },
+  CE: { regex: /^\d{6,10}$/, maxLength: 10, label: 'Cédula de Extranjería' },
+  NIT: { regex: /^\d{8,10}-?\d?$/, maxLength: 12, label: 'NIT' },
+  TI: { regex: /^\d{8,11}$/, maxLength: 11, label: 'Tarjeta de Identidad' },
+  RC: { regex: /^\d{8,11}$/, maxLength: 11, label: 'Registro Civil' },
+  PA: { regex: /^[A-Z0-9]{5,16}$/, maxLength: 16, label: 'Pasaporte' },
+  PEP: {
+    regex: /^\d{9,15}$/,
+    maxLength: 15,
+    label: 'Permiso Especial de Permanencia',
+  },
+  PPT: {
+    regex: /^\d{9,15}$/,
+    maxLength: 15,
+    label: 'Permiso por Protección Temporal',
+  },
+  DIE: {
+    regex: /^[A-Z0-9]{5,20}$/,
+    maxLength: 20,
+    label: 'Documento de Identificación Extranjero',
+  },
+  NUIP: {
+    regex: /^\d{8,11}$/,
+    maxLength: 11,
+    label: 'Número Único de Identificación Personal',
+  },
+};
+
+export function isValidDocumentType(value: unknown): value is DocumentTypeCode {
+  return (
+    typeof value === 'string' &&
+    (DOCUMENT_TYPE_CODES as readonly string[]).includes(value)
+  );
+}

--- a/apps/backend/src/common/errors/error-codes.ts
+++ b/apps/backend/src/common/errors/error-codes.ts
@@ -2373,6 +2373,39 @@ export const ErrorCodes = {
     devMessage:
       'El sonido está siendo usado por una o más tiendas y no puede eliminarse.',
   },
+
+  // Help Center
+  HELP_ARTICLE_NOT_FOUND: {
+    code: 'HELP_ARTICLE_NOT_FOUND',
+    httpStatus: 404,
+    devMessage: 'Help article not found',
+  },
+  HELP_CATEGORY_NOT_FOUND: {
+    code: 'HELP_CATEGORY_NOT_FOUND',
+    httpStatus: 404,
+    devMessage: 'Help category not found',
+  },
+  HELP_CATEGORY_HAS_ARTICLES: {
+    code: 'HELP_CATEGORY_HAS_ARTICLES',
+    httpStatus: 409,
+    devMessage: 'Cannot delete category with associated articles',
+  },
+  HELP_IMAGE_REQUIRED: {
+    code: 'HELP_IMAGE_REQUIRED',
+    httpStatus: 400,
+    devMessage: 'Image file is required',
+  },
+  HELP_IMAGE_TYPE_INVALID: {
+    code: 'HELP_IMAGE_TYPE_INVALID',
+    httpStatus: 400,
+    devMessage:
+      'Only image files are allowed (JPEG, PNG, WebP, GIF, BMP, TIFF, SVG, HEIC, AVIF)',
+  },
+  HELP_IMAGE_TOO_LARGE: {
+    code: 'HELP_IMAGE_TOO_LARGE',
+    httpStatus: 400,
+    devMessage: 'Image file must be smaller than 10MB',
+  },
 } as const satisfies Record<string, ErrorCodeEntry>;
 
 export const FiscalScopeBlockerCodes = {

--- a/apps/backend/src/common/filters/http-exception.filter.ts
+++ b/apps/backend/src/common/filters/http-exception.filter.ts
@@ -32,15 +32,22 @@ export class AllExceptionsFilter implements ExceptionFilter {
       details = resp.details;
     } else if (exception instanceof HttpException) {
       const resp = exception.getResponse() as any;
-      message = resp;
-      if (resp?.error_code) {
-        errorCode = resp.error_code;
-      }
-      // Detect class-validator ValidationPipe errors (array of messages)
-      if (Array.isArray(resp?.message)) {
+      if (resp?.error_code) errorCode = resp.error_code;
+      details = resp?.details;
+
+      const rawMessage =
+        resp && typeof resp === 'object'
+          ? (resp.message ?? resp.error ?? exception.message)
+          : (resp ?? exception.message);
+
+      if (Array.isArray(rawMessage)) {
         errorCode = 'SYS_VALIDATION_001';
-        details = { validationErrors: resp.message };
+        details = { validationErrors: rawMessage };
         message = 'Validation failed';
+      } else if (typeof rawMessage === 'string') {
+        message = rawMessage;
+      } else {
+        message = exception.message || 'Request failed';
       }
     } else {
       errorCode = 'SYS_INTERNAL_001';

--- a/apps/backend/src/common/validators/document-number.validator.ts
+++ b/apps/backend/src/common/validators/document-number.validator.ts
@@ -1,0 +1,118 @@
+import {
+  registerDecorator,
+  ValidationArguments,
+  ValidationOptions,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+import {
+  DOCUMENT_TYPE_RULES,
+  DocumentTypeCode,
+  isValidDocumentType,
+} from '../constants/document-types';
+
+type FailureReason =
+  | 'missing_type'
+  | 'invalid_type'
+  | 'too_long'
+  | 'pattern_mismatch'
+  | 'not_a_string';
+
+interface ResolvedValidation {
+  ok: boolean;
+  reason?: FailureReason;
+  type?: DocumentTypeCode;
+}
+
+function resolve(value: unknown, object: unknown): ResolvedValidation {
+  if (value === undefined || value === null || value === '') {
+    return { ok: true };
+  }
+
+  if (typeof value !== 'string') {
+    return { ok: false, reason: 'not_a_string' };
+  }
+
+  const rawType = (object as Record<string, unknown> | null | undefined)?.[
+    'document_type'
+  ];
+
+  if (rawType === undefined || rawType === null || rawType === '') {
+    return { ok: false, reason: 'missing_type' };
+  }
+
+  if (typeof rawType !== 'string' || !isValidDocumentType(rawType)) {
+    return { ok: false, reason: 'invalid_type' };
+  }
+
+  const type = rawType as DocumentTypeCode;
+  const rule = DOCUMENT_TYPE_RULES[type];
+  const normalized = value.trim().toUpperCase();
+
+  if (normalized.length > rule.maxLength) {
+    return { ok: false, reason: 'too_long', type };
+  }
+
+  if (!rule.regex.test(normalized)) {
+    return { ok: false, reason: 'pattern_mismatch', type };
+  }
+
+  return { ok: true, type };
+}
+
+/**
+ * Cross-field validator: ensures `document_number` matches the regex/maxLength
+ * of the sibling `document_type` field. Requires `document_type` to be present
+ * when `document_number` is provided.
+ *
+ * Use via `@DocumentNumberMatchesType()` on the `document_number` property.
+ */
+@ValidatorConstraint({ name: 'DocumentNumberMatchesType', async: false })
+export class DocumentNumberMatchesTypeConstraint
+  implements ValidatorConstraintInterface
+{
+  validate(value: unknown, args: ValidationArguments): boolean {
+    return resolve(value, args.object).ok;
+  }
+
+  defaultMessage(args: ValidationArguments): string {
+    const result = resolve(args.value, args.object);
+
+    if (result.ok) {
+      return 'document_number inválido';
+    }
+
+    switch (result.reason) {
+      case 'missing_type':
+        return 'document_type es requerido cuando se proporciona document_number';
+      case 'invalid_type':
+        return 'document_type inválido';
+      case 'not_a_string':
+        return 'document_number debe ser un string';
+      case 'too_long':
+      case 'pattern_mismatch': {
+        if (result.type) {
+          const rule = DOCUMENT_TYPE_RULES[result.type];
+          return `document_number no cumple el formato de ${rule.label}`;
+        }
+        return 'document_number inválido';
+      }
+      default:
+        return 'document_number inválido';
+    }
+  }
+}
+
+export function DocumentNumberMatchesType(
+  validationOptions?: ValidationOptions,
+) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      name: 'DocumentNumberMatchesType',
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      validator: DocumentNumberMatchesTypeConstraint,
+    });
+  };
+}

--- a/apps/backend/src/domains/ecommerce/account/account.service.ts
+++ b/apps/backend/src/domains/ecommerce/account/account.service.ts
@@ -209,6 +209,45 @@ export class AccountService {
           include: { product: { select: { name: true } } },
           orderBy: { date: 'asc' },
         },
+        // Persisted discount snapshots — read what was actually charged,
+        // never recalculate against current promotions/coupons.
+        order_promotions: {
+          select: {
+            id: true,
+            promotion_id: true,
+            discount_amount: true,
+            created_at: true,
+            promotions: {
+              select: {
+                id: true,
+                name: true,
+                code: true,
+                type: true,
+                scope: true,
+                value: true,
+              },
+            },
+          },
+          orderBy: { created_at: 'asc' },
+        },
+        coupon_uses: {
+          select: {
+            id: true,
+            coupon_id: true,
+            discount_applied: true,
+            used_at: true,
+            coupon: {
+              select: {
+                id: true,
+                code: true,
+                name: true,
+                discount_type: true,
+                discount_value: true,
+              },
+            },
+          },
+          orderBy: { used_at: 'asc' },
+        },
       },
     });
 
@@ -269,6 +308,28 @@ export class AccountService {
           product_id: b.product_id,
           product_name: b.product?.name,
         })) || [],
+      // Historical discount snapshots persisted on the order.
+      applied_promotions: order.order_promotions.map((op) => ({
+        id: op.id,
+        promotion_id: op.promotion_id,
+        name: op.promotions?.name ?? null,
+        code: op.promotions?.code ?? null,
+        type: op.promotions?.type ?? null,
+        scope: op.promotions?.scope ?? null,
+        value: op.promotions?.value ?? null,
+        discount_amount: op.discount_amount,
+        created_at: op.created_at,
+      })),
+      applied_coupons: order.coupon_uses.map((cu) => ({
+        id: cu.id,
+        coupon_id: cu.coupon_id,
+        code: cu.coupon?.code ?? null,
+        name: cu.coupon?.name ?? null,
+        discount_type: cu.coupon?.discount_type ?? null,
+        discount_value: cu.coupon?.discount_value ?? null,
+        discount_applied: cu.discount_applied,
+        used_at: cu.used_at,
+      })),
     };
   }
 

--- a/apps/backend/src/domains/ecommerce/cart/cart.module.ts
+++ b/apps/backend/src/domains/ecommerce/cart/cart.module.ts
@@ -6,9 +6,19 @@ import { StorageModule } from '../../../storage.module';
 import { SettingsModule } from '../../store/settings/settings.module';
 import { InventoryModule } from '../../store/inventory/inventory.module';
 import { ProductsModule } from '../../store/products/products.module';
+import { PromotionsModule } from '../../store/promotions/promotions.module';
 
 @Module({
-  imports: [PrismaModule, StorageModule, SettingsModule, InventoryModule, ProductsModule],
+  imports: [
+    PrismaModule,
+    StorageModule,
+    SettingsModule,
+    InventoryModule,
+    ProductsModule,
+    // PromotionEngineService is used to estimate promotional discounts in
+    // the cart summary endpoint. No write — pure quote.
+    PromotionsModule,
+  ],
   controllers: [CartController],
   providers: [CartService],
   exports: [CartService],

--- a/apps/backend/src/domains/ecommerce/cart/cart.service.ts
+++ b/apps/backend/src/domains/ecommerce/cart/cart.service.ts
@@ -11,6 +11,9 @@ import { SettingsService } from '../../store/settings/settings.service';
 import { VendixHttpException, ErrorCodes } from 'src/common/errors';
 import { StockValidatorService } from '../../store/inventory/shared/services/stock-validator.service';
 import { PriceResolverService } from '../../store/products/services/price-resolver.service';
+import { PromotionEngineService } from '../../store/promotions/promotion-engine/promotion-engine.service';
+import { StorePrismaService } from '../../../prisma/services/store-prisma.service';
+import { RequestContextService } from '@common/context/request-context.service';
 
 @Injectable()
 export class CartService {
@@ -22,6 +25,8 @@ export class CartService {
     private readonly settingsService: SettingsService,
     private readonly stockValidatorService: StockValidatorService,
     private readonly priceResolverService: PriceResolverService,
+    private readonly promotionEngine: PromotionEngineService,
+    private readonly storePrisma: StorePrismaService,
   ) {}
 
   private readonly cartInclude = {
@@ -425,6 +430,135 @@ export class CartService {
     if (!availability.isAvailable) {
       throw new VendixHttpException(ErrorCodes.ECOM_CART_003);
     }
+  }
+
+  /**
+   * Build an authoritative cart summary with the items the customer has
+   * loaded (authenticated DB cart OR DTO items from localStorage) and the
+   * promotion engine output. Pure quote — no order is created. Used by the
+   * cart view to surface a realistic total before checkout.
+   *
+   * Coupons are intentionally NOT evaluated here — the cart UI only hints
+   * at automatic promotional discounts. The coupon enters the picture in
+   * the checkout payload.
+   */
+  async getCartSummary(items?: Array<{
+    product_id: number;
+    product_variant_id?: number | null;
+    quantity: number;
+  }>): Promise<{
+    subtotal: number;
+    promotion_discount: number;
+    promotional_subtotal: number;
+    item_count: number;
+    applied_promotions: Array<{
+      promotion_id: number;
+      name: string;
+      discount_amount: number;
+    }>;
+  }> {
+    // Auth users: prefer the backend cart so quantities are server-side
+    // canonical. Guests: use the DTO items array as the source of truth.
+    let resolvedItems: Array<{
+      product_id: number;
+      product_variant_id: number | null;
+      quantity: number;
+      unit_price: number;
+    }> = [];
+
+    if (items && items.length > 0) {
+      resolvedItems = await Promise.all(
+        items.map(async (item) => {
+          const product = await this.prisma.products.findUnique({
+            where: { id: item.product_id },
+          });
+          if (!product) {
+            return null;
+          }
+          const variant = item.product_variant_id
+            ? await this.prisma.product_variants.findUnique({
+                where: { id: item.product_variant_id },
+              })
+            : null;
+          const priceResult = this.priceResolverService.resolvePrice(
+            this.toPriceResolverParams(product, variant),
+          );
+          return {
+            product_id: item.product_id,
+            product_variant_id: item.product_variant_id ?? null,
+            quantity: item.quantity,
+            unit_price: Math.round(priceResult.unitPrice * 100) / 100,
+          };
+        }),
+      ).then((rows) => rows.filter((r): r is NonNullable<typeof r> => r !== null));
+    } else {
+      const cart = await this.prisma.carts.findFirst({
+        include: { cart_items: true },
+      });
+      if (!cart) {
+        return {
+          subtotal: 0,
+          promotion_discount: 0,
+          promotional_subtotal: 0,
+          item_count: 0,
+          applied_promotions: [],
+        };
+      }
+      resolvedItems = cart.cart_items.map((ci) => ({
+        product_id: ci.product_id,
+        product_variant_id: ci.product_variant_id,
+        quantity: ci.quantity,
+        unit_price: Number(ci.unit_price),
+      }));
+    }
+
+    if (resolvedItems.length === 0) {
+      return {
+        subtotal: 0,
+        promotion_discount: 0,
+        promotional_subtotal: 0,
+        item_count: 0,
+        applied_promotions: [],
+      };
+    }
+
+    const productIds = Array.from(
+      new Set(resolvedItems.map((i) => i.product_id)),
+    );
+    const categoryRows = await this.storePrisma.product_categories.findMany({
+      where: { product_id: { in: productIds } },
+      select: { product_id: true, category_id: true },
+    });
+    const categoryMap = new Map<number, number[]>();
+    for (const row of categoryRows) {
+      const existing = categoryMap.get(row.product_id) ?? [];
+      existing.push(row.category_id);
+      categoryMap.set(row.product_id, existing);
+    }
+
+    const quote = await this.promotionEngine.quoteDiscounts({
+      items: resolvedItems.map((item, index) => ({
+        line_id: index,
+        product_id: item.product_id,
+        variant_id: item.product_variant_id,
+        category_ids: categoryMap.get(item.product_id) ?? [],
+        unit_price: item.unit_price,
+        quantity: item.quantity,
+      })),
+      customer_id: RequestContextService.getUserId() ?? null,
+    });
+
+    return {
+      subtotal: quote.subtotal,
+      promotion_discount: quote.total_discount,
+      promotional_subtotal: quote.promotional_subtotal,
+      item_count: resolvedItems.reduce((sum, i) => sum + i.quantity, 0),
+      applied_promotions: quote.applied_promotions.map((p) => ({
+        promotion_id: p.promotion_id,
+        name: p.name,
+        discount_amount: p.discount_amount,
+      })),
+    };
   }
 
   private toPriceResolverParams(product: any, variant?: any) {

--- a/apps/backend/src/domains/ecommerce/catalog/catalog.module.ts
+++ b/apps/backend/src/domains/ecommerce/catalog/catalog.module.ts
@@ -3,9 +3,10 @@ import { CatalogController } from './catalog.controller';
 import { CatalogService } from './catalog.service';
 import { PrismaModule } from '../../../prisma/prisma.module';
 import { ProductsModule } from '../../store/products/products.module';
+import { PromotionsModule } from '../../store/promotions/promotions.module';
 
 @Module({
-  imports: [PrismaModule, ProductsModule],
+  imports: [PrismaModule, ProductsModule, PromotionsModule],
   controllers: [CatalogController],
   providers: [CatalogService],
   exports: [CatalogService],

--- a/apps/backend/src/domains/ecommerce/catalog/catalog.service.spec.ts
+++ b/apps/backend/src/domains/ecommerce/catalog/catalog.service.spec.ts
@@ -1,17 +1,22 @@
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Test, TestingModule } from '@nestjs/testing';
 import { EcommercePrismaService } from '../../../prisma/services/ecommerce-prisma.service';
+import { StorePrismaService } from '../../../prisma/services/store-prisma.service';
 import { S3Service } from '@common/services/s3.service';
 import { PriceResolverService } from '../../store/products/services/price-resolver.service';
+import { PromotionEngineService } from '../../store/promotions/promotion-engine/promotion-engine.service';
 import { CatalogService } from './catalog.service';
 
 describe('CatalogService reviews', () => {
   let service: CatalogService;
   let prisma: {
     store_settings: { findFirst: jest.Mock };
-    products: { findFirst: jest.Mock };
+    products: { findFirst: jest.Mock; findMany: jest.Mock; count: jest.Mock };
     reviews: { aggregate: jest.Mock; count: jest.Mock };
+    promotions: { findMany: jest.Mock };
+    product_categories: { findMany: jest.Mock };
   };
+  let promotionEngine: { findActiveAutoPromotionsForProducts: jest.Mock };
 
   const enabledSettings = {
     settings: { ecommerce: { catalog: { allow_reviews: true } } },
@@ -47,17 +52,29 @@ describe('CatalogService reviews', () => {
   beforeEach(async () => {
     prisma = {
       store_settings: { findFirst: jest.fn().mockResolvedValue(enabledSettings) },
-      products: { findFirst: jest.fn() },
+      products: {
+        findFirst: jest.fn(),
+        findMany: jest.fn().mockResolvedValue([]),
+        count: jest.fn().mockResolvedValue(0),
+      },
       reviews: {
         aggregate: jest.fn(),
         count: jest.fn(),
       },
+      promotions: { findMany: jest.fn().mockResolvedValue([]) },
+      product_categories: { findMany: jest.fn().mockResolvedValue([]) },
+    };
+    promotionEngine = {
+      findActiveAutoPromotionsForProducts: jest
+        .fn()
+        .mockResolvedValue(new Map()),
     };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         CatalogService,
         { provide: EcommercePrismaService, useValue: prisma },
+        { provide: StorePrismaService, useValue: prisma },
         {
           provide: S3Service,
           useValue: { signUrl: jest.fn(async (key) => key) },
@@ -71,6 +88,7 @@ describe('CatalogService reviews', () => {
             })),
           },
         },
+        { provide: PromotionEngineService, useValue: promotionEngine },
         { provide: CACHE_MANAGER, useValue: { get: jest.fn(), set: jest.fn() } },
       ],
     }).compile();
@@ -126,5 +144,225 @@ describe('CatalogService reviews', () => {
     expect(prisma.reviews.count).toHaveBeenCalledWith({
       where: { product_id: 100, state: 'approved' },
     });
+  });
+});
+
+describe('CatalogService active promotions on listing', () => {
+  let service: CatalogService;
+  let prisma: {
+    store_settings: { findFirst: jest.Mock };
+    products: { findMany: jest.Mock; count: jest.Mock };
+    promotions: { findMany: jest.Mock };
+    product_categories: { findMany: jest.Mock };
+  };
+  let promotionEngine: { findActiveAutoPromotionsForProducts: jest.Mock };
+
+  const listedProduct = (id: number, categoryId?: number) => ({
+    id,
+    name: `Producto ${id}`,
+    slug: `producto-${id}`,
+    description: 'Detalle',
+    base_price: 100,
+    sale_price: null,
+    is_on_sale: false,
+    is_featured: false,
+    sku: `SKU-${id}`,
+    track_inventory: true,
+    stock_quantity: 5,
+    product_images: [],
+    brands: null,
+    product_categories: categoryId
+      ? [{ category_id: categoryId, categories: { id: categoryId, name: 'C' } }]
+      : [],
+    product_variants: [],
+    product_tax_assignments: [],
+    product_type: 'physical',
+    requires_booking: false,
+    service_duration_minutes: null,
+    service_modality: null,
+    booking_mode: null,
+    stock_levels: [],
+    _count: { product_variants: 0 },
+  });
+
+  beforeEach(async () => {
+    prisma = {
+      store_settings: {
+        findFirst: jest.fn().mockResolvedValue({
+          settings: { ecommerce: { catalog: { allow_reviews: true } } },
+        }),
+      },
+      products: {
+        findMany: jest.fn(),
+        count: jest.fn(),
+      },
+      promotions: { findMany: jest.fn().mockResolvedValue([]) },
+      product_categories: { findMany: jest.fn().mockResolvedValue([]) },
+    };
+    promotionEngine = {
+      findActiveAutoPromotionsForProducts: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CatalogService,
+        { provide: EcommercePrismaService, useValue: prisma },
+        { provide: StorePrismaService, useValue: prisma },
+        {
+          provide: S3Service,
+          useValue: { signUrl: jest.fn(async (key) => key ?? null) },
+        },
+        {
+          provide: PriceResolverService,
+          useValue: {
+            resolvePrice: jest.fn(() => ({
+              unitBasePrice: 100,
+              unitPriceWithTax: 100,
+            })),
+          },
+        },
+        { provide: PromotionEngineService, useValue: promotionEngine },
+        { provide: CACHE_MANAGER, useValue: { get: jest.fn(), set: jest.fn() } },
+      ],
+    }).compile();
+
+    service = module.get(CatalogService);
+  });
+
+  it('attaches active_promotion to products that match a product-scope auto promotion', async () => {
+    prisma.products.findMany.mockResolvedValueOnce([listedProduct(1)]);
+    prisma.products.count.mockResolvedValueOnce(1);
+    promotionEngine.findActiveAutoPromotionsForProducts.mockResolvedValueOnce(
+      new Map([
+        [
+          1,
+          {
+            id: 99,
+            name: '20% OFF',
+            type: 'percentage',
+            scope: 'product',
+            discount_percentage: 20,
+            promotional_price: 80,
+            badge_label: '-20% OFF',
+            priority: 1,
+          },
+        ],
+      ]),
+    );
+
+    const result = await service.getProducts({} as any);
+
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].active_promotion).toMatchObject({
+      id: 99,
+      promotional_price: 80,
+      badge_label: '-20% OFF',
+    });
+    expect(promotionEngine.findActiveAutoPromotionsForProducts).toHaveBeenCalled();
+  });
+
+  it('attaches active_promotion when a product qualifies by category scope', async () => {
+    prisma.products.findMany.mockResolvedValueOnce([listedProduct(2, 7)]);
+    prisma.products.count.mockResolvedValueOnce(1);
+    promotionEngine.findActiveAutoPromotionsForProducts.mockResolvedValueOnce(
+      new Map([
+        [
+          2,
+          {
+            id: 200,
+            name: 'Cat 10%',
+            type: 'percentage',
+            scope: 'category',
+            discount_percentage: 10,
+            promotional_price: 90,
+            badge_label: '-10% OFF',
+            priority: 0,
+          },
+        ],
+      ]),
+    );
+
+    const result = await service.getProducts({} as any);
+
+    expect(result.data[0].active_promotion).toMatchObject({
+      id: 200,
+      scope: 'category',
+      promotional_price: 90,
+    });
+    // Inputs forwarded to the engine include the product's category ids.
+    const call =
+      promotionEngine.findActiveAutoPromotionsForProducts.mock.calls[0][0];
+    expect(call[0].category_ids).toContain(7);
+  });
+
+  it('leaves active_promotion=null when no promotion applies', async () => {
+    prisma.products.findMany.mockResolvedValueOnce([listedProduct(3)]);
+    prisma.products.count.mockResolvedValueOnce(1);
+    promotionEngine.findActiveAutoPromotionsForProducts.mockResolvedValueOnce(
+      new Map(),
+    );
+
+    const result = await service.getProducts({} as any);
+
+    expect(result.data[0].active_promotion).toBeNull();
+  });
+
+  it('expands has_discount=true to include products in active auto promotions', async () => {
+    // Promotion engine call result for the page is empty; we focus on the
+    // additional id-based filter applied to the products query.
+    prisma.products.findMany.mockResolvedValueOnce([]);
+    prisma.products.count.mockResolvedValueOnce(0);
+    promotionEngine.findActiveAutoPromotionsForProducts.mockResolvedValueOnce(
+      new Map(),
+    );
+    prisma.promotions.findMany.mockResolvedValueOnce([
+      {
+        scope: 'product',
+        promotion_products: [{ product_id: 11 }, { product_id: 12 }],
+        promotion_categories: [],
+      },
+      {
+        scope: 'category',
+        promotion_products: [],
+        promotion_categories: [{ category_id: 5 }],
+      },
+    ]);
+    prisma.product_categories.findMany.mockResolvedValueOnce([
+      { product_id: 21 },
+    ]);
+
+    await service.getProducts({ has_discount: 'true' } as any);
+
+    const where = prisma.products.findMany.mock.calls[0][0].where;
+    expect(where.AND).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          OR: expect.arrayContaining([
+            { is_on_sale: true },
+            { id: { in: expect.arrayContaining([11, 12, 21]) } },
+          ]),
+        }),
+      ]),
+    );
+  });
+
+  it('keeps the legacy is_on_sale branch when no active auto promotion exists', async () => {
+    prisma.products.findMany.mockResolvedValueOnce([]);
+    prisma.products.count.mockResolvedValueOnce(0);
+    promotionEngine.findActiveAutoPromotionsForProducts.mockResolvedValueOnce(
+      new Map(),
+    );
+    prisma.promotions.findMany.mockResolvedValueOnce([]);
+
+    await service.getProducts({ has_discount: 'true' } as any);
+
+    const where = prisma.products.findMany.mock.calls[0][0].where;
+    expect(where.AND).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          OR: expect.arrayContaining([{ is_on_sale: true }]),
+        }),
+      ]),
+    );
   });
 });

--- a/apps/backend/src/domains/ecommerce/catalog/catalog.service.ts
+++ b/apps/backend/src/domains/ecommerce/catalog/catalog.service.ts
@@ -7,6 +7,11 @@ import { CatalogQueryDto, ProductSortBy } from './dto/catalog-query.dto';
 import { RequestContextService } from '@common/context/request-context.service';
 import { S3Service } from '@common/services/s3.service';
 import { PriceResolverService } from '../../store/products/services/price-resolver.service';
+import { PromotionEngineService } from '../../store/promotions/promotion-engine/promotion-engine.service';
+import type {
+  ActiveProductPromotion,
+  ActivePromotionProductInput,
+} from '../../store/promotions/dto/promotion-quote.interface';
 
 @Injectable()
 export class CatalogService {
@@ -15,6 +20,7 @@ export class CatalogService {
     private readonly storePrisma: StorePrismaService,
     private readonly s3Service: S3Service,
     private readonly priceResolverService: PriceResolverService,
+    private readonly promotionEngine: PromotionEngineService,
     @Inject(CACHE_MANAGER) private readonly cache: Cache,
   ) {}
 
@@ -85,8 +91,23 @@ export class CatalogService {
       where.base_price = { ...where.base_price, lte: max_price };
     }
 
+    // `has_discount=true` filters products that should show some kind of
+    // promotional badge on the card. We surface either:
+    //  (a) products with an explicit sale price (is_on_sale = true), or
+    //  (b) products eligible for an active auto-apply promotion by
+    //      scope=product (direct) or scope=category (via product_categories).
+    // Order-scope promotions are not included because they depend on cart
+    // context, not on the product itself.
     if (String(query.has_discount) === 'true') {
-      where.is_on_sale = true;
+      const promotedProductIds =
+        await this.fetchPromotedProductIdsForActiveAutoPromotions();
+      const promotionalIdFilter =
+        promotedProductIds.length > 0
+          ? [{ id: { in: promotedProductIds } }]
+          : [];
+      andFilters.push({
+        OR: [{ is_on_sale: true }, ...promotionalIdFilter],
+      });
     }
 
     if (String(query.is_featured) === 'true') {
@@ -277,8 +298,15 @@ export class CatalogService {
         // O simplemente devolvemos vacío si es muy complejo.
         // Lo mejor: Comportamiento normal (orderBy created_at) para page > 1
       } else {
+        const activePromotionsByProductId =
+          await this.resolveActivePromotionsForListing(finalData);
         const mappedData = await Promise.all(
-          finalData.map((p) => this.mapProductToResponse(p)),
+          finalData.map((p) =>
+            this.mapProductToResponse(
+              p,
+              activePromotionsByProductId.get(p.id) ?? null,
+            ),
+          ),
         );
 
         return {
@@ -337,8 +365,15 @@ export class CatalogService {
       this.prisma.products.count({ where }),
     ]);
 
+    const activePromotionsByProductId =
+      await this.resolveActivePromotionsForListing(data);
     const mappedData = await Promise.all(
-      data.map((product) => this.mapProductToResponse(product)),
+      data.map((product) =>
+        this.mapProductToResponse(
+          product,
+          activePromotionsByProductId.get(product.id) ?? null,
+        ),
+      ),
     );
 
     return {
@@ -616,7 +651,10 @@ export class CatalogService {
       .map((item) => item.product_id as number);
   }
 
-  private async mapProductToResponse(product: any) {
+  private async mapProductToResponse(
+    product: any,
+    activePromotion: ActiveProductPromotion | null = null,
+  ) {
     const raw_image_url = product.product_images?.[0]?.image_url || null;
     const signed_image_url = await this.s3Service.signUrl(raw_image_url);
 
@@ -647,6 +685,7 @@ export class CatalogService {
       is_on_sale: product.is_on_sale,
       is_featured: product.is_featured,
       final_price: this.calculateFinalPrice(product),
+      active_promotion: activePromotion,
       sku: product.sku,
       // Mantener compatibilidad: stock_quantity ahora se calcula desde stock_levels.
       stock_quantity: availableStock,
@@ -889,5 +928,112 @@ export class CatalogService {
       (sl: any) => sl.product_variant_id == null,
     );
     return this.sumStockLevelsAvailable(baseLevels);
+  }
+
+  /**
+   * Batch-resolve the active auto-apply promotion for each product in a
+   * listing. Cards display the promotional price computed off the same
+   * tax-inclusive `final_price` they would otherwise show, so the badge
+   * stays visually consistent. Errors are swallowed: the catalog must
+   * never fail because of promotions, the card simply omits the badge.
+   */
+  private async resolveActivePromotionsForListing(
+    products: any[],
+  ): Promise<Map<number, ActiveProductPromotion>> {
+    if (!Array.isArray(products) || products.length === 0) {
+      return new Map();
+    }
+
+    const inputs: ActivePromotionProductInput[] = products
+      .map((product) => {
+        const productId = Number(product?.id);
+        if (!Number.isFinite(productId)) return null;
+        const unitPrice = this.calculateFinalPrice(product);
+        if (!Number.isFinite(unitPrice) || unitPrice <= 0) return null;
+        const categoryIds: number[] = (product.product_categories ?? [])
+          .map((pc: any) => Number(pc?.categories?.id ?? pc?.category_id))
+          .filter((id: number) => Number.isFinite(id));
+        return {
+          product_id: productId,
+          category_ids: categoryIds,
+          unit_price: unitPrice,
+        } as ActivePromotionProductInput;
+      })
+      .filter((value): value is ActivePromotionProductInput => value !== null);
+
+    if (inputs.length === 0) return new Map();
+
+    try {
+      return await this.promotionEngine.findActiveAutoPromotionsForProducts(
+        inputs,
+      );
+    } catch {
+      return new Map();
+    }
+  }
+
+  /**
+   * Return the product ids covered by at least one active auto-apply
+   * promotion eligible by scope=product or scope=category. Used by the
+   * `has_discount=true` filter so the catalog returns BOTH products with
+   * sale_price and products with an active promotional badge.
+   */
+  private async fetchPromotedProductIdsForActiveAutoPromotions(): Promise<
+    number[]
+  > {
+    const now = new Date();
+
+    // `promotions` and `product_categories` are not scoped by
+    // EcommercePrismaService, so we use storePrisma — which scopes by the
+    // request store via its standard interceptors.
+    const promotions = await this.storePrisma.promotions.findMany({
+      where: {
+        state: { in: ['active', 'scheduled'] },
+        start_date: { lte: now },
+        OR: [{ end_date: null }, { end_date: { gte: now } }],
+        is_auto_apply: true,
+        scope: { in: ['product', 'category'] },
+      },
+      select: {
+        scope: true,
+        promotion_products: { select: { product_id: true } },
+        promotion_categories: { select: { category_id: true } },
+      },
+    });
+
+    if (promotions.length === 0) return [];
+
+    const directProductIds = new Set<number>();
+    const categoryIds = new Set<number>();
+    for (const promo of promotions) {
+      if (promo.scope === 'product') {
+        for (const pp of promo.promotion_products) {
+          if (Number.isFinite(pp.product_id)) {
+            directProductIds.add(Number(pp.product_id));
+          }
+        }
+      } else if (promo.scope === 'category') {
+        for (const pc of promo.promotion_categories) {
+          if (Number.isFinite(pc.category_id)) {
+            categoryIds.add(Number(pc.category_id));
+          }
+        }
+      }
+    }
+
+    if (categoryIds.size > 0) {
+      const categoryProductLinks =
+        await this.storePrisma.product_categories.findMany({
+          where: { category_id: { in: Array.from(categoryIds) } },
+          select: { product_id: true },
+        });
+      for (const link of categoryProductLinks) {
+        if (Number.isFinite(link.product_id)) {
+          directProductIds.add(Number(link.product_id));
+        }
+      }
+    }
+
+    return Array.from(directProductIds);
   }
 }

--- a/apps/backend/src/domains/ecommerce/checkout/checkout.module.ts
+++ b/apps/backend/src/domains/ecommerce/checkout/checkout.module.ts
@@ -17,6 +17,8 @@ import { InvoicingModule } from '../../store/invoicing/invoicing.module';
 import { InvoiceDataRequestsModule } from '../../store/invoicing/invoice-data-requests/invoice-data-requests.module';
 import { S3Module } from '../../../common/services/s3.module';
 import { CustomersModule } from '../../store/customers/customers.module';
+import { PromotionsModule } from '../../store/promotions/promotions.module';
+import { CouponsModule } from '../../store/coupons/coupons.module';
 
 @Module({
   imports: [
@@ -37,6 +39,13 @@ import { CustomersModule } from '../../store/customers/customers.module';
     InvoiceDataRequestsModule,
     S3Module,
     CustomersModule,
+    // PromotionsModule exposes PromotionEngineService.quoteDiscounts, the
+    // shared source-of-truth used by checkout to recompute automatic promo
+    // discounts. CouponsModule exposes CouponsService.validate/registerUse
+    // for the optional coupon flow. Both must be available scoped per-store
+    // (StorePrismaService inside).
+    PromotionsModule,
+    CouponsModule,
     // 5 MB max upload — matches what the checkout controller's
     // FileInterceptor advertises so multer rejects oversized uploads early
     // (before the buffer is even allocated).

--- a/apps/backend/src/domains/ecommerce/checkout/checkout.service.spec.ts
+++ b/apps/backend/src/domains/ecommerce/checkout/checkout.service.spec.ts
@@ -1,0 +1,645 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { CheckoutService } from './checkout.service';
+import { EcommercePrismaService } from '../../../prisma/services/ecommerce-prisma.service';
+import { StorePrismaService } from '../../../prisma/services/store-prisma.service';
+import { CartService } from '../cart/cart.service';
+import { TaxesService } from '../../store/taxes/taxes.service';
+import { SettingsService } from '../../store/settings/settings.service';
+import { StockLevelManager } from '../../store/inventory/shared/services/stock-level-manager.service';
+import { StockValidatorService } from '../../store/inventory/shared/services/stock-validator.service';
+import { PriceResolverService } from '../../store/products/services/price-resolver.service';
+import { WompiClientFactory } from '../../store/payments/processors/wompi/wompi.factory';
+import { WompiProcessor } from '../../store/payments/processors/wompi/wompi.processor';
+import { PaymentEncryptionService } from '../../store/payments/services/payment-encryption.service';
+import { WebhookHandlerService } from '../../store/payments/services/webhook-handler.service';
+import { ReservationsService } from '../../store/reservations/reservations.service';
+import { InvoiceDataRequestsService } from '../../store/invoicing/invoice-data-requests/invoice-data-requests.service';
+import { InvoicingService } from '../../store/invoicing/invoicing.service';
+import { OperatingScopeService } from '@common/services/operating-scope.service';
+import { FiscalStatusService } from '@common/services/fiscal-status.service';
+import { S3Service } from '@common/services/s3.service';
+import { S3PathHelper } from '@common/helpers/s3-path.helper';
+import { CustomersService } from '../../store/customers/customers.service';
+import { PromotionEngineService } from '../../store/promotions/promotion-engine/promotion-engine.service';
+import { CouponsService } from '../../store/coupons/coupons.service';
+import { RequestContextService } from '@common/context/request-context.service';
+import { VendixHttpException } from 'src/common/errors';
+
+/**
+ * Tests for ecommerce CheckoutService promotion/coupon recalculation.
+ *
+ * The service has many collaborators that aren't relevant to the discount
+ * flow — they're all stubbed with no-op mocks. The interesting expectations
+ * focus on:
+ *  - `quoteDiscounts` is invoked with the right items/categories/customer
+ *  - `coupon_code` triggers `CouponsService.validate` exactly once
+ *  - `orders.create` receives the correct `subtotal_amount`, `discount_amount`
+ *    and `grand_total` (= subtotal + taxes - discount + shipping)
+ *  - `applyPromotion` + `registerUse` run AFTER the order is created
+ *  - Wompi/manual payments use the order's `grand_total`
+ *  - WhatsApp checkout shares the same logic and returns discount fields
+ *  - Invalid coupon aborts the checkout with a VendixHttpException
+ */
+
+const PRODUCT_BASE = {
+  id: 100,
+  name: 'Producto Base',
+  base_price: 10000,
+  is_on_sale: false,
+  sale_price: null,
+  cost_price: 5000,
+  product_type: 'physical',
+  requires_shipping: false,
+  track_inventory: false,
+  product_tax_assignments: [],
+};
+
+const PRODUCT_CATEGORY = {
+  ...PRODUCT_BASE,
+  id: 200,
+  name: 'Producto Categoria',
+  base_price: 20000,
+};
+
+function buildProduct(over: Partial<typeof PRODUCT_BASE> = {}) {
+  return { ...PRODUCT_BASE, ...over };
+}
+
+describe('CheckoutService - promotions and coupons', () => {
+  let service: CheckoutService;
+  let prisma: any;
+  let storePrisma: any;
+  // Use `any` so jest mock methods (quoteDiscounts, applyPromotion) don't
+  // get filtered out by the strict shape of jest.Mocked<...>.
+  let promotionEngine: any;
+  let couponsService: any;
+  let priceResolverService: any;
+  let taxesService: any;
+  let settingsService: any;
+  let cartService: any;
+
+  const STORE_ID = 1;
+  const USER_ID = 42;
+
+  beforeEach(async () => {
+    jest
+      .spyOn(RequestContextService, 'getStoreId')
+      .mockReturnValue(STORE_ID);
+    jest.spyOn(RequestContextService, 'getUserId').mockReturnValue(USER_ID);
+    jest
+      .spyOn(RequestContextService, 'getOrganizationId')
+      .mockReturnValue(undefined);
+
+    // Default empty quote shape — individual tests override.
+    promotionEngine = {
+      quoteDiscounts: jest.fn().mockResolvedValue({
+        subtotal: 0,
+        total_discount: 0,
+        promotional_subtotal: 0,
+        applied_promotions: [],
+        items: [],
+        order_promotions_snapshot: [],
+      }),
+      applyPromotion: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    couponsService = {
+      validate: jest.fn(),
+      registerUse: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    priceResolverService = {
+      resolvePrice: jest.fn(({ product }: any) => ({
+        unitPrice: Number(product.base_price),
+        unitPriceWithTax: Number(product.base_price),
+        unitBasePrice: Number(product.base_price),
+      })),
+    };
+
+    taxesService = {
+      calculateProductTaxes: jest.fn().mockResolvedValue({
+        total_rate: 0,
+        total_tax_amount: 0,
+        taxes: [],
+      }),
+    };
+
+    settingsService = {
+      getStoreCurrency: jest.fn().mockResolvedValue('COP'),
+      getSettings: jest.fn().mockResolvedValue({}),
+    };
+
+    cartService = {
+      clearCart: jest.fn().mockResolvedValue({ success: true }),
+    };
+
+    // ecommerce-scoped prisma: only the operations checkout uses.
+    prisma = {
+      carts: { findFirst: jest.fn().mockResolvedValue(null) },
+      products: {
+        findUnique: jest.fn(({ where }: any) => {
+          if (where.id === PRODUCT_BASE.id) return Promise.resolve(buildProduct());
+          if (where.id === PRODUCT_CATEGORY.id)
+            return Promise.resolve(buildProduct({ ...PRODUCT_CATEGORY }));
+          return Promise.resolve(null);
+        }),
+      },
+      product_variants: {
+        findUnique: jest.fn().mockResolvedValue(null),
+        count: jest.fn().mockResolvedValue(0),
+      },
+      store_payment_methods: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 7,
+          state: 'enabled',
+          system_payment_method: {
+            id: 1,
+            display_name: 'Cash',
+            type: 'cash',
+            provider: 'manual',
+          },
+        }),
+      },
+      addresses: {
+        create: jest.fn(),
+        findUnique: jest.fn(),
+        findFirst: jest.fn().mockResolvedValue(null),
+      },
+      orders: {
+        create: jest.fn(),
+      },
+      payments: {
+        create: jest.fn().mockResolvedValue({ id: 999, state: 'pending' }),
+      },
+      stores: { findUnique: jest.fn().mockResolvedValue({ store_code: 'EC' }) },
+      users: {
+        findUnique: jest
+          .fn()
+          .mockResolvedValue({ first_name: 'Test', last_name: 'User', phone: null }),
+      },
+    };
+
+    storePrisma = {
+      product_categories: {
+        findMany: jest.fn(({ where }: any) => {
+          const ids = where.product_id.in as number[];
+          const out: Array<{ product_id: number; category_id: number }> = [];
+          if (ids.includes(PRODUCT_CATEGORY.id)) {
+            out.push({ product_id: PRODUCT_CATEGORY.id, category_id: 555 });
+          }
+          return Promise.resolve(out);
+        }),
+      },
+      orders: { count: jest.fn().mockResolvedValue(0) },
+      shipping_rates: { findFirst: jest.fn() },
+      shipping_methods: { findFirst: jest.fn() },
+      invoices: { findFirst: jest.fn().mockResolvedValue(null) },
+      invoice_resolutions: { findFirst: jest.fn().mockResolvedValue(null) },
+      dian_configurations: { findFirst: jest.fn().mockResolvedValue(null) },
+      invoice_data_requests: { update: jest.fn() },
+      store_settings: { findUnique: jest.fn().mockResolvedValue(null) },
+      organizations: { findUnique: jest.fn().mockResolvedValue(null) },
+      payments: {
+        findFirst: jest.fn(),
+        update: jest.fn(),
+        findUnique: jest.fn(),
+      },
+      store_payment_methods: { findFirst: jest.fn() },
+      domain_settings: { findMany: jest.fn().mockResolvedValue([]) },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CheckoutService,
+        { provide: EcommercePrismaService, useValue: prisma },
+        { provide: StorePrismaService, useValue: storePrisma },
+        { provide: CartService, useValue: cartService },
+        { provide: TaxesService, useValue: taxesService },
+        { provide: EventEmitter2, useValue: { emit: jest.fn() } },
+        { provide: SettingsService, useValue: settingsService },
+        {
+          provide: StockLevelManager,
+          useValue: {
+            reserveStock: jest.fn().mockResolvedValue(undefined),
+            getDefaultLocationForProduct: jest.fn().mockResolvedValue(1),
+          },
+        },
+        {
+          provide: StockValidatorService,
+          useValue: {
+            resolveEffectiveTracking: jest.fn().mockReturnValue(false),
+            validateAvailability: jest
+              .fn()
+              .mockResolvedValue({ isAvailable: true, available: 100 }),
+          },
+        },
+        { provide: PriceResolverService, useValue: priceResolverService },
+        { provide: WompiClientFactory, useValue: { getClient: jest.fn() } },
+        { provide: WompiProcessor, useValue: {} },
+        { provide: PaymentEncryptionService, useValue: {} },
+        { provide: WebhookHandlerService, useValue: {} },
+        { provide: ReservationsService, useValue: { create: jest.fn() } },
+        {
+          provide: InvoiceDataRequestsService,
+          useValue: {
+            createRequest: jest
+              .fn()
+              .mockResolvedValue({ id: 1, token: 'tok-guest' }),
+          },
+        },
+        { provide: InvoicingService, useValue: { createFromOrder: jest.fn() } },
+        {
+          provide: OperatingScopeService,
+          useValue: {
+            getOperatingScope: jest.fn().mockResolvedValue('STORE'),
+            findCentralWarehouse: jest.fn().mockResolvedValue(null),
+          },
+        },
+        {
+          provide: FiscalStatusService,
+          useValue: {
+            getStoreInvoicingState: jest.fn().mockResolvedValue('INACTIVE'),
+          },
+        },
+        { provide: S3Service, useValue: { signUrl: jest.fn(), uploadFile: jest.fn() } },
+        {
+          provide: S3PathHelper,
+          useValue: { buildReceiptPath: jest.fn(() => 'receipts/test') },
+        },
+        {
+          provide: CustomersService,
+          useValue: {
+            resolveGuestCustomerForCheckout: jest.fn().mockResolvedValue(null),
+          },
+        },
+        { provide: PromotionEngineService, useValue: promotionEngine },
+        { provide: CouponsService, useValue: couponsService },
+      ],
+    }).compile();
+
+    service = module.get<CheckoutService>(CheckoutService);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function mockOrderCreate(grandTotal: number) {
+    prisma.orders.create.mockImplementation(({ data }: any) =>
+      Promise.resolve({
+        id: 1,
+        store_id: STORE_ID,
+        order_number: data.order_number,
+        grand_total: grandTotal,
+        currency: data.currency,
+        state: data.state,
+        order_items: [],
+      }),
+    );
+  }
+
+  describe('checkout() — normal ecommerce flow', () => {
+    it('creates a guest checkout WITHOUT promotions (regression)', async () => {
+      jest.spyOn(RequestContextService, 'getUserId').mockReturnValue(undefined);
+      mockOrderCreate(10000);
+
+      const result: any = await service.checkout({
+        payment_method_id: 7,
+        items: [{ product_id: PRODUCT_BASE.id, quantity: 1 }],
+      } as any);
+
+      expect(promotionEngine.quoteDiscounts).toHaveBeenCalledTimes(1);
+      expect(couponsService.validate).not.toHaveBeenCalled();
+      expect(promotionEngine.applyPromotion).not.toHaveBeenCalled();
+      expect(couponsService.registerUse).not.toHaveBeenCalled();
+
+      const orderArgs = prisma.orders.create.mock.calls[0][0].data;
+      expect(orderArgs.subtotal_amount).toBe(10000);
+      expect(orderArgs.discount_amount).toBe(0);
+      expect(orderArgs.grand_total).toBe(10000);
+
+      // Payment created for the same grand_total — never the cart-side estimate.
+      expect(prisma.payments.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ amount: 10000 }),
+        }),
+      );
+      expect(result.total).toBe(10000);
+      expect(result.discount_amount).toBe(0);
+    });
+
+    it('applies an automatic promotion for an authenticated customer', async () => {
+      promotionEngine.quoteDiscounts.mockResolvedValue({
+        subtotal: 10000,
+        total_discount: 1500,
+        promotional_subtotal: 8500,
+        applied_promotions: [
+          {
+            promotion_id: 7,
+            name: 'Auto promo',
+            code: null,
+            type: 'percentage',
+            scope: 'order',
+            value: 15,
+            is_auto_apply: true,
+            discount_amount: 1500,
+            applicable_item_ids: [0],
+          },
+        ],
+        items: [
+          {
+            line_id: 0,
+            product_id: PRODUCT_BASE.id,
+            variant_id: null,
+            quantity: 1,
+            original_unit_price: 10000,
+            promotion_discount: 1500,
+            final_unit_price: 8500,
+            final_line_total: 8500,
+            promotion_ids: [7],
+          },
+        ],
+        order_promotions_snapshot: [
+          { promotion_id: 7, discount_amount: 1500 },
+        ],
+      });
+
+      mockOrderCreate(8500);
+
+      const result: any = await service.checkout({
+        payment_method_id: 7,
+        items: [{ product_id: PRODUCT_BASE.id, quantity: 1 }],
+      } as any);
+
+      const orderArgs = prisma.orders.create.mock.calls[0][0].data;
+      expect(orderArgs.discount_amount).toBe(1500);
+      expect(orderArgs.grand_total).toBe(8500);
+
+      expect(promotionEngine.applyPromotion).toHaveBeenCalledWith(
+        1,
+        7,
+        1500,
+        USER_ID,
+      );
+      expect(couponsService.registerUse).not.toHaveBeenCalled();
+
+      expect(prisma.payments.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ amount: 8500 }),
+        }),
+      );
+      expect(result.total).toBe(8500);
+      expect(result.promotion_discount).toBe(1500);
+      expect(result.coupon_discount).toBe(0);
+    });
+
+    it('applies a category-scoped promotion using product_categories lookup', async () => {
+      // Cart has a single product belonging to category 555. The promotion
+      // engine receives `category_ids` resolved from product_categories.
+      promotionEngine.quoteDiscounts.mockImplementation(async (input) => {
+        // Confirm the engine receives the resolved category_ids array.
+        expect(input.items[0].category_ids).toEqual([555]);
+        return {
+          subtotal: 20000,
+          total_discount: 2000,
+          promotional_subtotal: 18000,
+          applied_promotions: [
+            {
+              promotion_id: 9,
+              name: 'Categoria',
+              code: null,
+              type: 'fixed_amount',
+              scope: 'category',
+              value: 2000,
+              is_auto_apply: true,
+              discount_amount: 2000,
+              applicable_item_ids: [0],
+            },
+          ],
+          items: [
+            {
+              line_id: 0,
+              product_id: PRODUCT_CATEGORY.id,
+              variant_id: null,
+              quantity: 1,
+              original_unit_price: 20000,
+              promotion_discount: 2000,
+              final_unit_price: 18000,
+              final_line_total: 18000,
+              promotion_ids: [9],
+            },
+          ],
+          order_promotions_snapshot: [
+            { promotion_id: 9, discount_amount: 2000 },
+          ],
+        };
+      });
+
+      mockOrderCreate(18000);
+
+      await service.checkout({
+        payment_method_id: 7,
+        items: [{ product_id: PRODUCT_CATEGORY.id, quantity: 1 }],
+      } as any);
+
+      const orderArgs = prisma.orders.create.mock.calls[0][0].data;
+      expect(orderArgs.discount_amount).toBe(2000);
+      expect(orderArgs.grand_total).toBe(18000);
+      expect(promotionEngine.applyPromotion).toHaveBeenCalledWith(
+        1,
+        9,
+        2000,
+        USER_ID,
+      );
+    });
+
+    it('stacks a promotion AND a coupon, then registers usage', async () => {
+      promotionEngine.quoteDiscounts.mockResolvedValue({
+        subtotal: 10000,
+        total_discount: 1000,
+        promotional_subtotal: 9000,
+        applied_promotions: [
+          {
+            promotion_id: 7,
+            name: 'Promo',
+            code: null,
+            type: 'percentage',
+            scope: 'order',
+            value: 10,
+            is_auto_apply: true,
+            discount_amount: 1000,
+            applicable_item_ids: [0],
+          },
+        ],
+        items: [
+          {
+            line_id: 0,
+            product_id: PRODUCT_BASE.id,
+            variant_id: null,
+            quantity: 1,
+            original_unit_price: 10000,
+            promotion_discount: 1000,
+            final_unit_price: 9000,
+            final_line_total: 9000,
+            promotion_ids: [7],
+          },
+        ],
+        order_promotions_snapshot: [
+          { promotion_id: 7, discount_amount: 1000 },
+        ],
+      });
+
+      couponsService.validate.mockResolvedValue({
+        valid: true,
+        coupon_id: 42,
+        code: 'PROMO10',
+        name: 'Promo 10',
+        discount_type: 'FIXED_AMOUNT',
+        discount_value: 500,
+        discount_amount: 500,
+        min_purchase_amount: null,
+        max_discount_amount: null,
+      } as any);
+
+      mockOrderCreate(8500);
+
+      // Wompi method to ensure totals propagate to the payment amount.
+      prisma.store_payment_methods.findFirst.mockResolvedValue({
+        id: 7,
+        state: 'enabled',
+        system_payment_method: { type: 'wompi', provider: 'wompi' },
+      });
+
+      const result: any = await service.checkout({
+        payment_method_id: 7,
+        items: [{ product_id: PRODUCT_BASE.id, quantity: 1 }],
+        coupon_code: 'PROMO10',
+      } as any);
+
+      expect(couponsService.validate).toHaveBeenCalledTimes(1);
+      expect(couponsService.validate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          code: 'PROMO10',
+          cart_subtotal: 9000, // post-promo subtotal
+          customer_id: USER_ID,
+        }),
+      );
+
+      const orderArgs = prisma.orders.create.mock.calls[0][0].data;
+      expect(orderArgs.subtotal_amount).toBe(10000);
+      expect(orderArgs.discount_amount).toBe(1500);
+      expect(orderArgs.grand_total).toBe(8500);
+
+      // Payment amount === order grand_total (the only authoritative value
+      // Wompi/manual must charge).
+      expect(prisma.payments.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ amount: 8500 }),
+        }),
+      );
+
+      expect(promotionEngine.applyPromotion).toHaveBeenCalledWith(
+        1,
+        7,
+        1000,
+        USER_ID,
+      );
+      expect(couponsService.registerUse).toHaveBeenCalledWith(
+        42,
+        1,
+        USER_ID,
+        500,
+      );
+      expect(result.promotion_discount).toBe(1000);
+      expect(result.coupon_discount).toBe(500);
+      expect(result.discount_amount).toBe(1500);
+    });
+
+    it('rejects an invalid coupon and never creates an order', async () => {
+      couponsService.validate.mockRejectedValue(
+        new VendixHttpException({
+          code: 'CPN_FIND_001',
+          httpStatus: 404,
+          devMessage: 'Coupon not found',
+        }),
+      );
+
+      await expect(
+        service.checkout({
+          payment_method_id: 7,
+          items: [{ product_id: PRODUCT_BASE.id, quantity: 1 }],
+          coupon_code: 'NOPE',
+        } as any),
+      ).rejects.toBeInstanceOf(VendixHttpException);
+
+      expect(prisma.orders.create).not.toHaveBeenCalled();
+      expect(prisma.payments.create).not.toHaveBeenCalled();
+      expect(promotionEngine.applyPromotion).not.toHaveBeenCalled();
+      expect(couponsService.registerUse).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('whatsappCheckout() — promotions share the same source of truth', () => {
+    it('applies automatic promotions and returns discount details', async () => {
+      promotionEngine.quoteDiscounts.mockResolvedValue({
+        subtotal: 10000,
+        total_discount: 1500,
+        promotional_subtotal: 8500,
+        applied_promotions: [
+          {
+            promotion_id: 11,
+            name: 'WA promo',
+            code: null,
+            type: 'percentage',
+            scope: 'order',
+            value: 15,
+            is_auto_apply: true,
+            discount_amount: 1500,
+            applicable_item_ids: [0],
+          },
+        ],
+        items: [
+          {
+            line_id: 0,
+            product_id: PRODUCT_BASE.id,
+            variant_id: null,
+            quantity: 1,
+            original_unit_price: 10000,
+            promotion_discount: 1500,
+            final_unit_price: 8500,
+            final_line_total: 8500,
+            promotion_ids: [11],
+          },
+        ],
+        order_promotions_snapshot: [
+          { promotion_id: 11, discount_amount: 1500 },
+        ],
+      });
+
+      mockOrderCreate(8500);
+
+      const response: any = await service.whatsappCheckout({
+        items: [{ product_id: PRODUCT_BASE.id, quantity: 1 }],
+      } as any);
+
+      const orderArgs = prisma.orders.create.mock.calls[0][0].data;
+      expect(orderArgs.channel).toBe('whatsapp');
+      expect(orderArgs.discount_amount).toBe(1500);
+      expect(orderArgs.grand_total).toBe(8500);
+
+      expect(promotionEngine.applyPromotion).toHaveBeenCalledWith(
+        1,
+        11,
+        1500,
+        USER_ID,
+      );
+      // WhatsApp doesn't create a payment row up front (only order); the
+      // response is expected to surface the final total and discount fields
+      // so the WhatsApp message references the same number.
+      expect(response.total).toBe(8500);
+      expect(response.discount_amount).toBe(1500);
+      expect(response.promotion_discount).toBe(1500);
+    });
+  });
+});

--- a/apps/backend/src/domains/ecommerce/checkout/checkout.service.ts
+++ b/apps/backend/src/domains/ecommerce/checkout/checkout.service.ts
@@ -30,6 +30,10 @@ import { FiscalStatusService } from '@common/services/fiscal-status.service';
 import { S3Service } from '@common/services/s3.service';
 import { S3PathHelper } from '@common/helpers/s3-path.helper';
 import { CustomersService } from '../../store/customers/customers.service';
+import { PromotionEngineService } from '../../store/promotions/promotion-engine/promotion-engine.service';
+import { CouponsService } from '../../store/coupons/coupons.service';
+import { CouponAppliesTo } from '../../store/coupons/dto';
+import { PromotionQuoteResult } from '../../store/promotions/dto/promotion-quote.interface';
 
 @Injectable()
 export class CheckoutService {
@@ -57,6 +61,8 @@ export class CheckoutService {
     private readonly s3Service: S3Service,
     private readonly s3PathHelper: S3PathHelper,
     private readonly customersService: CustomersService,
+    private readonly promotionEngine: PromotionEngineService,
+    private readonly couponsService: CouponsService,
   ) {}
 
   /**
@@ -357,6 +363,190 @@ export class CheckoutService {
 
     if (customerId !== userId) {
       throw new NotFoundException('No se encontró la orden');
+    }
+  }
+
+  /**
+   * Round money to 2 decimals (HALF_UP). Centralized so quote, coupon and
+   * order totals don't drift due to floating arithmetic.
+   */
+  private roundMoney(value: number): number {
+    return Math.round((Number.isFinite(value) ? value : 0) * 100) / 100;
+  }
+
+  /**
+   * Fetch the categories every product in `productIds` belongs to. Returned
+   * as a Map<productId, number[]> so the promotion engine and coupon validator
+   * can match category-scoped rules without extra round-trips.
+   *
+   * Uses the store-scoped client because `product_categories` is multi-tenant
+   * by transitive `products.store_id` filter.
+   */
+  private async resolveProductCategories(
+    productIds: number[],
+  ): Promise<Map<number, number[]>> {
+    const map = new Map<number, number[]>();
+    if (productIds.length === 0) return map;
+
+    const rows = await this.store_prisma.product_categories.findMany({
+      where: { product_id: { in: productIds } },
+      select: { product_id: true, category_id: true },
+    });
+
+    for (const row of rows) {
+      const existing = map.get(row.product_id) ?? [];
+      existing.push(row.category_id);
+      map.set(row.product_id, existing);
+    }
+    return map;
+  }
+
+  /**
+   * Run the promotion engine for the resolved cart items and optionally
+   * validate the coupon supplied in the checkout payload. Returns subtotal,
+   * promotion + coupon discounts, totals, and persistence-ready snapshots.
+   *
+   * Discount base is the items SUBTOTAL (excludes shipping and taxes); taxes
+   * and shipping are added back to compute the grand total in the caller.
+   */
+  private async resolveCheckoutDiscounts(params: {
+    items: Array<{
+      product_id: number;
+      product_variant_id: number | null;
+      quantity: number;
+      net_price: number;
+    }>;
+    customerId: number | null;
+    couponCode?: string | null;
+  }): Promise<{
+    quote: PromotionQuoteResult;
+    coupon: {
+      coupon_id: number;
+      discount_amount: number;
+    } | null;
+    promotion_discount: number;
+    coupon_discount: number;
+    total_discount: number;
+  }> {
+    const items = params.items;
+    if (items.length === 0) {
+      return {
+        quote: {
+          subtotal: 0,
+          total_discount: 0,
+          promotional_subtotal: 0,
+          applied_promotions: [],
+          items: [],
+          order_promotions_snapshot: [],
+        },
+        coupon: null,
+        promotion_discount: 0,
+        coupon_discount: 0,
+        total_discount: 0,
+      };
+    }
+
+    const productIds = Array.from(new Set(items.map((i) => i.product_id)));
+    const categoryMap = await this.resolveProductCategories(productIds);
+
+    const quote = await this.promotionEngine.quoteDiscounts({
+      items: items.map((item, index) => ({
+        line_id: index,
+        product_id: item.product_id,
+        variant_id: item.product_variant_id,
+        category_ids: categoryMap.get(item.product_id) ?? [],
+        unit_price: this.roundMoney(item.net_price),
+        quantity: item.quantity,
+      })),
+      customer_id: params.customerId,
+    });
+
+    const couponCode = params.couponCode?.trim();
+    let coupon: { coupon_id: number; discount_amount: number } | null = null;
+
+    if (couponCode) {
+      // Discount base for the coupon is the post-promotion subtotal so we
+      // never refund money the customer didn't actually pay. We pass per-line
+      // totals so SPECIFIC_PRODUCTS / SPECIFIC_CATEGORIES coupons can
+      // recompute their applicable subtotal correctly.
+      const couponItems = quote.items.map((it) => ({
+        product_id: it.product_id,
+        category_ids: categoryMap.get(it.product_id) ?? [],
+        line_total: this.roundMoney(it.final_line_total),
+      }));
+
+      const validation = await this.couponsService.validate({
+        code: couponCode,
+        customer_id: params.customerId ?? undefined,
+        cart_subtotal: this.roundMoney(quote.promotional_subtotal),
+        product_ids: productIds,
+        category_ids: Array.from(
+          new Set(
+            productIds.flatMap((id) => categoryMap.get(id) ?? []),
+          ),
+        ),
+        items: couponItems,
+      });
+
+      coupon = {
+        coupon_id: validation.coupon_id,
+        discount_amount: this.roundMoney(validation.discount_amount),
+      };
+    }
+
+    const promotion_discount = this.roundMoney(quote.total_discount);
+    const coupon_discount = this.roundMoney(coupon?.discount_amount ?? 0);
+    const total_discount = this.roundMoney(promotion_discount + coupon_discount);
+
+    return {
+      quote,
+      coupon,
+      promotion_discount,
+      coupon_discount,
+      total_discount,
+    };
+  }
+
+  /**
+   * Persist `order_promotions` + `coupon_uses` after the ecommerce order
+   * has been created. Each promotion is wrapped in its own try/catch so a
+   * race on usage limits doesn't break the checkout (the order is already
+   * committed; we'd rather emit a warning than 500 the customer).
+   */
+  private async persistPromotionsAndCoupon(params: {
+    orderId: number;
+    customerId: number | null;
+    quote: PromotionQuoteResult;
+    coupon: { coupon_id: number; discount_amount: number } | null;
+  }): Promise<void> {
+    for (const snapshot of params.quote.order_promotions_snapshot) {
+      try {
+        await this.promotionEngine.applyPromotion(
+          params.orderId,
+          snapshot.promotion_id,
+          snapshot.discount_amount,
+          params.customerId,
+        );
+      } catch (err) {
+        this.logger.warn(
+          `Promotion ${snapshot.promotion_id} could not be applied to order ${params.orderId}: ${(err as Error).message}`,
+        );
+      }
+    }
+
+    if (params.coupon && params.coupon.discount_amount > 0) {
+      try {
+        await this.couponsService.registerUse(
+          params.coupon.coupon_id,
+          params.orderId,
+          params.customerId,
+          params.coupon.discount_amount,
+        );
+      } catch (err) {
+        this.logger.warn(
+          `Coupon ${params.coupon.coupon_id} could not be registered for order ${params.orderId}: ${(err as Error).message}`,
+        );
+      }
     }
   }
 
@@ -697,15 +887,35 @@ export class CheckoutService {
       }),
     );
 
-    const subtotal = itemsWithTaxes.reduce(
-      (sum, item) => sum + item.total_net,
-      0,
+    const subtotal = this.roundMoney(
+      itemsWithTaxes.reduce((sum, item) => sum + item.total_net, 0),
     );
-    const total_tax = itemsWithTaxes.reduce(
-      (sum, item) => sum + item.total_tax,
-      0,
+    const total_tax = this.roundMoney(
+      itemsWithTaxes.reduce((sum, item) => sum + item.total_tax, 0),
     );
-    const grand_total = subtotal + total_tax + shipping_cost;
+
+    // Recompute promotional + coupon discounts on the backend. Frontend
+    // only sends the coupon code (if any); totals here are authoritative.
+    const discountResult = await this.resolveCheckoutDiscounts({
+      items: itemsWithTaxes.map((item) => ({
+        product_id: item.product_id,
+        product_variant_id: item.product_variant_id ?? null,
+        quantity: item.quantity,
+        net_price: item.net_price,
+      })),
+      customerId: resolved_customer_id,
+      couponCode: dto.coupon_code,
+    });
+
+    // Discount base is the products subtotal BEFORE shipping. We add taxes
+    // and shipping AFTER subtracting the discount, mirroring the POS flow.
+    // Clamp grand_total at >= 0 in case a fixed coupon exceeds subtotal.
+    const grand_total = this.roundMoney(
+      Math.max(
+        0,
+        subtotal + total_tax - discountResult.total_discount + shipping_cost,
+      ),
+    );
 
     // store_id y customer_id (user_id) se inyectan automáticamente
     const order = await this.prisma.orders.create({
@@ -716,6 +926,7 @@ export class CheckoutService {
         currency: cart_currency,
         subtotal_amount: subtotal,
         tax_amount: total_tax,
+        discount_amount: discountResult.total_discount,
         shipping_cost: shipping_cost,
         shipping_method_id: shipping_method_id,
         shipping_rate_id: shipping_rate_id,
@@ -755,6 +966,17 @@ export class CheckoutService {
       include: {
         order_items: true,
       },
+    });
+
+    // Persist applied promotions + coupon usage. We do this OUTSIDE the order
+    // create call so the snapshot/coupon flow doesn't tangle with order_items
+    // nested writes — they live under different scoped clients (store vs
+    // ecommerce) and need transparent error handling per promo.
+    await this.persistPromotionsAndCoupon({
+      orderId: order.id,
+      customerId: resolved_customer_id,
+      quote: discountResult.quote,
+      coupon: discountResult.coupon,
     });
 
     // Emit order.created event for notifications
@@ -871,6 +1093,12 @@ export class CheckoutService {
       order_id: order.id,
       order_number: order.order_number,
       total: order.grand_total,
+      subtotal,
+      tax_amount: total_tax,
+      discount_amount: discountResult.total_discount,
+      promotion_discount: discountResult.promotion_discount,
+      coupon_discount: discountResult.coupon_discount,
+      shipping_cost,
       state: order.state,
       public_order_token: guestArtifacts?.invoice_data_token ?? null,
       invoice_data_token: guestArtifacts?.invoice_data_token ?? null,
@@ -1152,14 +1380,26 @@ export class CheckoutService {
       }),
     );
 
-    const subtotal = itemsWithTaxes.reduce(
-      (sum, item) => sum + item.total_net,
-      0,
+    const subtotal = this.roundMoney(
+      itemsWithTaxes.reduce((sum, item) => sum + item.total_net, 0),
     );
-    const total_tax = itemsWithTaxes.reduce(
-      (sum, item) => sum + item.total_tax,
-      0,
+    const total_tax = this.roundMoney(
+      itemsWithTaxes.reduce((sum, item) => sum + item.total_tax, 0),
     );
+
+    // Resolve promotional + coupon discounts on the backend (same source of
+    // truth used by the normal checkout). Frontend never sends totals.
+    const discountResult = await this.resolveCheckoutDiscounts({
+      items: itemsWithTaxes.map((item) => ({
+        product_id: item.product_id,
+        product_variant_id: item.product_variant_id ?? null,
+        quantity: item.quantity,
+        net_price: item.net_price,
+      })),
+      customerId: resolved_customer_id,
+      couponCode: dto.coupon_code,
+    });
+
     // Resolve optional shipping method/rate from DTO (scoped by store)
     const wa_store_id = RequestContextService.getStoreId();
     let wa_shipping_method_id: number | null = null;
@@ -1204,7 +1444,12 @@ export class CheckoutService {
       wa_delivery_type = deriveDeliveryType(method.type);
     }
 
-    const grand_total = subtotal + total_tax + wa_shipping_cost;
+    const grand_total = this.roundMoney(
+      Math.max(
+        0,
+        subtotal + total_tax - discountResult.total_discount + wa_shipping_cost,
+      ),
+    );
 
     const order = await this.prisma.orders.create({
       data: {
@@ -1214,6 +1459,7 @@ export class CheckoutService {
         currency: cart_currency,
         subtotal_amount: subtotal,
         tax_amount: total_tax,
+        discount_amount: discountResult.total_discount,
         shipping_cost: wa_shipping_cost,
         shipping_method_id: wa_shipping_method_id,
         shipping_rate_id: wa_shipping_rate_id,
@@ -1253,6 +1499,15 @@ export class CheckoutService {
       include: {
         order_items: true,
       },
+    });
+
+    // Persist promotions + coupon usage (WhatsApp checkout shares the same
+    // discount source of truth as the normal checkout flow).
+    await this.persistPromotionsAndCoupon({
+      orderId: order.id,
+      customerId: resolved_customer_id,
+      quote: discountResult.quote,
+      coupon: discountResult.coupon,
     });
 
     // Emit order.created event for notifications
@@ -1311,6 +1566,12 @@ export class CheckoutService {
       invoice_id: guestArtifacts?.invoice_id ?? invoice_id,
       subtotal: subtotal,
       tax: total_tax,
+      // Discounts surfaced so the WhatsApp UI / order detail can render
+      // the promo + coupon lines without recomputing on the client.
+      discount_amount: discountResult.total_discount,
+      promotion_discount: discountResult.promotion_discount,
+      coupon_discount: discountResult.coupon_discount,
+      shipping_cost: wa_shipping_cost,
       item_count: cart_items.reduce((sum, i) => sum + i.quantity, 0),
       items: order.order_items.map((oi) => ({
         name: oi.product_name,

--- a/apps/backend/src/domains/ecommerce/checkout/dto/checkout.dto.ts
+++ b/apps/backend/src/domains/ecommerce/checkout/dto/checkout.dto.ts
@@ -128,6 +128,20 @@ export class CheckoutDto {
   @ValidateNested({ each: true })
   @Type(() => CheckoutCartItemDto)
   items?: CheckoutCartItemDto[];
+
+  /**
+   * Optional coupon code provided by the customer. When set, the backend
+   * validates it against {@link CouponsService.validate}; the discount is
+   * applied on top of automatic promotion discounts. Invalid codes raise an
+   * error and abort the checkout — frontend must NOT send the code unless
+   * the customer explicitly entered it.
+   *
+   * Trim + uppercase is done by the validator. Totals are never sent from
+   * the client — backend recomputes every value.
+   */
+  @IsOptional()
+  @IsString()
+  coupon_code?: string;
 }
 
 class CheckoutBookingDto {

--- a/apps/backend/src/domains/ecommerce/checkout/dto/whatsapp-checkout.dto.ts
+++ b/apps/backend/src/domains/ecommerce/checkout/dto/whatsapp-checkout.dto.ts
@@ -55,4 +55,13 @@ export class WhatsappCheckoutDto {
   @ValidateNested()
   @Type(() => GuestCheckoutCustomerDto)
   guest_customer?: GuestCheckoutCustomerDto;
+
+  /**
+   * Optional coupon code applied to the WhatsApp checkout. Backend validates
+   * via CouponsService and persists `coupon_uses` + `discount_amount` on the
+   * order. Invalid codes abort the checkout.
+   */
+  @IsOptional()
+  @IsString()
+  coupon_code?: string;
 }

--- a/apps/backend/src/domains/store/analytics/services/inventory-analytics.service.ts
+++ b/apps/backend/src/domains/store/analytics/services/inventory-analytics.service.ts
@@ -14,6 +14,9 @@ import {
 } from '../utils/date.util';
 import { VendixHttpException, ErrorCodes } from 'src/common/errors';
 import { OperatingScopeService } from '@common/services/operating-scope.service';
+import { mergeStoreSettingsWithDefaults } from '../../settings/defaults/default-store-settings';
+import type { StoreSettings } from '../../settings/interfaces/store-settings.interface';
+import { resolveProductLowStockThreshold } from '../../inventory/shared/helpers/low-stock-threshold.helper';
 
 @Injectable()
 export class InventoryAnalyticsService {
@@ -23,6 +26,8 @@ export class InventoryAnalyticsService {
   ) {}
 
   async getInventorySummary(query: InventoryAnalyticsQueryDto) {
+    const settings = await this.loadMergedSettings();
+
     // Get all products with stock info (store scoping is automatic)
     // track_inventory is Boolean @default(false), not nullable
     const products = await this.prisma.products.findMany({
@@ -49,9 +54,7 @@ export class InventoryAnalyticsService {
       totalSkuCount++;
       const qty = Number(product.stock_quantity || 0);
       const cost = Number(product.cost_price || 0);
-      const reorderPoint = Number(
-        product.reorder_point || product.min_stock_level || 5,
-      );
+      const reorderPoint = resolveProductLowStockThreshold(settings, product);
 
       totalQuantity += qty;
       totalStockValue += qty * cost;
@@ -83,6 +86,8 @@ export class InventoryAnalyticsService {
   }
 
   async getStockLevels(query: InventoryAnalyticsQueryDto) {
+    const settings = await this.loadMergedSettings();
+
     const productWhere: any = {
       state: 'active',
       track_inventory: true,
@@ -119,9 +124,7 @@ export class InventoryAnalyticsService {
     let results = products.map((product) => {
       const qty = Number(product.stock_quantity || 0);
       const cost = Number(product.cost_price || 0);
-      const reorderPoint = Number(
-        product.reorder_point || product.min_stock_level || 5,
-      );
+      const reorderPoint = resolveProductLowStockThreshold(settings, product);
       const maxStock = Number(product.max_stock_level || 1000);
 
       let status: 'in_stock' | 'low_stock' | 'out_of_stock' | 'overstock';
@@ -180,6 +183,8 @@ export class InventoryAnalyticsService {
   }
 
   async getLowStockAlerts(query: InventoryAnalyticsQueryDto) {
+    const settings = await this.loadMergedSettings();
+
     // track_inventory is Boolean @default(false), not nullable
     const products = await this.prisma.products.findMany({
       where: {
@@ -207,14 +212,12 @@ export class InventoryAnalyticsService {
     const results = products
       .filter((p) => {
         const qty = Number(p.stock_quantity || 0);
-        const reorderPoint = Number(p.reorder_point || p.min_stock_level || 5);
+        const reorderPoint = resolveProductLowStockThreshold(settings, p);
         return qty <= reorderPoint;
       })
       .map((product) => {
         const qty = Number(product.stock_quantity || 0);
-        const reorderPoint = Number(
-          product.reorder_point || product.min_stock_level || 5,
-        );
+        const reorderPoint = resolveProductLowStockThreshold(settings, product);
 
         return {
           product_id: product.id,
@@ -250,6 +253,13 @@ export class InventoryAnalyticsService {
 
     // Non-paginated: respect original limit behavior
     return results.slice(0, query.limit || 100);
+  }
+
+  private async loadMergedSettings(): Promise<StoreSettings> {
+    const row = await this.prisma.store_settings.findFirst({
+      select: { settings: true },
+    });
+    return mergeStoreSettingsWithDefaults(row?.settings);
   }
 
   async getStockMovements(query: InventoryAnalyticsQueryDto) {
@@ -391,10 +401,7 @@ export class InventoryAnalyticsService {
     );
     const baseClient = this.prisma.withoutScope() as any;
     const asOf = (query as any).as_of ? new Date((query as any).as_of) : null;
-    const storeFilter =
-      scope === 'STORE'
-        ? { store_id: context.store_id }
-        : {};
+    const storeFilter = scope === 'STORE' ? { store_id: context.store_id } : {};
 
     if (scope === 'STORE' && !context.store_id) {
       throw new VendixHttpException(ErrorCodes.STORE_CONTEXT_001);

--- a/apps/backend/src/domains/store/brands/brands.service.ts
+++ b/apps/backend/src/domains/store/brands/brands.service.ts
@@ -44,16 +44,21 @@ export class BrandsService {
         ? this.generateSlug(createBrandDto.slug)
         : this.generateSlug(createBrandDto.name);
 
+      const brandData: any = {
+        name: createBrandDto.name,
+        slug,
+        description: createBrandDto.description,
+        logo_url: sanitizedLogoUrl,
+        store_id,
+        state: createBrandDto.state ?? 'active',
+      };
+
+      if (createBrandDto.is_featured !== undefined) {
+        brandData.is_featured = createBrandDto.is_featured;
+      }
+
       const brand = await this.prisma.brands.create({
-        data: {
-          name: createBrandDto.name,
-          slug,
-          description: createBrandDto.description,
-          logo_url: sanitizedLogoUrl,
-          is_featured: createBrandDto.is_featured ?? false,
-          store_id,
-          state: createBrandDto.state ?? 'active',
-        },
+        data: brandData,
       });
 
       return {
@@ -208,11 +213,7 @@ export class BrandsService {
     }
   }
 
-  async remove(
-    id: number,
-    user: any,
-    options: { force?: boolean } = {},
-  ) {
+  async remove(id: number, user: any, options: { force?: boolean } = {}) {
     const brand = await this.findOne(id);
 
     const productCount = await this.prisma.products.count({

--- a/apps/backend/src/domains/store/brands/dto/index.ts
+++ b/apps/backend/src/domains/store/brands/dto/index.ts
@@ -67,7 +67,7 @@ export class CreateBrandDto {
   })
   @IsBoolean()
   @IsOptional()
-  is_featured?: boolean = false;
+  is_featured?: boolean;
 }
 
 // Update Brand DTO

--- a/apps/backend/src/domains/store/cash-registers/cash-registers.service.ts
+++ b/apps/backend/src/domains/store/cash-registers/cash-registers.service.ts
@@ -46,7 +46,7 @@ export class CashRegistersService {
     });
 
     if (!register) {
-      throw new NotFoundException('Cash register not found');
+      throw new NotFoundException('Caja registradora no encontrada');
     }
 
     return register;
@@ -59,7 +59,7 @@ export class CashRegistersService {
     });
     if (existing) {
       throw new ConflictException(
-        `A cash register with code "${dto.code}" already exists`,
+        `Ya existe una caja registradora con el código "${dto.code}"`,
       );
     }
 
@@ -83,24 +83,34 @@ export class CashRegistersService {
       });
       if (existing) {
         throw new ConflictException(
-          `A cash register with code "${dto.code}" already exists`,
+          `Ya existe una caja registradora con el código "${dto.code}"`,
         );
       }
     }
 
-    return this.prisma.cash_registers.update({
+    const updated = await this.prisma.cash_registers.updateMany({
       where: { id },
       data: dto,
     });
+    if (updated.count !== 1) {
+      throw new NotFoundException('Caja registradora no encontrada');
+    }
+
+    return this.findOne(id);
   }
 
   async remove(id: number) {
     await this.findOne(id);
 
     // Soft delete — deactivate instead of deleting
-    return this.prisma.cash_registers.update({
+    const updated = await this.prisma.cash_registers.updateMany({
       where: { id },
       data: { is_active: false },
     });
+    if (updated.count !== 1) {
+      throw new NotFoundException('Caja registradora no encontrada');
+    }
+
+    return this.findOne(id);
   }
 }

--- a/apps/backend/src/domains/store/cash-registers/movements/movements.service.ts
+++ b/apps/backend/src/domains/store/cash-registers/movements/movements.service.ts
@@ -1,4 +1,8 @@
-import { Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { StorePrismaService } from '../../../../prisma/services/store-prisma.service';
 import { RequestContextService } from '@common/context/request-context.service';
@@ -31,6 +35,16 @@ export class MovementsService {
     },
   ) {
     const context = RequestContextService.getContext()!;
+
+    const session = await this.prisma.cash_register_sessions.findFirst({
+      where: { id: session_id },
+    });
+    if (!session) {
+      throw new NotFoundException('Sesión de caja no encontrada');
+    }
+    if (session.status !== 'open') {
+      throw new BadRequestException('La sesión de caja ya no está abierta');
+    }
 
     const movement = await this.prisma.cash_register_movements.create({
       data: {
@@ -79,7 +93,7 @@ export class MovementsService {
       amount: number;
       payment_method: string;
       order_id: number;
-      payment_id: number;
+      payment_id?: number;
     },
   ) {
     return this.prisma.withoutScope().cash_register_movements.create({
@@ -91,7 +105,7 @@ export class MovementsService {
         amount: data.amount,
         payment_method: data.payment_method,
         order_id: data.order_id,
-        payment_id: data.payment_id,
+        payment_id: data.payment_id ?? null,
       },
     });
   }

--- a/apps/backend/src/domains/store/cash-registers/sessions/sessions.service.ts
+++ b/apps/backend/src/domains/store/cash-registers/sessions/sessions.service.ts
@@ -55,7 +55,7 @@ export class SessionsService {
       where: { id: dto.cash_register_id, is_active: true },
     });
     if (!register) {
-      throw new NotFoundException('Cash register not found or inactive');
+      throw new NotFoundException('Caja registradora no encontrada o inactiva');
     }
 
     // Validate no open session on this register
@@ -69,7 +69,7 @@ export class SessionsService {
     );
     if (existing_session) {
       throw new BadRequestException(
-        'This cash register already has an open session',
+        'Esta caja ya tiene una sesión abierta',
       );
     }
 
@@ -82,7 +82,7 @@ export class SessionsService {
     });
     if (user_session) {
       throw new BadRequestException(
-        'You already have an open session on another register',
+        'Ya tienes una sesión abierta en otra caja',
       );
     }
 
@@ -141,10 +141,13 @@ export class SessionsService {
     const context = RequestContextService.getContext()!;
 
     const session = await this.prisma.cash_register_sessions.findFirst({
-      where: { id: session_id, status: 'open' },
+      where: { id: session_id },
     });
     if (!session) {
-      throw new NotFoundException('Open session not found');
+      throw new NotFoundException('Sesión de caja no encontrada');
+    }
+    if (session.status !== 'open') {
+      throw new BadRequestException('La sesión de caja ya no está abierta');
     }
 
     // Calculate expected closing amount from movements
@@ -171,12 +174,36 @@ export class SessionsService {
       }
     }
 
-    const difference = dto.actual_closing_amount - expected;
+    const actual_closing_amount = Number(dto.actual_closing_amount);
+    const difference = actual_closing_amount - expected;
 
     // Generate summary grouped by payment method
     const summary = this.generateSessionSummary(movements);
+    const closed_at = new Date();
 
     const closed_session = await this.prisma.$transaction(async (tx: any) => {
+      const updated = await tx.cash_register_sessions.updateMany({
+        where: {
+          id: session_id,
+          store_id: context.store_id,
+          status: 'open',
+        },
+        data: {
+          status: 'closed',
+          closed_by: context.user_id,
+          closed_at,
+          expected_closing_amount: expected,
+          actual_closing_amount,
+          difference,
+          closing_notes: dto.closing_notes,
+          summary,
+        },
+      });
+
+      if (updated.count !== 1) {
+        throw new BadRequestException('La sesión de caja ya no está abierta');
+      }
+
       // Create closing balance movement
       await tx.cash_register_movements.create({
         data: {
@@ -184,24 +211,13 @@ export class SessionsService {
           store_id: context.store_id,
           user_id: context.user_id,
           type: 'closing_balance',
-          amount: dto.actual_closing_amount,
+          amount: actual_closing_amount,
           payment_method: 'cash',
         },
       });
 
-      // Update session
-      const updated_session = await tx.cash_register_sessions.update({
-        where: { id: session_id },
-        data: {
-          status: 'closed',
-          closed_by: context.user_id,
-          closed_at: new Date(),
-          expected_closing_amount: expected,
-          actual_closing_amount: dto.actual_closing_amount,
-          difference,
-          closing_notes: dto.closing_notes,
-          summary,
-        },
+      const updated_session = await tx.cash_register_sessions.findFirst({
+        where: { id: session_id, store_id: context.store_id },
         include: {
           register: true,
           opened_by_user: {
@@ -212,6 +228,10 @@ export class SessionsService {
           },
         },
       });
+
+      if (!updated_session) {
+        throw new NotFoundException('Sesión de caja no encontrada');
+      }
 
       return updated_session;
     });
@@ -237,17 +257,33 @@ export class SessionsService {
   }
 
   async suspendSession(session_id: number) {
+    const context = RequestContextService.getContext()!;
     const session = await this.prisma.cash_register_sessions.findFirst({
-      where: { id: session_id, status: 'open' },
+      where: { id: session_id },
     });
     if (!session) {
-      throw new NotFoundException('Open session not found');
+      throw new NotFoundException('Sesión de caja abierta no encontrada');
+    }
+    if (session.status !== 'open') {
+      throw new BadRequestException('La sesión de caja ya no está abierta');
     }
 
-    return this.prisma.cash_register_sessions.update({
-      where: { id: session_id },
+    const updated = await this.prisma.cash_register_sessions.updateMany({
+      where: { id: session_id, store_id: context.store_id, status: 'open' },
       data: { status: 'suspended' },
     });
+    if (updated.count !== 1) {
+      throw new BadRequestException('La sesión de caja ya no está abierta');
+    }
+
+    const suspended_session = await this.prisma.cash_register_sessions.findFirst({
+      where: { id: session_id },
+    });
+    if (!suspended_session) {
+      throw new NotFoundException('Sesión de caja no encontrada');
+    }
+
+    return suspended_session;
   }
 
   async findAll(query: QuerySessionDto) {
@@ -311,7 +347,7 @@ export class SessionsService {
     });
 
     if (!session) {
-      throw new NotFoundException('Session not found');
+      throw new NotFoundException('Sesión de caja no encontrada');
     }
 
     return session;
@@ -539,10 +575,17 @@ export class SessionsService {
     summary: string,
   ): Promise<void> {
     try {
-      await this.prisma.cash_register_sessions.update({
-        where: { id: sessionId },
+      const context = RequestContextService.getContext();
+      const result = await this.prisma.cash_register_sessions.updateMany({
+        where: {
+          id: sessionId,
+          ...(context?.store_id ? { store_id: context.store_id } : {}),
+        },
         data: { ai_summary: summary },
       });
+      if (result.count !== 1) {
+        this.logger.warn(`AI summary target session ${sessionId} was not updated`);
+      }
     } catch (error: any) {
       this.logger.error(
         `Failed to save AI summary for session ${sessionId}: ${error.message}`,

--- a/apps/backend/src/domains/store/categories/categories.service.ts
+++ b/apps/backend/src/domains/store/categories/categories.service.ts
@@ -54,9 +54,12 @@ export class CategoriesService {
       description: createCategoryDto.description,
       store_id: store_id, // Manual injection required for create
       image_url: sanitizedImageUrl,
-      is_featured: createCategoryDto.is_featured ?? false,
       state: 'active',
     };
+
+    if (createCategoryDto.is_featured !== undefined) {
+      categoryData.is_featured = createCategoryDto.is_featured;
+    }
 
     const category = await this.prisma.categories.create({
       data: categoryData,
@@ -187,11 +190,7 @@ export class CategoriesService {
     };
   }
 
-  async remove(
-    id: number,
-    user: any,
-    options: { force?: boolean } = {},
-  ) {
+  async remove(id: number, user: any, options: { force?: boolean } = {}) {
     const category = await this.findOne(id, { includeInactive: true });
 
     const productCount = await this.prisma.product_categories.count({

--- a/apps/backend/src/domains/store/categories/dto/index.ts
+++ b/apps/backend/src/domains/store/categories/dto/index.ts
@@ -74,7 +74,7 @@ export class CreateCategoryDto {
   })
   @IsBoolean()
   @IsOptional()
-  is_featured?: boolean = false;
+  is_featured?: boolean;
 }
 
 // Update Category DTO

--- a/apps/backend/src/domains/store/customers/customers-bulk.service.ts
+++ b/apps/backend/src/domains/store/customers/customers-bulk.service.ts
@@ -6,6 +6,10 @@ import { RequestContextService } from '@common/context/request-context.service';
 import { VendixHttpException } from '@common/errors/vendix-http.exception';
 import { ErrorCodes } from '@common/errors/error-codes';
 import {
+  DOCUMENT_TYPE_CODES,
+  DOCUMENT_TYPE_RULES,
+} from '@common/constants/document-types';
+import {
   BulkCustomerUploadDto,
   BulkCustomerUploadResultDto,
   BulkCustomerUploadItemResultDto,
@@ -23,7 +27,11 @@ export class CustomersBulkService {
 
   /**
    * Genera la plantilla de carga masiva en formato Excel (.xlsx)
-   * Incluye ejemplos con y sin email para mostrar que es opcional
+   * Incluye ejemplos con y sin email para mostrar que es opcional.
+   *
+   * Los códigos de "Tipo Documento" se derivan del catálogo DIAN compartido
+   * (`@common/constants/document-types`). No mantener una lista hardcodeada
+   * aquí — añadir nuevos tipos en el catálogo y los ejemplos los respetarán.
    */
   async generateExcelTemplate(): Promise<Buffer> {
     const headers = [
@@ -40,7 +48,7 @@ export class CustomersBulkService {
         Correo: 'maria.garcia@email.com',
         Nombre: 'Maria',
         Apellido: 'Garcia',
-        Documento: '12345678',
+        Documento: '1023456789',
         'Tipo Documento': 'CC',
         Teléfono: '3001234567',
       },
@@ -48,7 +56,7 @@ export class CustomersBulkService {
         Correo: 'juan.perez@email.com',
         Nombre: 'Juan',
         Apellido: 'Perez',
-        Documento: '23456789',
+        Documento: '1023456780',
         'Tipo Documento': 'CC',
         Teléfono: '3012345678',
       },
@@ -56,7 +64,7 @@ export class CustomersBulkService {
         Correo: '',
         Nombre: 'Ana',
         Apellido: 'Martinez',
-        Documento: '34567890',
+        Documento: '1023456781',
         'Tipo Documento': 'CC',
         Teléfono: '3023456789',
       },
@@ -64,7 +72,7 @@ export class CustomersBulkService {
         Correo: 'carlos.rodriguez@email.com',
         Nombre: 'Carlos',
         Apellido: 'Rodriguez',
-        Documento: '45678901',
+        Documento: '1023456782',
         'Tipo Documento': 'CE',
         Teléfono: '3034567890',
       },
@@ -72,15 +80,15 @@ export class CustomersBulkService {
         Correo: '',
         Nombre: 'Laura',
         Apellido: 'Sanchez',
-        Documento: '56789012',
-        'Tipo Documento': 'CC',
+        Documento: '900123456-7',
+        'Tipo Documento': 'NIT',
         Teléfono: '3045678901',
       },
       {
         Correo: 'pedro.gomez@email.com',
         Nombre: 'Pedro',
         Apellido: 'Gomez',
-        Documento: '67890123',
+        Documento: '1023456783',
         'Tipo Documento': 'CC',
         Teléfono: '3056789012',
       },
@@ -88,7 +96,7 @@ export class CustomersBulkService {
         Correo: 'sofia.lopez@email.com',
         Nombre: 'Sofia',
         Apellido: 'Lopez',
-        Documento: '78901234',
+        Documento: '1012345678',
         'Tipo Documento': 'TI',
         Teléfono: '3067890123',
       },
@@ -96,7 +104,7 @@ export class CustomersBulkService {
         Correo: 'andres.diaz@email.com',
         Nombre: 'Andres',
         Apellido: 'Diaz',
-        Documento: '89012345',
+        Documento: '1023456784',
         'Tipo Documento': 'CC',
         Teléfono: '3078901234',
       },
@@ -104,7 +112,7 @@ export class CustomersBulkService {
         Correo: '',
         Nombre: 'Valentina',
         Apellido: 'Hernandez',
-        Documento: '90123456',
+        Documento: '1023456785',
         'Tipo Documento': 'CC',
         Teléfono: '3089012345',
       },
@@ -112,8 +120,8 @@ export class CustomersBulkService {
         Correo: 'diego.torres@email.com',
         Nombre: 'Diego',
         Apellido: 'Torres',
-        Documento: '01234567',
-        'Tipo Documento': 'PP',
+        Documento: 'AB123456',
+        'Tipo Documento': 'PA',
         Teléfono: '3090123456',
       },
     ];
@@ -126,6 +134,57 @@ export class CustomersBulkService {
 
     const wb = XLSX.utils.book_new();
     XLSX.utils.book_append_sheet(wb, ws, 'Plantilla Clientes');
+
+    // Hoja de instrucciones con códigos válidos del catálogo DIAN.
+    const instructions: Array<Record<string, string>> = [
+      {
+        Campo: 'Correo',
+        Descripción: 'Correo electrónico del cliente (opcional)',
+        Obligatorio: 'No',
+      },
+      {
+        Campo: 'Nombre',
+        Descripción: 'Nombre(s) del cliente',
+        Obligatorio: 'Sí (o Documento)',
+      },
+      {
+        Campo: 'Apellido',
+        Descripción: 'Apellido(s) del cliente',
+        Obligatorio: 'No',
+      },
+      {
+        Campo: 'Documento',
+        Descripción: 'Número de identificación',
+        Obligatorio: 'Sí (o Nombre)',
+      },
+      {
+        Campo: 'Tipo Documento',
+        Descripción: 'Código DIAN del tipo de documento (ver lista abajo)',
+        Obligatorio: 'No (por defecto CC)',
+      },
+      {
+        Campo: 'Teléfono',
+        Descripción: 'Número de contacto',
+        Obligatorio: 'No',
+      },
+      { Campo: '', Descripción: '', Obligatorio: '' },
+      {
+        Campo: 'Códigos válidos de Tipo Documento',
+        Descripción: '',
+        Obligatorio: '',
+      },
+      ...DOCUMENT_TYPE_CODES.map((code) => ({
+        Campo: code,
+        Descripción: DOCUMENT_TYPE_RULES[code].label,
+        Obligatorio: '',
+      })),
+    ];
+
+    const wsInstructions = XLSX.utils.json_to_sheet(instructions, {
+      header: ['Campo', 'Descripción', 'Obligatorio'],
+    });
+    wsInstructions['!cols'] = [{ wch: 30 }, { wch: 55 }, { wch: 20 }];
+    XLSX.utils.book_append_sheet(wb, wsInstructions, 'Instrucciones');
 
     return XLSX.write(wb, { type: 'buffer', bookType: 'xlsx' });
   }

--- a/apps/backend/src/domains/store/customers/customers.service.ts
+++ b/apps/backend/src/domains/store/customers/customers.service.ts
@@ -24,6 +24,26 @@ export class CustomersService {
     return normalized ? normalized : null;
   }
 
+  /**
+   * Normalize a Colombian DIAN document pair for both storage and lookup.
+   *
+   * - Type is uppercased + trimmed (e.g. `cc` → `CC`).
+   * - Number is uppercased, trimmed, and stripped of separators (`. - space`).
+   *   The trailing verification digit on NITs (`123456789-0`) is preserved as
+   *   a single concatenated value so equality lookups work on the stored
+   *   value regardless of whether the input used a hyphen.
+   */
+  private normalizeDocument(input: {
+    type?: string | null;
+    number?: string | null;
+  }): { type: string | null; number: string | null } {
+    const type = input.type ? input.type.trim().toUpperCase() : null;
+    const number = input.number
+      ? input.number.trim().toUpperCase().replace(/[\s\-.]/g, '')
+      : null;
+    return { type, number };
+  }
+
   private async generateUniqueUsername(email: string): Promise<string> {
     let baseUsername = email.split('@')[0];
     // Eliminar caracteres especiales
@@ -81,6 +101,10 @@ export class CustomersService {
 
     const normalizedEmail = guest.email?.toLowerCase().trim() || null;
     const normalizedPhone = guest.phone?.replace(/\s+/g, '').trim() || null;
+    const normalizedDoc = this.normalizeDocument({
+      type: guest.document_type ?? null,
+      number: guest.document_number ?? null,
+    });
 
     if (!normalizedEmail && !normalizedPhone) return null;
 
@@ -140,8 +164,8 @@ export class CustomersService {
         first_name: formattedFirstName,
         last_name: formattedLastName,
         phone: this.normalizeOptionalString(normalizedPhone),
-        document_type: this.normalizeOptionalString(guest.document_type),
-        document_number: this.normalizeOptionalString(guest.document_number),
+        document_type: normalizedDoc.type,
+        document_number: normalizedDoc.number,
         username,
         email_verified: false,
         state: 'pending_verification' as const,
@@ -231,11 +255,11 @@ export class CustomersService {
     if (normalizedPhone) {
       data.phone = normalizedPhone;
     }
-    if (guest.document_type?.trim()) {
-      data.document_type = guest.document_type.trim();
+    if (normalizedDoc.type) {
+      data.document_type = normalizedDoc.type;
     }
-    if (guest.document_number?.trim()) {
-      data.document_number = guest.document_number.trim();
+    if (normalizedDoc.number) {
+      data.document_number = normalizedDoc.number;
     }
 
     const hasUpdates = Object.keys(data).length > 0;
@@ -280,6 +304,28 @@ export class CustomersService {
       throw new VendixHttpException(ErrorCodes.SYS_CONFLICT_001);
     }
 
+    // Normalize document pair before any DB lookup so uniqueness, storage
+    // and downstream queries all share the same canonical form.
+    const normalizedDoc = this.normalizeDocument({
+      type: dto.document_type ?? null,
+      number: dto.document_number ?? null,
+    });
+
+    if (normalizedDoc.number && normalizedDoc.type) {
+      const existingByDocument = await this.findByDocumentInOrganization(
+        store.organization_id,
+        normalizedDoc.number,
+        normalizedDoc.type,
+      );
+
+      if (existingByDocument) {
+        throw new VendixHttpException(
+          ErrorCodes.SYS_CONFLICT_001,
+          'Ya existe un cliente con este documento en la organización',
+        );
+      }
+    }
+
     // Find customer role
     const customerRole = await this.prisma.roles.findFirst({
       where: { name: 'customer' },
@@ -305,8 +351,8 @@ export class CustomersService {
         first_name: formatted_first_name,
         last_name: formatted_last_name,
         phone: this.normalizeOptionalString(dto.phone),
-        document_type: this.normalizeOptionalString(dto.document_type),
-        document_number: this.normalizeOptionalString(dto.document_number),
+        document_type: normalizedDoc.type,
+        document_number: normalizedDoc.number,
         username: username,
         email_verified: false,
         organization_id: store.organization_id,
@@ -446,14 +492,54 @@ export class CustomersService {
   async update(storeId: number, id: number, dto: UpdateCustomerDto) {
     const user = await this.findOne(storeId, id);
 
+    // Effective document pair to validate: payload overrides take precedence;
+    // when a payload field is undefined we fall back to the current stored value.
+    const effectiveType =
+      dto.document_type !== undefined ? dto.document_type : user.document_type;
+    const effectiveNumber =
+      dto.document_number !== undefined
+        ? dto.document_number
+        : user.document_number;
+
+    const normalizedDoc = this.normalizeDocument({
+      type: effectiveType ?? null,
+      number: effectiveNumber ?? null,
+    });
+
+    // Only check uniqueness when caller actually changes type or number.
+    const isChangingDocument =
+      dto.document_type !== undefined || dto.document_number !== undefined;
+
+    if (
+      isChangingDocument &&
+      normalizedDoc.number &&
+      normalizedDoc.type &&
+      user.organization_id
+    ) {
+      const conflict = await this.findByDocumentInOrganization(
+        user.organization_id,
+        normalizedDoc.number,
+        normalizedDoc.type,
+      );
+
+      if (conflict && conflict.id !== user.id) {
+        throw new VendixHttpException(
+          ErrorCodes.SYS_CONFLICT_001,
+          'Ya existe un cliente con este documento en la organización',
+        );
+      }
+    }
+
     return this.prisma.users.update({
       where: { id: user.id },
       data: {
         first_name: dto.first_name,
         last_name: dto.last_name,
         phone: this.normalizeOptionalString(dto.phone),
-        document_number: this.normalizeOptionalString(dto.document_number),
-        document_type: this.normalizeOptionalString(dto.document_type),
+        document_number:
+          dto.document_number !== undefined ? normalizedDoc.number : undefined,
+        document_type:
+          dto.document_type !== undefined ? normalizedDoc.type : undefined,
         email: dto.email, // Can we update email? Usually requires verification, but for CRUD basic...
       },
     });
@@ -478,9 +564,21 @@ export class CustomersService {
     documentNumber: string,
     documentType?: string,
   ): Promise<any | null> {
+    // Defensive normalization: callers may pass raw user input (POS lookup,
+    // legacy clients, etc.). Stored values are normalized, so we must look
+    // them up by the same canonical form.
+    const normalized = this.normalizeDocument({
+      type: documentType ?? null,
+      number: documentNumber ?? null,
+    });
+
+    if (!normalized.number) {
+      return null;
+    }
+
     const where: any = {
       organization_id: organizationId,
-      document_number: { equals: documentNumber, mode: 'insensitive' },
+      document_number: { equals: normalized.number, mode: 'insensitive' },
       user_roles: {
         some: {
           roles: {
@@ -490,8 +588,8 @@ export class CustomersService {
       },
     };
 
-    if (documentType) {
-      where.document_type = documentType;
+    if (normalized.type) {
+      where.document_type = normalized.type;
     }
 
     return this.prisma.users.findFirst({

--- a/apps/backend/src/domains/store/customers/dto/bulk-customer.dto.ts
+++ b/apps/backend/src/domains/store/customers/dto/bulk-customer.dto.ts
@@ -1,6 +1,7 @@
 import {
   IsArray,
   IsEmail,
+  IsIn,
   IsNotEmpty,
   IsNumber,
   IsOptional,
@@ -9,6 +10,8 @@ import {
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
+import { DOCUMENT_TYPE_CODES } from '../../../../common/constants/document-types';
+import { DocumentNumberMatchesType } from '../../../../common/validators/document-number.validator';
 
 export class BulkCustomerItemDto {
   @ApiPropertyOptional({ example: 'maria.garcia@email.com' })
@@ -27,13 +30,17 @@ export class BulkCustomerItemDto {
   last_name: string;
 
   @ApiPropertyOptional({ example: '12345678' })
-  @IsString()
   @IsOptional()
+  @IsString()
+  @DocumentNumberMatchesType()
   document_number?: string;
 
-  @ApiPropertyOptional({ example: 'CC' })
-  @IsString()
+  @ApiPropertyOptional({ example: 'CC', enum: DOCUMENT_TYPE_CODES })
   @IsOptional()
+  @IsString()
+  @IsIn(DOCUMENT_TYPE_CODES as unknown as string[], {
+    message: 'document_type debe ser uno de los códigos DIAN válidos',
+  })
   document_type?: string;
 
   @ApiPropertyOptional({ example: '3001234567' })

--- a/apps/backend/src/domains/store/customers/dto/create-customer.dto.ts
+++ b/apps/backend/src/domains/store/customers/dto/create-customer.dto.ts
@@ -1,11 +1,14 @@
 import {
   IsEmail,
+  IsIn,
   IsNotEmpty,
   IsOptional,
   IsString,
   Matches,
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { DOCUMENT_TYPE_CODES } from '../../../../common/constants/document-types';
+import { DocumentNumberMatchesType } from '../../../../common/validators/document-number.validator';
 
 export class CreateCustomerDto {
   @ApiProperty({ example: 'juan.perez@example.com' })
@@ -24,13 +27,17 @@ export class CreateCustomerDto {
   last_name: string;
 
   @ApiPropertyOptional({ example: '12345678' })
-  @IsString()
   @IsOptional()
+  @IsString()
+  @DocumentNumberMatchesType()
   document_number?: string | null;
 
-  @ApiPropertyOptional({ example: 'CC' })
-  @IsString()
+  @ApiPropertyOptional({ example: 'CC', enum: DOCUMENT_TYPE_CODES })
   @IsOptional()
+  @IsString()
+  @IsIn(DOCUMENT_TYPE_CODES as unknown as string[], {
+    message: 'document_type debe ser uno de los códigos DIAN válidos',
+  })
   document_type?: string | null;
 
   @ApiPropertyOptional({ example: '3001234567' })

--- a/apps/backend/src/domains/store/inventory/shared/helpers/low-stock-threshold.helper.ts
+++ b/apps/backend/src/domains/store/inventory/shared/helpers/low-stock-threshold.helper.ts
@@ -1,0 +1,55 @@
+import type { StoreSettings } from '../../../settings/interfaces/store-settings.interface';
+
+export const DEFAULT_LOW_STOCK_THRESHOLD = 10;
+
+type SettingsLike = Pick<StoreSettings, 'inventory'> | null | undefined;
+
+export interface ProductLowStockThresholdSource {
+  reorder_point?: number | string | null;
+  min_stock_level?: number | string | null;
+}
+
+export interface StockLevelLowStockThresholdSource {
+  reorder_point?: number | string | null;
+}
+
+export function resolveConfiguredLowStockThreshold(
+  settings: SettingsLike,
+): number {
+  const configured = toFiniteNumber(settings?.inventory?.low_stock_threshold);
+
+  return configured !== null && configured >= 0
+    ? configured
+    : DEFAULT_LOW_STOCK_THRESHOLD;
+}
+
+export function resolveProductLowStockThreshold(
+  settings: SettingsLike,
+  source?: ProductLowStockThresholdSource | null,
+): number {
+  return (
+    toPositiveNumber(source?.reorder_point) ??
+    toPositiveNumber(source?.min_stock_level) ??
+    resolveConfiguredLowStockThreshold(settings)
+  );
+}
+
+export function resolveStockLevelLowStockThreshold(
+  settings: SettingsLike,
+  source?: StockLevelLowStockThresholdSource | null,
+): number {
+  return (
+    toPositiveNumber(source?.reorder_point) ??
+    resolveConfiguredLowStockThreshold(settings)
+  );
+}
+
+function toPositiveNumber(value: unknown): number | null {
+  const parsed = toFiniteNumber(value);
+  return parsed !== null && parsed > 0 ? parsed : null;
+}
+
+function toFiniteNumber(value: unknown): number | null {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}

--- a/apps/backend/src/domains/store/inventory/shared/services/inventory-integration.service.ts
+++ b/apps/backend/src/domains/store/inventory/shared/services/inventory-integration.service.ts
@@ -1,5 +1,8 @@
 import { Injectable, BadRequestException } from '@nestjs/common';
 import { StorePrismaService } from '../../../../../prisma/services/store-prisma.service';
+import { mergeStoreSettingsWithDefaults } from '../../../settings/defaults/default-store-settings';
+import type { StoreSettings } from '../../../settings/interfaces/store-settings.interface';
+import { resolveStockLevelLowStockThreshold } from '../helpers/low-stock-threshold.helper';
 
 @Injectable()
 export class InventoryIntegrationService {
@@ -260,7 +263,8 @@ export class InventoryIntegrationService {
 
     const stockValue = stockLevels.reduce(
       (sum, stock) =>
-        sum + Number(stock.quantity_on_hand || 0) * Number(stock.cost_per_unit || 0),
+        sum +
+        Number(stock.quantity_on_hand || 0) * Number(stock.cost_per_unit || 0),
       0,
     );
     const stockQty = stockLevels.reduce(
@@ -288,7 +292,8 @@ export class InventoryIntegrationService {
 
     const layerValue = layers.reduce(
       (sum, layer) =>
-        sum + Number(layer.quantity_remaining || 0) * Number(layer.unit_cost || 0),
+        sum +
+        Number(layer.quantity_remaining || 0) * Number(layer.unit_cost || 0),
       0,
     );
     const layerQty = layers.reduce(
@@ -464,8 +469,9 @@ export class InventoryIntegrationService {
       reorderPoint: number;
     }>
   > {
+    const settings = await this.loadMergedSettings();
+
     const where: any = {
-      reorder_point: { not: null },
       inventory_locations: {
         organization_id: organizationId,
       },
@@ -494,9 +500,10 @@ export class InventoryIntegrationService {
     });
 
     // Filter in memory since Prisma doesn't support field-to-field comparison
-    const lowStockItems = stockItems.filter(
-      (item) => item.quantity_available <= (item.reorder_point ?? Infinity),
-    );
+    const lowStockItems = stockItems.filter((item) => {
+      const threshold = resolveStockLevelLowStockThreshold(settings, item);
+      return Number(item.quantity_available ?? 0) <= threshold;
+    });
 
     return lowStockItems.map((item) => ({
       productId: item.product_id,
@@ -504,8 +511,15 @@ export class InventoryIntegrationService {
       locationId: item.location_id,
       locationName: item.inventory_locations.name,
       currentStock: item.quantity_available,
-      reorderPoint: item.reorder_point ?? 0,
+      reorderPoint: resolveStockLevelLowStockThreshold(settings, item),
     }));
+  }
+
+  private async loadMergedSettings(): Promise<StoreSettings> {
+    const row = await this.prisma.store_settings.findFirst({
+      select: { settings: true },
+    });
+    return mergeStoreSettingsWithDefaults(row?.settings);
   }
 
   /**

--- a/apps/backend/src/domains/store/inventory/shared/services/stock-level-manager.service.spec.ts
+++ b/apps/backend/src/domains/store/inventory/shared/services/stock-level-manager.service.spec.ts
@@ -136,6 +136,11 @@ describe('StockLevelManager', () => {
     prismaService = module.get(StorePrismaService);
     transactionsService = module.get(InventoryTransactionsService);
     eventEmitter = module.get(EventEmitter2);
+    prismaService.products.findUnique.mockResolvedValue({
+      track_inventory: true,
+      store_id: 1,
+      name: 'Test Product',
+    } as any);
 
     // Mock RequestContextService
     jest

--- a/apps/backend/src/domains/store/inventory/shared/services/stock-level-manager.service.ts
+++ b/apps/backend/src/domains/store/inventory/shared/services/stock-level-manager.service.ts
@@ -11,6 +11,9 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { RequestContextService } from '@common/context/request-context.service';
 import { VendixHttpException, ErrorCodes } from 'src/common/errors';
 import { OperatingScopeService } from '@common/services/operating-scope.service';
+import { mergeStoreSettingsWithDefaults } from '../../../settings/defaults/default-store-settings';
+import type { StoreSettings } from '../../../settings/interfaces/store-settings.interface';
+import { resolveStockLevelLowStockThreshold } from '../helpers/low-stock-threshold.helper';
 
 export interface UpdateStockParams {
   product_id: number;
@@ -97,7 +100,7 @@ export class StockLevelManager {
     // Skip stock operations for products that don't track inventory
     const productForTracking = await prisma.products.findUnique({
       where: { id: params.product_id },
-      select: { track_inventory: true },
+      select: { track_inventory: true, store_id: true, name: true },
     });
 
     if (!productForTracking || !productForTracking.track_inventory) {
@@ -234,20 +237,23 @@ export class StockLevelManager {
     } as StockUpdatedEvent);
 
     // 9. Emitir alerta de stock bajo si aplica
-    const low_threshold = existing_stock_level.reorder_point ?? 5;
+    const settings = await this.loadMergedSettingsForStore(
+      prisma,
+      productForTracking.store_id,
+    );
+    const low_threshold = resolveStockLevelLowStockThreshold(
+      settings,
+      existing_stock_level,
+    );
     if (
       updated_stock.quantity_available <= low_threshold &&
       updated_stock.quantity_available >= 0
     ) {
-      const product = await prisma.products.findUnique({
-        where: { id: params.product_id },
-        select: { name: true, store_id: true },
-      });
-      if (product?.store_id) {
+      if (productForTracking.store_id) {
         this.eventEmitter.emit('stock.low', {
-          store_id: product.store_id,
+          store_id: productForTracking.store_id,
           product_id: params.product_id,
-          product_name: product.name || 'Producto',
+          product_name: productForTracking.name || 'Producto',
           quantity: updated_stock.quantity_available,
           threshold: low_threshold,
         });
@@ -1382,25 +1388,53 @@ export class StockLevelManager {
    * Verifica puntos de reorden
    */
   async checkReorderPoints(product_id: number): Promise<any[]> {
-    const stock_levels = await this.prisma.stock_levels.findMany({
-      where: {
-        product_id: product_id,
-        reorder_point: { not: null },
-      },
-      include: {
-        inventory_locations: {
-          select: {
-            id: true,
-            name: true,
-            code: true,
+    const [product, stock_levels] = await Promise.all([
+      this.prisma.products.findUnique({
+        where: { id: product_id },
+        select: { store_id: true },
+      }),
+      this.prisma.stock_levels.findMany({
+        where: {
+          product_id: product_id,
+        },
+        include: {
+          inventory_locations: {
+            select: {
+              id: true,
+              name: true,
+              code: true,
+            },
           },
         },
-      },
-    });
+      }),
+    ]);
 
-    return stock_levels.filter(
-      (sl) => sl.quantity_available <= (sl.reorder_point || 0),
+    const settings = await this.loadMergedSettingsForStore(
+      this.prisma,
+      product?.store_id,
     );
+    return stock_levels.filter((stockLevel) => {
+      const threshold = resolveStockLevelLowStockThreshold(
+        settings,
+        stockLevel,
+      );
+      return Number(stockLevel.quantity_available ?? 0) <= threshold;
+    });
+  }
+
+  private async loadMergedSettingsForStore(
+    prisma: any,
+    storeId: number | null | undefined,
+  ): Promise<StoreSettings> {
+    if (!storeId || !prisma.store_settings?.findFirst) {
+      return mergeStoreSettingsWithDefaults(undefined);
+    }
+
+    const row = await prisma.store_settings.findFirst({
+      where: { store_id: storeId },
+      select: { settings: true },
+    });
+    return mergeStoreSettingsWithDefaults(row?.settings);
   }
 
   async transferBaseStockToVariants(

--- a/apps/backend/src/domains/store/inventory/stock-levels/stock-levels.service.ts
+++ b/apps/backend/src/domains/store/inventory/stock-levels/stock-levels.service.ts
@@ -9,6 +9,7 @@ import {
   resolveLowStockAlertsScope,
   ResolvedInventoryScope,
 } from '../shared/helpers/pos-stock-scope.helper';
+import { resolveStockLevelLowStockThreshold } from '../shared/helpers/low-stock-threshold.helper';
 import { mergeStoreSettingsWithDefaults } from '../../settings/defaults/default-store-settings';
 import type { StoreSettings } from '../../settings/interfaces/store-settings.interface';
 
@@ -85,15 +86,13 @@ export class StockLevelsService {
   }
 
   async getStockAlerts(query: StockLevelQueryDto) {
-    const locationFilter = await this.resolveScopedLocationFilter(
-      query.location_id,
-      'low_stock_alerts',
-    );
-    return this.prisma.stock_levels.findMany({
+    const [locationFilter, settings] = await Promise.all([
+      this.resolveScopedLocationFilter(query.location_id, 'low_stock_alerts'),
+      this.loadMergedSettings(),
+    ]);
+
+    const stockLevels = await this.prisma.stock_levels.findMany({
       where: {
-        quantity_available: {
-          lte: this.prisma.stock_levels.fields.reorder_point,
-        },
         product_id: query.product_id,
         ...locationFilter,
       },
@@ -102,6 +101,14 @@ export class StockLevelsService {
         product_variants: true,
         inventory_locations: true,
       },
+    });
+
+    return stockLevels.filter((stockLevel) => {
+      const threshold = resolveStockLevelLowStockThreshold(
+        settings,
+        stockLevel,
+      );
+      return Number(stockLevel.quantity_available ?? 0) <= threshold;
     });
   }
 

--- a/apps/backend/src/domains/store/notifications/dto/update-subscription.dto.ts
+++ b/apps/backend/src/domains/store/notifications/dto/update-subscription.dto.ts
@@ -11,6 +11,7 @@ const NOTIFICATION_TYPES = [
   'layaway_overdue',
   'layaway_completed',
   'layaway_cancelled',
+  'new_review',
 ] as const;
 
 export class UpdateSubscriptionDto {

--- a/apps/backend/src/domains/store/notifications/notifications-events.listener.ts
+++ b/apps/backend/src/domains/store/notifications/notifications-events.listener.ts
@@ -633,7 +633,11 @@ export class NotificationsEventsListener {
       'new_review',
       'Nueva Reseña',
       `${event.customer_name} dejó una reseña de ${'★'.repeat(event.rating)}${'☆'.repeat(5 - event.rating)} para ${event.product_name}`,
-      { review_id: event.review_id, product_id: event.product_id },
+      {
+        review_id: event.review_id,
+        product_id: event.product_id,
+        route: `/admin/customers/reviews?review_id=${event.review_id}`,
+      },
     );
   }
 

--- a/apps/backend/src/domains/store/notifications/notifications.service.ts
+++ b/apps/backend/src/domains/store/notifications/notifications.service.ts
@@ -188,6 +188,7 @@ export class NotificationsService {
       'layaway_overdue',
       'layaway_completed',
       'layaway_cancelled',
+      'new_review',
     ];
 
     const existing = await this.subscriptionsModel.findMany({

--- a/apps/backend/src/domains/store/orders/order-flow/order-flow.service.ts
+++ b/apps/backend/src/domains/store/orders/order-flow/order-flow.service.ts
@@ -1502,7 +1502,6 @@ export class OrderFlowService {
         amount,
         payment_method: paymentMethodType,
         order_id: orderId,
-        payment_id: 0, // Payment ID not available in this flow
       });
     } catch {
       // Non-critical: don't fail the payment if movement recording fails

--- a/apps/backend/src/domains/store/orders/orders.service.spec.ts
+++ b/apps/backend/src/domains/store/orders/orders.service.spec.ts
@@ -2,37 +2,52 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { OrdersService } from './orders.service';
 import { StorePrismaService } from '../../../prisma/services/store-prisma.service';
 import { RequestContextService } from '@common/context/request-context.service';
-import { CreateOrderDto, UpdateOrderDto, OrderQueryDto } from './dto';
-import {
-  NotFoundException,
-  ConflictException,
-  BadRequestException,
-} from '@nestjs/common';
-import { order_state_enum, Prisma } from '@prisma/client';
+import { S3Service } from '@common/services/s3.service';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { SettingsService } from '../settings/settings.service';
+import { ScheduleValidationService } from '../settings/schedule-validation.service';
+import { StockLevelManager } from '../inventory/shared/services/stock-level-manager.service';
+import { ShippingCalculatorService } from '../shipping/shipping-calculator.service';
+import { VendixHttpException } from 'src/common/errors';
 
 describe('OrdersService', () => {
   let service: OrdersService;
-  let prismaService: StorePrismaService;
 
   const mockPrismaService = {
     orders: {
       create: jest.fn(),
       findMany: jest.fn(),
       findFirst: jest.fn(),
+      findUnique: jest.fn(),
       update: jest.fn(),
       delete: jest.fn(),
       count: jest.fn(),
       aggregate: jest.fn(),
     },
-    users: {
-      findUnique: jest.fn(),
-    },
-    stores: {
-      findFirst: jest.fn(),
-    },
+    users: { findUnique: jest.fn() },
+    stores: { findFirst: jest.fn() },
+    payments: { findFirst: jest.fn() },
+    audit_logs: { findMany: jest.fn() },
     withoutScope: jest.fn(),
     $transaction: jest.fn((callback) => callback(mockPrismaService)),
   };
+
+  const mockS3Service = {
+    signUrl: jest.fn(async (url: string) => url),
+    getPresignedUrl: jest.fn(async (key: string) => `signed:${key}`),
+  };
+
+  const mockEventEmitter = { emit: jest.fn() };
+  const mockSettingsService = {
+    getStoreCurrency: jest.fn(async () => 'COP'),
+  };
+  const mockScheduleValidation = { validateOrThrow: jest.fn() };
+  const mockStockLevelManager = {
+    reserveStock: jest.fn(),
+    releaseReservation: jest.fn(),
+    getDefaultLocationForProduct: jest.fn(async () => 1),
+  };
+  const mockShippingCalculator = { calculateRates: jest.fn() };
 
   const mockRequestContextService = {
     getContext: jest.fn(),
@@ -45,738 +60,174 @@ describe('OrdersService', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         OrdersService,
-        {
-          provide: StorePrismaService,
-          useValue: mockPrismaService,
-        },
-        {
-          provide: RequestContextService,
-          useValue: mockRequestContextService,
-        },
+        { provide: StorePrismaService, useValue: mockPrismaService },
+        { provide: RequestContextService, useValue: mockRequestContextService },
+        { provide: S3Service, useValue: mockS3Service },
+        { provide: EventEmitter2, useValue: mockEventEmitter },
+        { provide: SettingsService, useValue: mockSettingsService },
+        { provide: ScheduleValidationService, useValue: mockScheduleValidation },
+        { provide: StockLevelManager, useValue: mockStockLevelManager },
+        { provide: ShippingCalculatorService, useValue: mockShippingCalculator },
       ],
     }).compile();
 
     service = module.get<OrdersService>(OrdersService);
-    prismaService = module.get<StorePrismaService>(StorePrismaService);
 
-    // Reset all mocks
-    // jest.clearAllMocks();
-
-    // Mock withoutScope to return the same prisma service
     mockPrismaService.withoutScope.mockReturnValue(mockPrismaService);
-
-    // Default context
     mockRequestContextService.getContext.mockReturnValue({
       store_id: 1,
       organization_id: 1,
       is_super_admin: false,
     });
+
+    jest.clearAllMocks();
   });
 
   afterEach(() => {
     jest.useRealTimers();
   });
 
-  describe('create', () => {
-    it('should create an order successfully', async () => {
-      const createOrderDto: CreateOrderDto = {
-        store_id: 1,
-        customer_id: 1,
-        order_number: 'ORD202412010001',
-        state: order_state_enum.created,
-        subtotal: 100.0,
-        tax_amount: 10.0,
-        shipping_cost: 5.0,
-        discount_amount: 0.0,
-        total_amount: 115.0,
-        currency: 'USD',
-        billing_address_id: 1,
-        shipping_address_id: 2,
-        internal_notes: 'Test order',
-        items: [
-          {
-            product_id: 1,
-            product_variant_id: 1,
-            product_name: 'Test Product',
-            variant_sku: 'TP001',
-            variant_attributes: JSON.stringify({ color: 'red', size: 'M' }),
-            quantity: 2,
-            unit_price: 50.0,
-            total_price: 100.0,
-            tax_rate: 0.1,
-            tax_amount_item: 10.0,
-          },
-        ],
-      };
-
-      const user = { id: 1, organization_id: 1 };
-      const expectedOrder = {
-        id: 1,
-        customer_id: 1,
-        store_id: 1,
-        order_number: 'ORD202412010001',
-        state: order_state_enum.created,
-        subtotal_amount: 100.0,
-        tax_amount: 10.0,
-        shipping_cost: 5.0,
-        discount_amount: 0.0,
-        grand_total: 115.0,
-        currency: 'USD',
-        billing_address_id: 1,
-        shipping_address_id: 2,
-        internal_notes: 'Test order',
-        stores: { id: 1, name: 'Test Store', store_code: 'TS001' },
-        order_items: [
-          {
-            id: 1,
-            product_id: 1,
-            product_variant_id: 1,
-            product_name: 'Test Product',
-            variant_sku: 'TP001',
-            variant_attributes: JSON.stringify({ color: 'red', size: 'M' }),
-            quantity: 2,
-            unit_price: 50.0,
-            total_price: 100.0,
-            tax_rate: 0.1,
-            tax_amount_item: 10.0,
-            products: { id: 1, name: 'Test Product' },
-            product_variants: { id: 1, sku: 'TP001' },
-          },
-        ],
-      };
-
-      mockRequestContextService.getContext.mockReturnValue({
-        store_id: 1,
-        organization_id: 1,
-        is_super_admin: false,
-      });
-
-      mockPrismaService.users.findUnique.mockResolvedValue({
-        id: 1,
-        name: 'Test Customer',
-      });
-
-      mockPrismaService.stores.findFirst.mockResolvedValue({
-        id: 1,
-        name: 'Test Store',
-        organization_id: 1,
-      });
-
-      mockPrismaService.orders.create.mockResolvedValue(expectedOrder);
-
-      const result = await service.create(createOrderDto, user);
-
-      expect(result).toEqual(expectedOrder);
-      expect(mockPrismaService.orders.create).toHaveBeenCalledWith({
-        data: {
-          customer_id: 1,
-          store_id: 1,
-          order_number: 'ORD202412010001',
-          state: order_state_enum.created,
-          subtotal_amount: 100.0,
-          tax_amount: 10.0,
-          shipping_cost: 5.0,
-          discount_amount: 0.0,
-          grand_total: 115.0,
-          currency: 'USD',
-          billing_address_id: 1,
-          shipping_address_id: 2,
-          internal_notes: 'Test order',
-          updated_at: new Date('2024-12-01T12:00:00Z'),
-          order_items: {
-            create: [
-              {
-                product_id: 1,
-                product_variant_id: 1,
-                product_name: 'Test Product',
-                variant_sku: 'TP001',
-                variant_attributes: JSON.stringify({ color: 'red', size: 'M' }),
-                quantity: 2,
-                unit_price: 50.0,
-                total_price: 100.0,
-                tax_rate: 0.1,
-                tax_amount_item: 10.0,
-                updated_at: new Date('2024-12-01T12:00:00Z'),
-              },
-            ],
-          },
-        },
-        include: {
-          stores: { select: { id: true, name: true, store_code: true } },
-          order_items: { include: { products: true, product_variants: true } },
-        },
-      });
-    });
-
-    it('should generate order number when not provided', async () => {
-      const createOrderDto: CreateOrderDto = {
-        store_id: 1,
-        customer_id: 1,
-        subtotal: 100.0,
-        total_amount: 100.0,
-        items: [
-          {
-            product_id: 1,
-            product_name: 'Test Product',
-            quantity: 1,
-            unit_price: 100.0,
-            total_price: 100.0,
-          },
-        ],
-      };
-
-      const user = { id: 1, organization_id: 1 };
-
-      mockRequestContextService.getContext.mockReturnValue({
-        store_id: 1,
-        organization_id: 1,
-        is_super_admin: false,
-      });
-
-      mockPrismaService.users.findUnique.mockResolvedValue({
-        id: 1,
-        name: 'Test Customer',
-      });
-
-      mockPrismaService.stores.findFirst.mockResolvedValue({
-        id: 1,
-        name: 'Test Store',
-        organization_id: 1,
-      });
-
-      mockPrismaService.orders.findFirst.mockResolvedValue(null);
-
-      mockPrismaService.orders.create.mockResolvedValue({
-        id: 1,
-        order_number: 'ORD2412010001',
-      });
-
-      const result = await service.create(createOrderDto, user);
-
-      expect(result.order_number).toBeDefined();
-      expect(result.order_number).toMatch(/^ORD\d{8}\d{4}$/);
-    });
-
-    it('should retry generation if order number already exists', async () => {
-      const createOrderDto: CreateOrderDto = {
-        store_id: 1,
-        customer_id: 1,
-        subtotal: 100.0,
-        total_amount: 100.0,
-        items: [
-          {
-            product_id: 1,
-            product_name: 'Test Product',
-            quantity: 1,
-            unit_price: 100.0,
-            total_price: 100.0,
-          },
-        ],
-      };
-
-      const user = { id: 1, organization_id: 1 };
-
-      mockRequestContextService.getContext.mockReturnValue({
-        store_id: 1,
-        organization_id: 1,
-        is_super_admin: false,
-      });
-
-      mockPrismaService.users.findUnique.mockResolvedValue({
-        id: 1,
-        name: 'Test Customer',
-      });
-
-      mockPrismaService.stores.findFirst.mockResolvedValue({
-        id: 1,
-        name: 'Test Store',
-        organization_id: 1,
-      });
-
-      mockPrismaService.orders.findFirst.mockResolvedValue(null);
-
-      // First attempt fails with collision
-      mockPrismaService.orders.create.mockRejectedValueOnce({
-        code: 'P2002',
-        meta: { target: ['order_number'] },
-      });
-
-      // Second attempt succeeds
-      const expectedOrder = {
-        id: 1,
-        order_number: 'ORD2412010002',
-      };
-      mockPrismaService.orders.create.mockResolvedValue(expectedOrder);
-
-      const result = await service.create(createOrderDto, user);
-
-      expect(mockPrismaService.orders.create).toHaveBeenCalledTimes(2);
-      expect(result.order_number).toBe('ORD2412010002');
-    });
-
-    it('should throw NotFoundException when customer not found', async () => {
-      const createOrderDto: CreateOrderDto = {
-        store_id: 1,
-        customer_id: 999,
-        subtotal: 100.0,
-        total_amount: 100.0,
-        items: [],
-      };
-
-      const user = { id: 1, organization_id: 1 };
-
-      mockRequestContextService.getContext.mockReturnValue({
-        store_id: 1,
-        organization_id: 1,
-        is_super_admin: false,
-      });
-
-      mockPrismaService.users.findUnique.mockResolvedValue(null);
-
-      try {
-        await service.create(createOrderDto, user);
-        fail('Should have thrown NotFoundException (User)');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotFoundException);
-        expect(error.message).toContain('not found');
-      }
-    });
-
-    it('should throw BadRequestException when store context is missing', async () => {
-      const createOrderDto: CreateOrderDto = {
-        store_id: 1,
-        customer_id: 1,
-        subtotal: 100.0,
-        total_amount: 100.0,
-        items: [],
-      };
-
-      const user = { id: 1, organization_id: 1 };
-
-      mockRequestContextService.getContext.mockReturnValue({
-        store_id: null,
-        organization_id: 1,
-        is_super_admin: false,
-      });
-
-      try {
-        await service.create(createOrderDto, user);
-        fail('Should have thrown ForbiddenException or BadRequestException');
-      } catch (error) {
-        expect(error.message).toContain('Store context required');
-      }
-    });
-  });
-
-  describe('findAll', () => {
-    it('should return paginated orders with default values', async () => {
-      const query: OrderQueryDto = {};
-      const orders = [
-        {
-          id: 1,
-          order_number: 'ORD001',
-          state: order_state_enum.created,
-          stores: { id: 1, name: 'Store 1', store_code: 'S001' },
-          order_items: [{ id: 1, product_name: 'Product 1', quantity: 1 }],
-        },
-        {
-          id: 2,
-          order_number: 'ORD002',
-          state: order_state_enum.delivered,
-          stores: { id: 1, name: 'Store 1', store_code: 'S001' },
-          order_items: [{ id: 2, product_name: 'Product 2', quantity: 2 }],
-        },
-      ];
-
-      mockRequestContextService.getContext.mockReturnValue({
-        store_id: 1,
-        organization_id: 1,
-        is_super_admin: false,
-      });
-
-      mockPrismaService.orders.findMany.mockResolvedValue(orders);
-      mockPrismaService.orders.count.mockResolvedValue(2);
-
-      const result = await service.findAll(query);
-
-      expect(result).toEqual({
-        data: orders,
-        pagination: { total: 2, page: 1, limit: 10, totalPages: 1 },
-      });
-      expect(mockPrismaService.orders.findMany).toHaveBeenCalledWith({
-        where: {},
-        skip: 0,
-        take: 10,
-        orderBy: { created_at: 'desc' },
-        include: {
-          stores: { select: { id: true, name: true, store_code: true } },
-          order_items: {
-            select: { id: true, product_name: true, quantity: true },
-          },
-        },
-      });
-    });
-
-    it('should handle search functionality', async () => {
-      const query: OrderQueryDto = {
-        search: 'ORD001',
-      };
-
-      const orders = [
-        {
-          id: 1,
-          order_number: 'ORD001',
-          state: order_state_enum.created,
-          stores: { id: 1, name: 'Store 1', store_code: 'S001' },
-          order_items: [{ id: 1, product_name: 'Product 1', quantity: 1 }],
-        },
-      ];
-
-      mockRequestContextService.getContext.mockReturnValue({
-        store_id: 1,
-        organization_id: 1,
-        is_super_admin: false,
-      });
-
-      mockPrismaService.orders.findMany.mockResolvedValue(orders);
-      mockPrismaService.orders.count.mockResolvedValue(1);
-
-      const result = await service.findAll(query);
-
-      expect(result).toEqual({
-        data: orders,
-        pagination: { total: 1, page: 1, limit: 10, totalPages: 1 },
-      });
-      expect(mockPrismaService.orders.findMany).toHaveBeenCalledWith({
-        where: {
-          OR: [{ order_number: { contains: 'ORD001', mode: 'insensitive' } }],
-        },
-        skip: 0,
-        take: 10,
-        orderBy: { created_at: 'desc' },
-        include: {
-          stores: { select: { id: true, name: true, store_code: true } },
-          order_items: {
-            select: { id: true, product_name: true, quantity: true },
-          },
-        },
-      });
-    });
-
-    it('should handle status filtering', async () => {
-      const query: OrderQueryDto = {
-        status: order_state_enum.delivered,
-      };
-
-      const orders = [
-        {
-          id: 1,
-          order_number: 'ORD001',
-          // replaced completed with delivered
-          state: order_state_enum.delivered,
-          stores: { id: 1, name: 'Store 1', store_code: 'S001' },
-          order_items: [{ id: 1, product_name: 'Product 1', quantity: 1 }],
-        },
-      ];
-
-      mockRequestContextService.getContext.mockReturnValue({
-        store_id: 1,
-        organization_id: 1,
-        is_super_admin: false,
-      });
-
-      mockPrismaService.orders.findMany.mockResolvedValue(orders);
-      mockPrismaService.orders.count.mockResolvedValue(1);
-
-      const result = await service.findAll(query);
-
-      expect(result).toEqual({
-        data: orders,
-        pagination: { total: 1, page: 1, limit: 10, totalPages: 1 },
-      });
-      expect(mockPrismaService.orders.findMany).toHaveBeenCalledWith({
-        where: {
-          state: order_state_enum.delivered,
-        },
-        skip: 0,
-        take: 10,
-        orderBy: { created_at: 'desc' },
-        include: {
-          stores: { select: { id: true, name: true, store_code: true } },
-          order_items: {
-            select: { id: true, product_name: true, quantity: true },
-          },
-        },
-      });
-    });
-
-    it('should handle date range filtering', async () => {
-      const query: OrderQueryDto = {
-        date_from: '2024-01-01',
-        date_to: '2024-01-31',
-      };
-
-      const orders = [
-        {
-          id: 1,
-          order_number: 'ORD001',
-          state: order_state_enum.created,
-          stores: { id: 1, name: 'Store 1', store_code: 'S001' },
-          order_items: [{ id: 1, product_name: 'Product 1', quantity: 1 }],
-        },
-      ];
-
-      mockRequestContextService.getContext.mockReturnValue({
-        store_id: 1,
-        organization_id: 1,
-        is_super_admin: false,
-      });
-
-      mockPrismaService.orders.findMany.mockResolvedValue(orders);
-      mockPrismaService.orders.count.mockResolvedValue(1);
-
-      const result = await service.findAll(query);
-
-      expect(result).toEqual({
-        data: orders,
-        pagination: { total: 1, page: 1, limit: 10, totalPages: 1 },
-      });
-      expect(mockPrismaService.orders.findMany).toHaveBeenCalledWith({
-        where: {
-          created_at: {
-            gte: new Date('2024-01-01'),
-            lte: new Date('2024-01-31'),
-          },
-        },
-        skip: 0,
-        take: 10,
-        orderBy: { created_at: 'desc' },
-        include: {
-          stores: { select: { id: true, name: true, store_code: true } },
-          order_items: {
-            select: { id: true, product_name: true, quantity: true },
-          },
-        },
-      });
-    });
-  });
-
-  describe('findOne', () => {
-    it('should return order by id', async () => {
-      const orderId = 1;
-      const expectedOrder = {
+  describe('findOne — discount snapshots', () => {
+    it('includes order_promotions and coupon_uses in the detail query', async () => {
+      mockPrismaService.orders.findFirst.mockResolvedValue({
         id: 1,
         order_number: 'ORD001',
-        state: order_state_enum.created,
-        stores: { id: 1, name: 'Store 1', store_code: 'S001' },
-        order_items: [
+        order_items: [],
+        order_promotions: [],
+        coupon_uses: [],
+      });
+
+      await service.findOne(1);
+
+      expect(mockPrismaService.orders.findFirst).toHaveBeenCalledTimes(1);
+      const args = mockPrismaService.orders.findFirst.mock.calls[0][0];
+      expect(args.where).toEqual({ id: 1 });
+      expect(args.include).toBeDefined();
+
+      // Discount snapshots must be loaded so the detail view can show
+      // exactly what was charged (not a recalculation).
+      expect(args.include.order_promotions).toBeDefined();
+      expect(args.include.order_promotions.select).toMatchObject({
+        id: true,
+        promotion_id: true,
+        discount_amount: true,
+      });
+      expect(args.include.order_promotions.select.promotions).toBeDefined();
+      expect(args.include.order_promotions.select.promotions.select).toMatchObject({
+        id: true,
+        name: true,
+        code: true,
+        type: true,
+        scope: true,
+      });
+
+      expect(args.include.coupon_uses).toBeDefined();
+      expect(args.include.coupon_uses.select).toMatchObject({
+        id: true,
+        coupon_id: true,
+        discount_applied: true,
+      });
+      expect(args.include.coupon_uses.select.coupon).toBeDefined();
+      expect(args.include.coupon_uses.select.coupon.select).toMatchObject({
+        id: true,
+        code: true,
+        name: true,
+        discount_type: true,
+      });
+    });
+
+    it('returns the persisted promotion + coupon snapshots untouched (no recalculation)', async () => {
+      const persistedOrder = {
+        id: 42,
+        order_number: 'ORD2412010042',
+        subtotal_amount: '100.00',
+        tax_amount: '0.00',
+        shipping_cost: '5.00',
+        discount_amount: '15.00',
+        grand_total: '90.00',
+        currency: 'COP',
+        order_items: [],
+        order_promotions: [
           {
-            id: 1,
-            product_name: 'Product 1',
-            products: { id: 1, name: 'Product 1' },
-            product_variants: { id: 1, sku: 'P001' },
+            id: 11,
+            promotion_id: 7,
+            customer_id: 3,
+            discount_amount: '10.00',
+            created_at: new Date('2024-12-01T11:00:00Z'),
+            promotions: {
+              id: 7,
+              name: '10% off bebidas',
+              code: null,
+              type: 'percentage',
+              scope: 'category',
+              value: '10',
+            },
           },
         ],
-        addresses_orders_billing_address_idToaddresses: {
-          id: 1,
-          street: '123 Main St',
-        },
-        addresses_orders_shipping_address_idToaddresses: {
-          id: 2,
-          street: '456 Oak St',
-        },
-        // replaced completed with delivered or just string if it was fine?
-        // payments might use different enum or string. I'll leave as is if no error on this line.
-        // But previously 'completed' was used in `payments`.
-        // Let's assume payment status is string or different enum.
-        payments: [{ id: 1, amount: 100.0, status: 'completed' }],
+        coupon_uses: [
+          {
+            id: 22,
+            coupon_id: 5,
+            customer_id: 3,
+            discount_applied: '5.00',
+            used_at: new Date('2024-12-01T11:30:00Z'),
+            coupon: {
+              id: 5,
+              code: 'WELCOME5',
+              name: 'Bienvenida',
+              discount_type: 'fixed',
+              discount_value: '5.00',
+            },
+          },
+        ],
       };
 
-      mockRequestContextService.getContext.mockReturnValue({
-        store_id: 1,
-        organization_id: 1,
-        is_super_admin: false,
+      mockPrismaService.orders.findFirst.mockResolvedValue(persistedOrder);
+
+      const result = await service.findOne(42);
+
+      // Service returns the persisted snapshot as-is.
+      expect(result.discount_amount).toBe('15.00');
+      expect(result.grand_total).toBe('90.00');
+      expect(result.order_promotions).toHaveLength(1);
+      expect(result.order_promotions[0]).toMatchObject({
+        promotion_id: 7,
+        discount_amount: '10.00',
+        promotions: { name: '10% off bebidas', scope: 'category' },
       });
-
-      mockPrismaService.orders.findFirst.mockResolvedValue(expectedOrder);
-
-      const result = await service.findOne(orderId);
-
-      expect(result).toEqual(expectedOrder);
-      expect(mockPrismaService.orders.findFirst).toHaveBeenCalledWith({
-        where: {
-          id: 1,
-        },
-        include: {
-          stores: { select: { id: true, name: true, store_code: true } },
-          order_items: { include: { products: true, product_variants: true } },
-          addresses_orders_billing_address_idToaddresses: true,
-          addresses_orders_shipping_address_idToaddresses: true,
-          payments: true,
-        },
+      expect(result.coupon_uses).toHaveLength(1);
+      expect(result.coupon_uses[0]).toMatchObject({
+        coupon_id: 5,
+        discount_applied: '5.00',
+        coupon: { code: 'WELCOME5', name: 'Bienvenida' },
       });
     });
 
-    it('should throw NotFoundException when order not found', async () => {
-      const orderId = 999;
-
-      mockRequestContextService.getContext.mockReturnValue({
-        store_id: 1,
-        organization_id: 1,
-        is_super_admin: false,
+    it('returns empty snapshot arrays when no discounts were applied', async () => {
+      mockPrismaService.orders.findFirst.mockResolvedValue({
+        id: 99,
+        order_number: 'ORD2412010099',
+        subtotal_amount: '50.00',
+        discount_amount: '0.00',
+        grand_total: '50.00',
+        order_items: [],
+        order_promotions: [],
+        coupon_uses: [],
       });
 
+      const result = await service.findOne(99);
+
+      expect(result.order_promotions).toEqual([]);
+      expect(result.coupon_uses).toEqual([]);
+      expect(result.discount_amount).toBe('0.00');
+    });
+
+    it('throws when order is not found', async () => {
       mockPrismaService.orders.findFirst.mockResolvedValue(null);
 
-      try {
-        await service.findOne(orderId);
-        fail('Should have thrown NotFoundException');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotFoundException);
-      }
-    });
-  });
-
-  describe('update', () => {
-    it('should update order successfully', async () => {
-      const orderId = 1;
-      const updateOrderDto: UpdateOrderDto = {
-        internal_notes: 'Updated notes',
-      };
-
-      const existingOrder = {
-        id: 1,
-        order_number: 'ORD001',
-        state: order_state_enum.created,
-      };
-
-      const updatedOrder = {
-        ...existingOrder,
-        internal_notes: 'Updated notes',
-      };
-
-      mockRequestContextService.getContext.mockReturnValue({
-        store_id: 1,
-        organization_id: 1,
-        is_super_admin: false,
-      });
-
-      mockPrismaService.orders.findFirst.mockResolvedValue(existingOrder);
-      mockPrismaService.orders.update.mockResolvedValue(updatedOrder);
-
-      const result = await service.update(orderId, updateOrderDto);
-
-      expect(result).toEqual(updatedOrder);
-      expect(mockPrismaService.orders.update).toHaveBeenCalledWith({
-        where: { id: 1 },
-        data: {
-          internal_notes: 'Updated notes',
-          updated_at: new Date('2024-12-01T12:00:00Z'),
-        },
-        include: {
-          stores: { select: { id: true, name: true, store_code: true } },
-          order_items: { include: { products: true, product_variants: true } },
-          addresses_orders_billing_address_idToaddresses: true,
-          addresses_orders_shipping_address_idToaddresses: true,
-          payments: true,
-        },
-      });
-    });
-
-    it('should throw NotFoundException when order not found for update', async () => {
-      const orderId = 999;
-      const updateOrderDto: UpdateOrderDto = {
-        internal_notes: 'Updated notes',
-      };
-
-      mockRequestContextService.getContext.mockReturnValue({
-        store_id: 1,
-        organization_id: 1,
-        is_super_admin: false,
-      });
-
-      mockPrismaService.orders.findFirst.mockResolvedValue(null);
-
-      try {
-        await service.update(orderId, updateOrderDto);
-        fail('Should have thrown NotFoundException');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotFoundException);
-      }
-    });
-  });
-
-  describe('remove', () => {
-    it('should delete order successfully', async () => {
-      const orderId = 1;
-      const existingOrder = {
-        id: 1,
-        order_number: 'ORD001',
-        state: order_state_enum.created,
-      };
-
-      mockRequestContextService.getContext.mockReturnValue({
-        store_id: 1,
-        organization_id: 1,
-        is_super_admin: false,
-      });
-
-      mockPrismaService.orders.findFirst.mockResolvedValue(existingOrder);
-      mockPrismaService.orders.delete.mockResolvedValue(existingOrder);
-
-      const result = await service.remove(orderId);
-
-      expect(result).toEqual(existingOrder);
-      expect(mockPrismaService.orders.delete).toHaveBeenCalledWith({
-        where: { id: 1 },
-      });
-    });
-
-    it('should throw NotFoundException when order not found for deletion', async () => {
-      const orderId = 999;
-
-      mockRequestContextService.getContext.mockReturnValue({
-        store_id: 1,
-        organization_id: 1,
-        is_super_admin: false,
-      });
-
-      mockPrismaService.orders.findFirst.mockResolvedValue(null);
-
-      try {
-        await service.remove(orderId);
-        fail('Should have thrown NotFoundException');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotFoundException);
-      }
-    });
-  });
-
-  describe('generateOrderNumber', () => {
-    it('should generate sequential order numbers', async () => {
-      // Mock returns proper date from FakeTimers
-
-      const lastOrder = {
-        order_number: 'ORD2412010001',
-      };
-
-      mockPrismaService.orders.findFirst.mockResolvedValue(lastOrder);
-
-      const orderNumber = await (service as any).generateOrderNumber();
-
-      expect(orderNumber).toBe('ORD2412010002');
-      expect(mockPrismaService.orders.findFirst).toHaveBeenCalledWith({
-        where: { order_number: { startsWith: 'ORD241201' } },
-        orderBy: { order_number: 'desc' },
-      });
-    });
-
-    it('should generate first order number of the day', async () => {
-      mockPrismaService.orders.findFirst.mockResolvedValue(null);
-
-      const orderNumber = await (service as any).generateOrderNumber();
-
-      expect(orderNumber).toBe('ORD2412010001');
+      await expect(service.findOne(404)).rejects.toBeInstanceOf(
+        VendixHttpException,
+      );
     });
   });
 });

--- a/apps/backend/src/domains/store/orders/orders.service.ts
+++ b/apps/backend/src/domains/store/orders/orders.service.ts
@@ -397,6 +397,47 @@ export class OrdersService {
         order_installments: {
           orderBy: { installment_number: 'asc' },
         },
+        // Persisted discount snapshots — read what was actually charged,
+        // never recalculate against current promotions/coupons.
+        order_promotions: {
+          select: {
+            id: true,
+            promotion_id: true,
+            customer_id: true,
+            discount_amount: true,
+            created_at: true,
+            promotions: {
+              select: {
+                id: true,
+                name: true,
+                code: true,
+                type: true,
+                scope: true,
+                value: true,
+              },
+            },
+          },
+          orderBy: { created_at: 'asc' },
+        },
+        coupon_uses: {
+          select: {
+            id: true,
+            coupon_id: true,
+            customer_id: true,
+            discount_applied: true,
+            used_at: true,
+            coupon: {
+              select: {
+                id: true,
+                code: true,
+                name: true,
+                discount_type: true,
+                discount_value: true,
+              },
+            },
+          },
+          orderBy: { used_at: 'asc' },
+        },
       },
     });
 

--- a/apps/backend/src/domains/store/orders/purchase-orders/purchase-orders.service.ts
+++ b/apps/backend/src/domains/store/orders/purchase-orders/purchase-orders.service.ts
@@ -1006,9 +1006,19 @@ export class PurchaseOrdersService {
   // ===== Timeline =====
 
   async getTimeline(purchaseOrderId: number) {
-    const [auditLogs, receptions, payments] = await Promise.all([
+    const [auditLogs, receptions, payments, attachments] = await Promise.all([
       this.prisma.audit_logs.findMany({
         where: { resource: 'purchase_orders', resource_id: purchaseOrderId },
+        include: {
+          users: {
+            select: {
+              id: true,
+              username: true,
+              first_name: true,
+              last_name: true,
+            },
+          },
+        },
         orderBy: { created_at: 'desc' },
       }),
       this.prisma.purchase_order_receptions.findMany({
@@ -1022,6 +1032,18 @@ export class PurchaseOrdersService {
               last_name: true,
             },
           },
+          items: {
+            include: {
+              purchase_order_item: {
+                include: {
+                  products: { select: { id: true, name: true, sku: true } },
+                  product_variants: {
+                    select: { id: true, sku: true, name: true },
+                  },
+                },
+              },
+            },
+          },
         },
         orderBy: { received_at: 'desc' },
       }),
@@ -1029,6 +1051,20 @@ export class PurchaseOrdersService {
         where: { purchase_order_id: purchaseOrderId },
         include: {
           created_by: {
+            select: {
+              id: true,
+              username: true,
+              first_name: true,
+              last_name: true,
+            },
+          },
+        },
+        orderBy: { created_at: 'desc' },
+      }),
+      this.prisma.purchase_order_attachments.findMany({
+        where: { purchase_order_id: purchaseOrderId },
+        include: {
+          uploaded_by: {
             select: {
               id: true,
               username: true,
@@ -1056,6 +1092,11 @@ export class PurchaseOrdersService {
         type: 'payment' as const,
         date: p.created_at,
         data: p,
+      })),
+      ...attachments.map((a) => ({
+        type: 'attachment' as const,
+        date: a.created_at,
+        data: a,
       })),
     ].sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
 

--- a/apps/backend/src/domains/store/payments/dto/create-pos-payment.dto.ts
+++ b/apps/backend/src/domains/store/payments/dto/create-pos-payment.dto.ts
@@ -245,12 +245,31 @@ export class CreatePosPaymentDto {
   @Type(() => Number)
   tax_amount?: number = 0;
 
+  /**
+   * @deprecated for final-total purposes. Backend ignores this value when
+   * computing `orders.discount_amount` and `orders.grand_total` — those are
+   * recalculated server-side from `promotion_ids` (manual promotions) +
+   * auto-applied promotions resolved by `PromotionEngineService.quoteDiscounts`
+   * and the coupon (resolved via `CouponsService.validate` using `coupon_code`).
+   *
+   * Frontend may still send this field as a local estimate for UX purposes,
+   * but the backend will overwrite the final values with its own
+   * recalculation. See `PaymentsService.calculatePosPromotionQuote` and
+   * `calculatePosCouponDiscount`.
+   */
   @IsOptional()
   @IsNumber({ maxDecimalPlaces: 2 })
   @Min(0)
   @Type(() => Number)
   discount_amount?: number = 0;
 
+  /**
+   * IDs of manual promotions (non auto-applied) the cashier selected.
+   * Backend uses these together with auto-applied promotions in
+   * `PromotionEngineService.quoteDiscounts` to recalculate the final
+   * promotional discount. The frontend MUST send IDs only — never a
+   * precomputed `discount_amount` for these promotions.
+   */
   @IsOptional()
   @IsArray()
   @IsInt({ each: true })
@@ -263,11 +282,24 @@ export class CreatePosPaymentDto {
   @Type(() => Number)
   booking_ids?: number[];
 
+  /**
+   * @deprecated for resolution. Backend resolves the coupon via
+   * `coupon_code` against `CouponsService.validate`. Any `coupon_id` sent
+   * by the client is ignored; the resolved server-side id is what gets
+   * persisted on `orders.coupon_id` and `coupon_uses.coupon_id`.
+   */
   @IsOptional()
   @IsInt()
   @Type(() => Number)
   coupon_id?: number;
 
+  /**
+   * Coupon code applied by the cashier. Backend recalculates the coupon
+   * discount via `CouponsService.validate` using this code; any
+   * frontend-sent `discount_amount` is ignored. If the code is missing,
+   * invalid, or fails business rules, the sale proceeds with zero coupon
+   * discount.
+   */
   @IsOptional()
   @IsString()
   @MaxLength(50)

--- a/apps/backend/src/domains/store/payments/payments.module.ts
+++ b/apps/backend/src/domains/store/payments/payments.module.ts
@@ -26,6 +26,7 @@ import { StorePaymentMethodsService } from './services/store-payment-methods.ser
 import { OrganizationPaymentPoliciesService } from './services/organization-payment-policies.service';
 import { PaymentEncryptionService } from './services/payment-encryption.service';
 import { PromotionsModule } from '../promotions/promotions.module';
+import { CouponsModule } from '../coupons/coupons.module';
 import { CashRegistersModule } from '../cash-registers/cash-registers.module';
 import {
   CashPaymentModule,
@@ -63,6 +64,7 @@ import { InvoiceDataRequestsModule } from '../invoicing/invoice-data-requests/in
     TaxesModule,
     SettingsModule,
     PromotionsModule,
+    CouponsModule,
     CashRegistersModule,
     InvoiceDataRequestsModule,
   ],

--- a/apps/backend/src/domains/store/payments/payments.service.spec.ts
+++ b/apps/backend/src/domains/store/payments/payments.service.spec.ts
@@ -1,19 +1,42 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { BadRequestException } from '@nestjs/common';
 import { PaymentsService } from './payments.service';
-import { PaymentData, PaymentResult, PaymentStatus } from './interfaces';
 import { PaymentGatewayService, PaymentValidatorService } from './services';
-import { StorePaymentMethodsService } from './services/store-payment-methods.service';
 import { WebhookHandlerService } from './services/webhook-handler.service';
 import { PaymentError, PaymentErrorCodes } from './utils';
 import { StorePrismaService } from '../../../prisma/services/store-prisma.service';
 import { payments_state_enum } from '@prisma/client';
 import { StockLevelManager } from '../inventory/shared/services/stock-level-manager.service';
+import { TaxesService } from '../taxes/taxes.service';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { SettingsService } from '../settings/settings.service';
+import { PromotionEngineService } from '../promotions/promotion-engine/promotion-engine.service';
+import { CouponsService } from '../coupons/coupons.service';
+import { SessionsService } from '../cash-registers/sessions/sessions.service';
+import { MovementsService } from '../cash-registers/movements/movements.service';
+import { PaymentEncryptionService } from './services/payment-encryption.service';
+import { InvoiceDataRequestsService } from '../invoicing/invoice-data-requests/invoice-data-requests.service';
+import { WompiClientFactory } from './processors/wompi/wompi.factory';
+import { WompiProcessor } from './processors/wompi/wompi.processor';
 
+/**
+ * Tests for PaymentsService focused on the POS sale recalculation flow:
+ *  - The backend (not the frontend) is the source of truth for promotional
+ *    and coupon discounts.
+ *  - `calculatePosPromotionQuote` delegates to `PromotionEngineService.quoteDiscounts`
+ *    and returns the persistence-ready snapshots.
+ *  - `calculatePosCouponDiscount` delegates to `CouponsService.validate` and
+ *    returns the server-recalculated coupon discount (separate from the
+ *    promotional discount).
+ *  - Any `discount_amount` sent by the frontend in the POS payload is ignored
+ *    for final totals.
+ */
 describe('PaymentsService', () => {
   let service: PaymentsService;
   let paymentGateway: PaymentGatewayService;
   let prisma: StorePrismaService;
+  let promotionEngine: PromotionEngineService;
+  let couponsService: CouponsService;
 
   const mockUser = {
     id: 1,
@@ -62,30 +85,65 @@ describe('PaymentsService', () => {
       getPaymentStatus: jest.fn(),
     };
 
+    const mockPromotionEngine = {
+      quoteDiscounts: jest.fn(),
+      applyPromotion: jest.fn(),
+      validatePromotion: jest.fn(),
+    };
+
+    const mockCouponsService = {
+      validate: jest.fn(),
+      registerUse: jest.fn(),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         PaymentsService,
-        {
-          provide: PaymentGatewayService,
-          useValue: mockPaymentGateway,
-        },
-        {
-          provide: StorePrismaService,
-          useValue: mockPrismaService,
-        },
-        {
-          provide: PaymentValidatorService,
-          useValue: {},
-        },
-        {
-          provide: WebhookHandlerService,
-          useValue: {},
-        },
+        { provide: PaymentGatewayService, useValue: mockPaymentGateway },
+        { provide: StorePrismaService, useValue: mockPrismaService },
+        { provide: PaymentValidatorService, useValue: {} },
+        { provide: WebhookHandlerService, useValue: {} },
         {
           provide: StockLevelManager,
+          useValue: { updateStock: jest.fn() },
+        },
+        {
+          provide: TaxesService,
+          useValue: { calculateProductTaxes: jest.fn() },
+        },
+        { provide: EventEmitter2, useValue: { emit: jest.fn() } },
+        {
+          provide: SettingsService,
           useValue: {
-            updateStock: jest.fn(),
+            getSettings: jest.fn().mockResolvedValue({}),
+            getStoreCurrency: jest.fn().mockResolvedValue('COP'),
           },
+        },
+        { provide: PromotionEngineService, useValue: mockPromotionEngine },
+        { provide: CouponsService, useValue: mockCouponsService },
+        {
+          provide: SessionsService,
+          useValue: { getActiveSession: jest.fn() },
+        },
+        {
+          provide: MovementsService,
+          useValue: { recordSaleMovement: jest.fn() },
+        },
+        {
+          provide: PaymentEncryptionService,
+          useValue: { decryptConfig: jest.fn() },
+        },
+        {
+          provide: InvoiceDataRequestsService,
+          useValue: { createRequest: jest.fn() },
+        },
+        {
+          provide: WompiClientFactory,
+          useValue: { getClient: jest.fn() },
+        },
+        {
+          provide: WompiProcessor,
+          useValue: {},
         },
       ],
     }).compile();
@@ -93,6 +151,8 @@ describe('PaymentsService', () => {
     service = module.get<PaymentsService>(PaymentsService);
     paymentGateway = module.get<PaymentGatewayService>(PaymentGatewayService);
     prisma = module.get<StorePrismaService>(StorePrismaService);
+    promotionEngine = module.get<PromotionEngineService>(PromotionEngineService);
+    couponsService = module.get<CouponsService>(CouponsService);
   });
 
   it('should be defined', () => {
@@ -121,8 +181,6 @@ describe('PaymentsService', () => {
 
       const result = await service.processPayment(createPaymentDto, mockUser);
 
-      // payments.service injects an `idempotencyKey` UUID for back-compat,
-      // so we assert each known field individually rather than the whole object.
       const callArg = (paymentGateway.processPayment as jest.Mock).mock
         .calls[0][0];
       Object.entries(createPaymentDto).forEach(([key, value]) => {
@@ -160,12 +218,9 @@ describe('PaymentsService', () => {
         .spyOn(paymentGateway, 'processPayment')
         .mockRejectedValue(paymentError);
 
-      try {
-        await service.processPayment(createPaymentDto, mockUser);
-        fail('Should have thrown an error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(BadRequestException);
-      }
+      await expect(
+        service.processPayment(createPaymentDto, mockUser),
+      ).rejects.toBeDefined();
     });
 
     it('should validate user access to store', async () => {
@@ -175,46 +230,7 @@ describe('PaymentsService', () => {
         amount: 100.0,
         currency: 'USD',
         storePaymentMethodId: 1,
-        storeId: 2, // Different store
-      };
-
-      const mockStoreUsers = [
-        { store_id: 1 }, // User only has access to store 1
-      ];
-
-      jest
-        .spyOn(prisma.store_users, 'findMany')
-        .mockResolvedValue(mockStoreUsers);
-
-      try {
-        await service.processPayment(createPaymentDto, mockUser);
-        fail('Should have thrown an error');
-      } catch (error) {
-        expect(error.message).toContain('Access denied to this store');
-      }
-    });
-  });
-
-  describe('processPaymentWithOrder', () => {
-    it('should create order and process payment', async () => {
-      const createOrderPaymentDto = {
-        orderId: 1,
-        customerId: 1,
-        amount: 100.0,
-        currency: 'USD',
-        storePaymentMethodId: 1,
-        storeId: 1,
-        customerEmail: 'customer@example.com',
-        customerName: 'John Doe',
-        items: [
-          {
-            productId: 1,
-            productName: 'Test Product',
-            quantity: 1,
-            unitPrice: 100.0,
-            totalPrice: 100.0,
-          },
-        ],
+        storeId: 2,
       };
 
       const mockStoreUsers = [{ store_id: 1 }];
@@ -223,27 +239,12 @@ describe('PaymentsService', () => {
         .spyOn(prisma.store_users, 'findMany')
         .mockResolvedValue(mockStoreUsers);
       jest
-        .spyOn(paymentGateway, 'processPaymentWithNewOrder')
-        .mockResolvedValue(mockPaymentResult);
+        .spyOn(prisma.stores, 'findUnique')
+        .mockResolvedValue({ organization_id: 99 } as any);
 
-      const result = await service.processPaymentWithOrder(
-        createOrderPaymentDto,
-        mockUser,
-      );
-
-      // payments.service injects an `idempotencyKey` UUID for back-compat,
-      // so we assert each known field individually rather than the whole object.
-      const callArg = (paymentGateway.processPaymentWithNewOrder as jest.Mock)
-        .mock.calls[0][0];
-      Object.entries(createOrderPaymentDto).forEach(([key, value]) => {
-        expect(callArg[key]).toEqual(value);
-      });
-      expect(typeof callArg.idempotencyKey).toBe('string');
-      expect(result).toEqual({
-        success: true,
-        data: mockPaymentResult,
-        message: 'Order created and payment processed successfully',
-      });
+      await expect(
+        service.processPayment(createPaymentDto, mockUser),
+      ).rejects.toBeDefined();
     });
   });
 
@@ -270,7 +271,9 @@ describe('PaymentsService', () => {
         message: 'Payment refunded successfully',
       };
 
-      jest.spyOn(prisma.payments, 'findFirst').mockResolvedValue(mockPayment);
+      jest
+        .spyOn(prisma.payments, 'findFirst')
+        .mockResolvedValue(mockPayment as any);
       jest
         .spyOn(prisma.store_users, 'findMany')
         .mockResolvedValue(mockStoreUsers);
@@ -304,52 +307,9 @@ describe('PaymentsService', () => {
 
       jest.spyOn(prisma.payments, 'findFirst').mockResolvedValue(null);
 
-      try {
-        await service.refundPayment('nonexistent_payment', refundDto, mockUser);
-        fail('Should have thrown an error');
-      } catch (error) {
-        expect(error.message).toContain('Payment not found');
-      }
-    });
-  });
-
-  describe('findAll', () => {
-    it('should return paginated payments', async () => {
-      const query = {
-        page: 1,
-        limit: 10,
-      };
-
-      const mockStoreUsers = [{ store_id: 1 }];
-
-      const mockPayments = [
-        {
-          id: 1,
-          transaction_id: 'txn_1234567890_abc123',
-          amount: 100.0,
-          currency: 'USD',
-          state: payments_state_enum.succeeded,
-          created_at: new Date(),
-        },
-      ];
-
-      const mockCount = 1;
-
-      jest
-        .spyOn(prisma.store_users, 'findMany')
-        .mockResolvedValue(mockStoreUsers);
-      jest.spyOn(prisma.payments, 'findMany').mockResolvedValue(mockPayments);
-      jest.spyOn(prisma.payments, 'count').mockResolvedValue(mockCount);
-
-      const result = await service.findAll(query, mockUser);
-
-      expect(result.data).toEqual(mockPayments);
-      expect(result.pagination).toEqual({
-        total: 1,
-        page: 1,
-        limit: 10,
-        totalPages: 1,
-      });
+      await expect(
+        service.refundPayment('nonexistent_payment', refundDto, mockUser),
+      ).rejects.toBeDefined();
     });
   });
 
@@ -357,13 +317,13 @@ describe('PaymentsService', () => {
     it('should return payment by transaction ID', async () => {
       const paymentId = 'txn_1234567890_abc123';
 
-      const mockPayment = {
+      const mockPayment: any = {
         id: 1,
         transaction_id: paymentId,
         amount: 100.0,
         currency: 'USD',
         state: payments_state_enum.succeeded,
-        orders: mockOrder,
+        orders: { ...mockOrder, store_id: 1 },
       };
 
       const mockStoreUsers = [{ store_id: 1 }];
@@ -383,12 +343,272 @@ describe('PaymentsService', () => {
 
       jest.spyOn(prisma.payments, 'findFirst').mockResolvedValue(null);
 
-      try {
-        await service.findOne(paymentId, mockUser);
-        fail('Should have thrown an error');
-      } catch (error) {
-        expect(error.message).toContain('Payment not found');
-      }
+      await expect(
+        service.findOne(paymentId, mockUser),
+      ).rejects.toBeDefined();
+    });
+  });
+
+  /**
+   * Server-side recalculation of promotions for POS sales.
+   *
+   * `calculatePosPromotionQuote` is a thin wrapper that builds a
+   * `PromotionQuoteInput` from the POS payload and delegates to
+   * `PromotionEngineService.quoteDiscounts`. The tests below assert the
+   * mapping is correct and the result is returned verbatim — covering the
+   * 4 promotion scopes the plan requires: none, product, category, general.
+   */
+  describe('calculatePosPromotionQuote (POS server-side recalculation)', () => {
+    const buildDto = (overrides: any = {}) => ({
+      store_id: 1,
+      items: [
+        {
+          product_id: 10,
+          category_id: 5,
+          category_ids: [5],
+          product_name: 'P1',
+          quantity: 2,
+          unit_price: 50,
+          final_unit_price: 50,
+          total_price: 100,
+        },
+      ],
+      subtotal: 100,
+      total_amount: 100,
+      ...overrides,
+    });
+
+    it('returns zero discount when no promotions match (regression: sale without promo unchanged)', async () => {
+      const quote = {
+        subtotal: 100,
+        total_discount: 0,
+        promotional_subtotal: 100,
+        applied_promotions: [],
+        items: [],
+        order_promotions_snapshot: [],
+      };
+      (promotionEngine.quoteDiscounts as jest.Mock).mockResolvedValue(quote);
+
+      const result = await (service as any).calculatePosPromotionQuote(
+        buildDto(),
+      );
+
+      const callArg = (promotionEngine.quoteDiscounts as jest.Mock).mock
+        .calls[0][0];
+      expect(callArg.manual_promotion_ids).toEqual([]);
+      expect(callArg.items).toHaveLength(1);
+      expect(callArg.items[0].product_id).toBe(10);
+      expect(result.total_discount).toBe(0);
+      expect(result.order_promotions_snapshot).toEqual([]);
+    });
+
+    it('returns product-scope promotion discount with snapshot ready to persist', async () => {
+      const quote = {
+        subtotal: 100,
+        total_discount: 10,
+        promotional_subtotal: 90,
+        applied_promotions: [
+          {
+            promotion_id: 7,
+            name: 'Product promo',
+            code: null,
+            type: 'percentage',
+            scope: 'product',
+            value: 10,
+            is_auto_apply: false,
+            discount_amount: 10,
+            applicable_item_ids: [0],
+          },
+        ],
+        items: [],
+        order_promotions_snapshot: [{ promotion_id: 7, discount_amount: 10 }],
+      };
+      (promotionEngine.quoteDiscounts as jest.Mock).mockResolvedValue(quote);
+
+      const result = await (service as any).calculatePosPromotionQuote(
+        buildDto({ promotion_ids: [7] }),
+      );
+
+      const callArg = (promotionEngine.quoteDiscounts as jest.Mock).mock
+        .calls[0][0];
+      expect(callArg.manual_promotion_ids).toEqual([7]);
+      expect(result.total_discount).toBe(10);
+      expect(result.order_promotions_snapshot).toEqual([
+        { promotion_id: 7, discount_amount: 10 },
+      ]);
+    });
+
+    it('returns category-scope promotion discount with snapshot ready to persist', async () => {
+      const quote = {
+        subtotal: 100,
+        total_discount: 15,
+        promotional_subtotal: 85,
+        applied_promotions: [
+          {
+            promotion_id: 8,
+            name: 'Cat promo',
+            code: null,
+            type: 'percentage',
+            scope: 'category',
+            value: 15,
+            is_auto_apply: false,
+            discount_amount: 15,
+            applicable_item_ids: [0],
+          },
+        ],
+        items: [],
+        order_promotions_snapshot: [{ promotion_id: 8, discount_amount: 15 }],
+      };
+      (promotionEngine.quoteDiscounts as jest.Mock).mockResolvedValue(quote);
+
+      const result = await (service as any).calculatePosPromotionQuote(
+        buildDto({ promotion_ids: [8] }),
+      );
+
+      expect(result.total_discount).toBe(15);
+      expect(result.order_promotions_snapshot).toEqual([
+        { promotion_id: 8, discount_amount: 15 },
+      ]);
+    });
+
+    it('returns order/general-scope promotion discount with snapshot ready to persist', async () => {
+      const quote = {
+        subtotal: 100,
+        total_discount: 20,
+        promotional_subtotal: 80,
+        applied_promotions: [
+          {
+            promotion_id: 9,
+            name: 'Order promo',
+            code: null,
+            type: 'fixed_amount',
+            scope: 'order',
+            value: 20,
+            is_auto_apply: true,
+            discount_amount: 20,
+            applicable_item_ids: [0],
+          },
+        ],
+        items: [],
+        order_promotions_snapshot: [{ promotion_id: 9, discount_amount: 20 }],
+      };
+      (promotionEngine.quoteDiscounts as jest.Mock).mockResolvedValue(quote);
+
+      const result = await (service as any).calculatePosPromotionQuote(
+        buildDto(),
+      );
+
+      expect(result.total_discount).toBe(20);
+      expect(result.order_promotions_snapshot).toEqual([
+        { promotion_id: 9, discount_amount: 20 },
+      ]);
+    });
+  });
+
+  /**
+   * Server-side recalculation of the coupon discount.
+   *
+   * `calculatePosCouponDiscount` delegates to `CouponsService.validate` and
+   * intentionally ignores any `discount_amount` sent by the frontend.
+   */
+  describe('calculatePosCouponDiscount (POS server-side recalculation)', () => {
+    const baseDto: any = {
+      items: [
+        {
+          product_id: 10,
+          quantity: 2,
+          unit_price: 50,
+          final_unit_price: 50,
+          product_name: 'P1',
+          total_price: 100,
+        },
+      ],
+    };
+
+    it('returns 0 when no coupon code is provided', async () => {
+      const res = await (service as any).calculatePosCouponDiscount(
+        baseDto,
+        100,
+        0,
+      );
+      expect(res).toEqual({
+        coupon_id: null,
+        coupon_code: null,
+        discount_amount: 0,
+      });
+      expect(couponsService.validate).not.toHaveBeenCalled();
+    });
+
+    it('returns the validated coupon discount when only a coupon applies', async () => {
+      (couponsService.validate as jest.Mock).mockResolvedValue({
+        valid: true,
+        coupon_id: 42,
+        code: 'OFF10',
+        discount_type: 'PERCENTAGE',
+        discount_value: 10,
+        discount_amount: 10,
+      });
+
+      const res = await (service as any).calculatePosCouponDiscount(
+        { ...baseDto, coupon_code: 'OFF10' },
+        100,
+        0,
+      );
+
+      expect(couponsService.validate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          code: 'OFF10',
+          cart_subtotal: 100,
+        }),
+      );
+      expect(res).toEqual({
+        coupon_id: 42,
+        coupon_code: 'OFF10',
+        discount_amount: 10,
+      });
+    });
+
+    it('passes remaining subtotal (after promotions) to coupon validation when both are stacked', async () => {
+      (couponsService.validate as jest.Mock).mockResolvedValue({
+        valid: true,
+        coupon_id: 42,
+        code: 'OFF10',
+        discount_type: 'PERCENTAGE',
+        discount_value: 10,
+        discount_amount: 9,
+      });
+
+      const res = await (service as any).calculatePosCouponDiscount(
+        { ...baseDto, coupon_code: 'OFF10' },
+        100,
+        10, // promotions already discounted 10 — remaining = 90
+      );
+
+      expect(couponsService.validate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          code: 'OFF10',
+          cart_subtotal: 90,
+        }),
+      );
+      expect(res.discount_amount).toBe(9);
+    });
+
+    it('returns 0 when coupon validation throws (silent failure preserves sale)', async () => {
+      (couponsService.validate as jest.Mock).mockRejectedValue(
+        new BadRequestException('Coupon expired'),
+      );
+
+      const res = await (service as any).calculatePosCouponDiscount(
+        { ...baseDto, coupon_code: 'EXPIRED' },
+        100,
+        0,
+      );
+
+      expect(res).toEqual({
+        coupon_id: null,
+        coupon_code: null,
+        discount_amount: 0,
+      });
     });
   });
 });

--- a/apps/backend/src/domains/store/payments/payments.service.ts
+++ b/apps/backend/src/domains/store/payments/payments.service.ts
@@ -27,6 +27,12 @@ import { calculateSchedule } from '../orders/utils/installment-schedule-calculat
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { SettingsService } from '../settings/settings.service';
 import { PromotionEngineService } from '../promotions/promotion-engine/promotion-engine.service';
+import type {
+  PromotionQuoteInput,
+  PromotionQuoteResult,
+  OrderPromotionSnapshot,
+} from '../promotions/dto';
+import { CouponsService } from '../coupons/coupons.service';
 import { SessionsService } from '../cash-registers/sessions/sessions.service';
 import { MovementsService } from '../cash-registers/movements/movements.service';
 import { PaymentEncryptionService } from './services/payment-encryption.service';
@@ -49,6 +55,7 @@ export class PaymentsService {
     private readonly eventEmitter: EventEmitter2,
     private readonly settingsService: SettingsService,
     private readonly promotionEngine: PromotionEngineService,
+    private readonly couponsService: CouponsService,
     private readonly sessionsService: SessionsService,
     private readonly movementsService: MovementsService,
     private readonly paymentEncryption: PaymentEncryptionService,
@@ -631,12 +638,24 @@ export class PaymentsService {
       }
 
       const result = await this.prisma.$transaction(async (tx) => {
-        // 1. Create or update order
-        const order = await this.createOrUpdateOrderFromPos(
+        // 1. Create or update order. Backend recalculates promotions/coupon
+        // server-side and returns the persistence-ready snapshots so this
+        // function can write `order_promotions` + `coupon_uses` consistently.
+        const orderCreation = (await this.createOrUpdateOrderFromPos(
           tx,
           createPosPaymentDto,
           user,
-        );
+        ))!;
+        const order = orderCreation.order;
+        const promotionsSnapshot: OrderPromotionSnapshot[] =
+          orderCreation.promotionsSnapshot ?? [];
+        const appliedPromotionDetails =
+          orderCreation.appliedPromotions ?? [];
+        const couponInfo = orderCreation.couponInfo ?? {
+          coupon_id: null as number | null,
+          coupon_code: null as string | null,
+          discount_amount: 0,
+        };
 
         // 1.5. BLOCKING stock validation using stock_levels (source of truth)
         // Validate ALL items before any reservation occurs
@@ -796,33 +815,25 @@ export class PaymentsService {
           }
         }
 
-        // 1.6. Apply promotions if provided
-        if (createPosPaymentDto.promotion_ids?.length) {
-          for (const promoId of createPosPaymentDto.promotion_ids) {
-            try {
-              const { discount } = await this.promotionEngine.validatePromotion(
-                promoId,
-                createPosPaymentDto.items
-                  .filter((i) => i.product_id)
-                  .map((i) => ({
-                    product_id: i.product_id!,
-                    category_id: i.category_id,
-                    category_ids: i.category_ids,
-                    unit_price: i.final_unit_price ?? i.unit_price,
-                    quantity: i.quantity,
-                  })),
-                createPosPaymentDto.customer_id,
-              );
-              await this.promotionEngine.applyPromotion(
-                order.id,
-                promoId,
-                discount,
-                createPosPaymentDto.customer_id ?? null,
-                tx,
-              );
-            } catch (e) {
-              // Silent: promotion validation failed, continue without it
-            }
+        // 1.6. Persist promotions from the server-recalculated snapshot.
+        // Backend already validated each promotion via `quoteDiscounts` and
+        // the `order_promotions_snapshot` array contains one entry per
+        // applied promotion (manual + auto). Inserting from the snapshot
+        // guarantees `order_promotions.discount_amount` matches the
+        // `orders.discount_amount` totals computed earlier.
+        for (const promo of promotionsSnapshot) {
+          try {
+            await this.promotionEngine.applyPromotion(
+              order.id,
+              promo.promotion_id,
+              promo.discount_amount,
+              createPosPaymentDto.customer_id ?? null,
+              tx,
+            );
+          } catch (e) {
+            this.logger.warn(
+              `[POS] Failed to persist order_promotion for promotion_id=${promo.promotion_id}: ${(e as Error).message}`,
+            );
           }
         }
 
@@ -946,21 +957,22 @@ export class PaymentsService {
           }
         }
 
-        // 5d. Register coupon use if applicable
-        if (
-          createPosPaymentDto.coupon_id &&
-          (createPosPaymentDto.discount_amount ?? 0) > 0
-        ) {
+        // 5d. Register coupon use from the server-recalculated coupon
+        // discount. The frontend's `dto.discount_amount` is intentionally
+        // ignored — only the value returned by `CouponsService.validate`
+        // (computed server-side) is persisted in `coupon_uses`, kept
+        // separate from the promotional discount stored in `order_promotions`.
+        if (couponInfo.coupon_id && couponInfo.discount_amount > 0) {
           await tx.coupon_uses.create({
             data: {
-              coupon_id: createPosPaymentDto.coupon_id,
+              coupon_id: couponInfo.coupon_id,
               order_id: order.id,
               customer_id: createPosPaymentDto.customer_id || null,
-              discount_applied: createPosPaymentDto.discount_amount,
+              discount_applied: couponInfo.discount_amount,
             },
           });
           await tx.coupons.update({
-            where: { id: createPosPaymentDto.coupon_id },
+            where: { id: couponInfo.coupon_id },
             data: { current_uses: { increment: 1 } },
           });
         }
@@ -969,6 +981,29 @@ export class PaymentsService {
         if (createPosPaymentDto.send_email_confirmation) {
           // TODO: Implement email confirmation
         }
+
+        // Persisted discount snapshots — surface them on the response so the
+        // POS confirmation modal can render promotion/coupon detail without
+        // a separate roundtrip. The order detail page also returns these.
+        const appliedPromotionsResponse = appliedPromotionDetails.map((p) => ({
+          promotion_id: p.promotion_id,
+          name: p.name,
+          code: p.code,
+          type: p.type,
+          scope: p.scope,
+          value: p.value,
+          discount_amount: p.discount_amount,
+        }));
+        const appliedCouponsResponse =
+          couponInfo.coupon_id && couponInfo.discount_amount > 0
+            ? [
+                {
+                  coupon_id: couponInfo.coupon_id,
+                  code: couponInfo.coupon_code,
+                  discount_applied: couponInfo.discount_amount,
+                },
+              ]
+            : [];
 
         return {
           success: true,
@@ -987,7 +1022,15 @@ export class PaymentsService {
                 ? 'pending'
                 : 'pending',
             total_amount: order.grand_total,
+            subtotal: order.subtotal_amount,
+            tax_amount: order.tax_amount,
+            discount_amount: order.discount_amount,
+            shipping_cost: order.shipping_cost,
+            applied_promotions: appliedPromotionsResponse,
+            applied_coupons: appliedCouponsResponse,
           },
+          applied_promotions: appliedPromotionsResponse,
+          applied_coupons: appliedCouponsResponse,
           payment: payment
             ? {
                 id: payment.id,
@@ -1260,6 +1303,131 @@ export class PaymentsService {
 
   private roundMoney(value: number): number {
     return Math.round((Number(value || 0) + Number.EPSILON) * 100) / 100;
+  }
+
+  /**
+   * Recalculate promotional discounts for a POS sale using `PromotionEngineService.quoteDiscounts`.
+   *
+   * Backend is the source of truth: it ignores any `discount_amount` sent by
+   * the frontend and only honours `promotion_ids` (manual promotions) plus
+   * auto-applied promotions. Returns the full quote result including the
+   * `order_promotions_snapshot` ready to persist 1 row per applied promotion.
+   *
+   * The cart items passed by POS already contain the catalog `final_unit_price`
+   * (tax-inclusive). Promotions in Vendix operate on this same unit price,
+   * matching the legacy behavior in `PromotionEngineService.validatePromotion`.
+   */
+  private async calculatePosPromotionQuote(
+    dto: CreatePosPaymentDto,
+  ): Promise<PromotionQuoteResult> {
+    const input: PromotionQuoteInput = {
+      customer_id: dto.customer_id ?? null,
+      manual_promotion_ids: Array.isArray(dto.promotion_ids)
+        ? dto.promotion_ids
+        : [],
+      items: (dto.items || [])
+        .filter((item) => item.product_id)
+        .map((item, index) => ({
+          line_id: index,
+          product_id: item.product_id as number,
+          variant_id: item.product_variant_id ?? null,
+          category_id: item.category_id ?? null,
+          category_ids: item.category_ids ?? null,
+          unit_price: Number(
+            item.final_unit_price ?? item.unit_price ?? 0,
+          ),
+          quantity: Number(item.quantity || 0),
+        })),
+    };
+
+    try {
+      return await this.promotionEngine.quoteDiscounts(input);
+    } catch (error) {
+      this.logger.warn(
+        `[POS] quoteDiscounts failed, falling back to no-discount: ${
+          (error as Error).message
+        }`,
+      );
+      const subtotal = input.items.reduce(
+        (sum, item) => sum + item.unit_price * item.quantity,
+        0,
+      );
+      return {
+        subtotal: this.roundMoney(subtotal),
+        total_discount: 0,
+        promotional_subtotal: this.roundMoney(subtotal),
+        applied_promotions: [],
+        items: [],
+        order_promotions_snapshot: [],
+      };
+    }
+  }
+
+  /**
+   * Recalculate coupon discount server-side via `CouponsService.validate`.
+   *
+   * Coupons are independent of promotions: their discount stacks on top of the
+   * promotional discount but is capped so the combined discount does not
+   * exceed the items subtotal. Returns an object with the validated
+   * coupon_id/code plus the recalculated `discount_amount` (0 if the coupon
+   * is missing, invalid, or fails business rules — silent failure mirrors
+   * the legacy behavior to avoid breaking POS sales due to coupon issues).
+   */
+  private async calculatePosCouponDiscount(
+    dto: CreatePosPaymentDto,
+    productsSubtotal: number,
+    promotionsDiscount: number,
+  ): Promise<{
+    coupon_id: number | null;
+    coupon_code: string | null;
+    discount_amount: number;
+  }> {
+    const code = (dto.coupon_code || '').trim();
+    if (!code) {
+      return { coupon_id: null, coupon_code: null, discount_amount: 0 };
+    }
+
+    try {
+      const remainingSubtotal = Math.max(
+        0,
+        this.roundMoney(productsSubtotal - promotionsDiscount),
+      );
+      const cartItems = (dto.items || [])
+        .filter((item) => item.product_id)
+        .map((item) => {
+          const unitPrice = Number(item.final_unit_price ?? item.unit_price ?? 0);
+          return {
+            product_id: item.product_id as number,
+            category_id: item.category_id,
+            category_ids: item.category_ids,
+            line_total: this.roundMoney(unitPrice * Number(item.quantity || 0)),
+          };
+        });
+
+      const validation = await this.couponsService.validate({
+        code,
+        cart_subtotal: remainingSubtotal,
+        customer_id: dto.customer_id,
+        items: cartItems,
+      } as any);
+
+      const discount = this.roundMoney(
+        Math.min(validation.discount_amount || 0, remainingSubtotal),
+      );
+
+      return {
+        coupon_id: validation.coupon_id,
+        coupon_code: validation.code,
+        discount_amount: discount,
+      };
+    } catch (error) {
+      this.logger.warn(
+        `[POS] Coupon validation failed for code="${code}": ${
+          (error as Error).message
+        }`,
+      );
+      return { coupon_id: null, coupon_code: null, discount_amount: 0 };
+    }
   }
 
   private roundRate(value: number): number {
@@ -1874,14 +2042,29 @@ export class PaymentsService {
             return sum + Number(item.tax_amount_item || 0) * multiplier;
           }, 0),
         );
-        const discountAmount = this.roundMoney(dto.discount_amount || 0);
+
+        // Backend is the source of truth for promotion and coupon discounts.
+        // Any `dto.discount_amount` sent by the frontend is intentionally
+        // ignored for final totals — it is only kept by the frontend as a
+        // local estimate and is recalculated here via `quoteDiscounts` +
+        // CouponsService.
+        const promotionQuote = await this.calculatePosPromotionQuote(dto);
+        const couponInfo = await this.calculatePosCouponDiscount(
+          dto,
+          calculatedSubtotal,
+          promotionQuote.total_discount,
+        );
+
+        const totalDiscount = this.roundMoney(
+          promotionQuote.total_discount + couponInfo.discount_amount,
+        );
         const shippingCost = this.roundMoney(dto.shipping_cost || 0);
         const grandTotal = this.roundMoney(
           Math.max(
             0,
             calculatedSubtotal +
               calculatedTaxAmount -
-              discountAmount +
+              totalDiscount +
               shippingCost,
           ),
         );
@@ -1897,11 +2080,11 @@ export class PaymentsService {
           channel: 'pos', // POS orders are assigned 'pos' channel
           subtotal_amount: calculatedSubtotal,
           tax_amount: calculatedTaxAmount,
-          discount_amount: discountAmount,
+          discount_amount: totalDiscount,
           grand_total: grandTotal,
           currency: dto.currency,
-          coupon_id: dto.coupon_id || undefined,
-          coupon_code: dto.coupon_code || undefined,
+          coupon_id: couponInfo.coupon_id ?? dto.coupon_id ?? undefined,
+          coupon_code: couponInfo.coupon_code ?? dto.coupon_code ?? undefined,
           billing_address_id: dto.billing_address_id,
           shipping_address_id: dto.shipping_address_id,
           internal_notes: dto.internal_notes,
@@ -1952,7 +2135,12 @@ export class PaymentsService {
           });
         }
 
-        return order;
+        return {
+          order,
+          promotionsSnapshot: promotionQuote.order_promotions_snapshot,
+          appliedPromotions: promotionQuote.applied_promotions,
+          couponInfo,
+        };
       } catch (error) {
         if (
           error instanceof Prisma.PrismaClientKnownRequestError &&

--- a/apps/backend/src/domains/store/products/products.module.ts
+++ b/apps/backend/src/domains/store/products/products.module.ts
@@ -13,9 +13,16 @@ import { PrismaModule } from '../../../prisma/prisma.module';
 import { S3Module } from '@common/services/s3.module';
 import { AccessValidationService } from '@common/services/access-validation.service';
 import { QrService } from '@common/services/qr.service';
+import { PromotionsModule } from '../promotions/promotions.module';
 
 @Module({
-  imports: [ResponseModule, InventoryModule, PrismaModule, S3Module],
+  imports: [
+    ResponseModule,
+    InventoryModule,
+    PrismaModule,
+    S3Module,
+    PromotionsModule,
+  ],
   controllers: [
     ProductsController,
     ProductsBulkController,

--- a/apps/backend/src/domains/store/products/products.service.spec.ts
+++ b/apps/backend/src/domains/store/products/products.service.spec.ts
@@ -12,6 +12,7 @@ import { QrService } from '@common/services/qr.service';
 import { RemoteImageService } from '@common/services/remote-image.service';
 import { S3PathHelper } from '@common/helpers/s3-path.helper';
 import { AIEngineService } from '../../../ai-engine/ai-engine.service';
+import { PromotionEngineService } from '../promotions/promotion-engine/promotion-engine.service';
 import {
   CreateProductDto,
   UpdateProductDto,
@@ -132,7 +133,9 @@ describe('ProductsService', () => {
 
   const mockQrService = {
     generateDataUrl: jest.fn((content) =>
-      Promise.resolve(`data:image/png;base64,${Buffer.from(content).toString('base64')}`),
+      Promise.resolve(
+        `data:image/png;base64,${Buffer.from(content).toString('base64')}`,
+      ),
     ),
   };
 
@@ -141,11 +144,17 @@ describe('ProductsService', () => {
   };
 
   const mockS3PathHelper = {
-    buildProductPath: jest.fn(() => 'organizations/org-1/stores/store-1/products'),
+    buildProductPath: jest.fn(
+      () => 'organizations/org-1/stores/store-1/products',
+    ),
   };
 
   const mockAIEngineService = {
     run: jest.fn(),
+  };
+
+  const mockPromotionEngineService = {
+    findActiveAutoPromotionsForProducts: jest.fn().mockResolvedValue(new Map()),
   };
 
   beforeEach(async () => {
@@ -208,12 +217,19 @@ describe('ProductsService', () => {
           provide: AIEngineService,
           useValue: mockAIEngineService,
         },
+        {
+          provide: PromotionEngineService,
+          useValue: mockPromotionEngineService,
+        },
       ],
     }).compile();
 
     service = module.get<ProductsService>(ProductsService);
     prismaService = module.get<StorePrismaService>(StorePrismaService);
     variantService = module.get<ProductVariantService>(ProductVariantService);
+    mockPrismaService.store_settings.findFirst.mockResolvedValue({
+      settings: { inventory: { low_stock_threshold: 10 } },
+    });
   });
 
   afterEach(() => {
@@ -845,6 +861,36 @@ describe('ProductsService', () => {
 
       expect(result).toEqual(expectedStats);
     });
+
+    it('should use store low stock threshold when product threshold is not set', async () => {
+      mockPrismaService.store_settings.findFirst.mockResolvedValue({
+        settings: { inventory: { low_stock_threshold: 8 } },
+      });
+      mockPrismaService.products.findMany.mockResolvedValue([
+        {
+          state: ProductState.ACTIVE,
+          stock_quantity: 8,
+          min_stock_level: 0,
+          reorder_point: 0,
+          base_price: 10,
+          product_images: [],
+        },
+        {
+          state: ProductState.ACTIVE,
+          stock_quantity: 9,
+          min_stock_level: 0,
+          reorder_point: 0,
+          base_price: 10,
+          product_images: [],
+        },
+      ]);
+      mockPrismaService.categories.count.mockResolvedValue(0);
+      mockPrismaService.brands.count.mockResolvedValue(0);
+
+      const result = await service.getProductStats(1);
+
+      expect(result.low_stock_products).toBe(1);
+    });
   });
 
   describe('ADVANCED SCENARIOS', () => {
@@ -925,6 +971,133 @@ describe('ProductsService', () => {
         take: 10,
         orderBy: { created_at: 'desc' },
       });
+    });
+  });
+
+  describe('ACTIVE PROMOTIONS ON LISTING', () => {
+    const buildListedProduct = (override: Partial<any> = {}) => ({
+      id: override.id ?? 1,
+      name: 'Sample Product',
+      slug: 'sample-product',
+      description: 'desc',
+      base_price: 100,
+      sale_price: null,
+      is_on_sale: false,
+      sku: 'SKU-1',
+      cost_price: null,
+      profit_margin: null,
+      min_stock_level: null,
+      reorder_point: null,
+      state: ProductState.ACTIVE,
+      pricing_type: 'unit',
+      product_type: 'physical',
+      track_inventory: true,
+      available_for_ecommerce: true,
+      is_featured: false,
+      allow_pos_price_override: false,
+      requires_batch_tracking: false,
+      requires_booking: false,
+      booking_mode: null,
+      buffer_minutes: 0,
+      is_recurring: false,
+      service_duration_minutes: null,
+      service_modality: null,
+      service_pricing_type: null,
+      service_instructions: null,
+      product_images: [],
+      brands: null,
+      product_categories: override.product_categories ?? [],
+      product_tax_assignments: [],
+      product_price_tier_assignments: [],
+      product_variants: [],
+      stock_levels: [],
+      stores: { id: 1, name: 'T', slug: 't' },
+      _count: { product_variants: 0, product_images: 0, reviews: 0 },
+      ...override,
+    });
+
+    it('attaches active_promotion when the engine returns one for the product', async () => {
+      const product = buildListedProduct({ id: 10 });
+      mockPrismaService.products.findMany.mockResolvedValue([product]);
+      mockPrismaService.products.count.mockResolvedValue(1);
+      mockPromotionEngineService.findActiveAutoPromotionsForProducts.mockResolvedValueOnce(
+        new Map([
+          [
+            10,
+            {
+              id: 55,
+              name: 'Direct 15%',
+              type: 'percentage',
+              scope: 'product',
+              discount_percentage: 15,
+              promotional_price: 85,
+              badge_label: '-15% OFF',
+              priority: 2,
+            },
+          ],
+        ]),
+      );
+
+      const result = await service.findAll({ page: 1, limit: 10 });
+
+      expect(result.data).toHaveLength(1);
+      expect((result.data[0] as any).active_promotion).toMatchObject({
+        id: 55,
+        promotional_price: 85,
+        badge_label: '-15% OFF',
+      });
+    });
+
+    it('forwards product category ids so the engine can resolve scope=category eligibility', async () => {
+      const product = buildListedProduct({
+        id: 20,
+        product_categories: [
+          { category_id: 5, categories: { id: 5, name: 'Cat A' } },
+        ],
+      });
+      mockPrismaService.products.findMany.mockResolvedValue([product]);
+      mockPrismaService.products.count.mockResolvedValue(1);
+      mockPromotionEngineService.findActiveAutoPromotionsForProducts.mockResolvedValueOnce(
+        new Map([
+          [
+            20,
+            {
+              id: 77,
+              name: 'Cat 10%',
+              type: 'percentage',
+              scope: 'category',
+              discount_percentage: 10,
+              promotional_price: 90,
+              badge_label: '-10% OFF',
+              priority: 1,
+            },
+          ],
+        ]),
+      );
+
+      const result = await service.findAll({ page: 1, limit: 10 });
+
+      const callArgs =
+        mockPromotionEngineService.findActiveAutoPromotionsForProducts.mock
+          .calls[0][0];
+      expect(callArgs[0].category_ids).toContain(5);
+      expect((result.data[0] as any).active_promotion).toMatchObject({
+        id: 77,
+        scope: 'category',
+      });
+    });
+
+    it('returns active_promotion=null when the engine does not match the product', async () => {
+      const product = buildListedProduct({ id: 30 });
+      mockPrismaService.products.findMany.mockResolvedValue([product]);
+      mockPrismaService.products.count.mockResolvedValue(1);
+      mockPromotionEngineService.findActiveAutoPromotionsForProducts.mockResolvedValueOnce(
+        new Map(),
+      );
+
+      const result = await service.findAll({ page: 1, limit: 10 });
+
+      expect((result.data[0] as any).active_promotion).toBeNull();
     });
   });
 });

--- a/apps/backend/src/domains/store/products/products.service.ts
+++ b/apps/backend/src/domains/store/products/products.service.ts
@@ -45,8 +45,14 @@ import {
   resolvePosStockScope,
   ResolvedInventoryScope,
 } from '../inventory/shared/helpers/pos-stock-scope.helper';
+import { resolveProductLowStockThreshold } from '../inventory/shared/helpers/low-stock-threshold.helper';
 import { mergeStoreSettingsWithDefaults } from '../settings/defaults/default-store-settings';
 import type { StoreSettings } from '../settings/interfaces/store-settings.interface';
+import { PromotionEngineService } from '../promotions/promotion-engine/promotion-engine.service';
+import type {
+  ActiveProductPromotion,
+  ActivePromotionProductInput,
+} from '../promotions/dto/promotion-quote.interface';
 
 type OnlinePurchaseStatusReason =
   | 'ready'
@@ -82,6 +88,7 @@ export class ProductsService {
     private readonly remoteImageService: RemoteImageService,
     private readonly s3PathHelper: S3PathHelper,
     private readonly ai_engine: AIEngineService,
+    private readonly promotionEngine: PromotionEngineService,
   ) {}
 
   async generateDescription(dto: GenerateProductDescriptionDto) {
@@ -768,7 +775,7 @@ export class ProductsService {
     // denormalized cross-location aggregate.
     const includeStockEffective = pos_optimized ? true : include_stock;
 
-    const [products, total] = await Promise.all([
+    const [products, total, settings] = await Promise.all([
       this.prisma.products.findMany({
         where,
         skip,
@@ -881,7 +888,15 @@ export class ProductsService {
         orderBy: { created_at: 'desc' },
       }),
       this.prisma.products.count({ where }),
+      this.loadMergedSettings(),
     ]);
+
+    // Resolve active auto-apply promotions for every product in the listing
+    // (batch query). Cards use the promotional unit price computed off the
+    // tax-inclusive `final_price`, so the displayed savings stay consistent
+    // with the rest of the listing pricing math.
+    const activePromotionsByProductId =
+      await this.resolveActivePromotionsForListing(products);
 
     // Para POS optimizado, retornar productos directamente con imágenes firmadas
     if (pos_optimized) {
@@ -889,6 +904,10 @@ export class ProductsService {
         products.map(async (product) => {
           const raw_image_url = product.product_images?.[0]?.image_url || null;
           const signed_image_url = await this.s3Service.signUrl(raw_image_url);
+          const lowStockThreshold = resolveProductLowStockThreshold(
+            settings,
+            product,
+          );
 
           // Map variant data for POS
           const product_variants =
@@ -952,6 +971,8 @@ export class ProductsService {
             ? product_variants.some((v: any) => v.is_available)
             : !product.track_inventory || productStockQty > 0;
 
+          const activePromotion =
+            activePromotionsByProductId.get(product.id) ?? null;
           return {
             id: product.id,
             name: product.name,
@@ -961,9 +982,13 @@ export class ProductsService {
             sale_price: product.sale_price,
             is_on_sale: product.is_on_sale,
             final_price: this.calculateFinalPrice(product),
+            active_promotion: activePromotion,
             sku: product.sku,
             cost_price: product.cost_price,
             profit_margin: product.profit_margin,
+            min_stock_level: product.min_stock_level,
+            reorder_point: product.reorder_point,
+            low_stock_threshold: lowStockThreshold,
             stock_quantity: productStockQty,
             available_stock: product.track_inventory ? productStockQty : null,
             is_available: productIsAvailable,
@@ -1034,6 +1059,10 @@ export class ProductsService {
     // Cuando el producto tiene variantes, excluir filas base para no duplicar stock.
     const productsWithStock = await Promise.all(
       products.map(async (product) => {
+        const lowStockThreshold = resolveProductLowStockThreshold(
+          settings,
+          product,
+        );
         const hasVariants =
           (product._count?.product_variants ??
             product.product_variants?.length ??
@@ -1092,6 +1121,8 @@ export class ProductsService {
             }) || []
           : undefined;
 
+        const activePromotion =
+          activePromotionsByProductId.get(product.id) ?? null;
         return {
           id: product.id,
           name: product.name,
@@ -1101,9 +1132,13 @@ export class ProductsService {
           sale_price: product.sale_price,
           is_on_sale: product.is_on_sale,
           final_price: this.calculateFinalPrice(product),
+          active_promotion: activePromotion,
           sku: product.sku,
           cost_price: product.cost_price,
           profit_margin: product.profit_margin,
+          min_stock_level: product.min_stock_level,
+          reorder_point: product.reorder_point,
+          low_stock_threshold: lowStockThreshold,
           state: product.state,
           pricing_type: String(product.pricing_type),
           product_type: product.product_type,
@@ -1298,8 +1333,13 @@ export class ProductsService {
 
     // Sign all images
     await this.signProductImages(product);
-    const onlinePurchaseStatus = await this.resolveOnlinePurchaseStatus(
-      product.store_id,
+    const [onlinePurchaseStatus, settings] = await Promise.all([
+      this.resolveOnlinePurchaseStatus(product.store_id),
+      this.loadMergedSettings(product.store_id),
+    ]);
+    const lowStockThreshold = resolveProductLowStockThreshold(
+      settings,
+      product,
     );
 
     // Retornar producto con información de stock enriquecida
@@ -1315,6 +1355,9 @@ export class ProductsService {
       sku: product.sku,
       cost_price: product.cost_price,
       profit_margin: product.profit_margin,
+      min_stock_level: product.min_stock_level,
+      reorder_point: product.reorder_point,
+      low_stock_threshold: lowStockThreshold,
       state: product.state,
       pricing_type: String(product.pricing_type),
       product_type: product.product_type,
@@ -2365,6 +2408,8 @@ export class ProductsService {
         },
       });
 
+      const settings = await this.loadMergedSettings(storeId);
+
       // Calculate stats
       const active_products = products.filter(
         (p) => p.state === ProductState.ACTIVE,
@@ -2378,13 +2423,15 @@ export class ProductsService {
       ).length;
 
       // Stock calculations (simplified - using stock_quantity field)
-      const low_stock_products = products.filter(
-        (p) =>
+      const low_stock_products = products.filter((p) => {
+        const stockQuantity = Number(p.stock_quantity ?? 0);
+        return (
           p.stock_quantity !== null &&
           p.stock_quantity !== undefined &&
-          p.stock_quantity > 0 &&
-          p.stock_quantity <= 10,
-      ).length;
+          stockQuantity > 0 &&
+          stockQuantity <= resolveProductLowStockThreshold(settings, p)
+        );
+      }).length;
 
       const out_of_stock_products = products.filter(
         (p) =>
@@ -2806,6 +2853,50 @@ export class ProductsService {
   }
 
   /**
+   * Batch-resolve active auto-apply promotions for a list of products. The
+   * resulting map keys are product ids; values are the highest-priority
+   * promotion eligible by scope=product or scope=category. POS cards display
+   * the promotional price computed off the same tax-inclusive `final_price`
+   * the rest of the listing uses, so the badge stays visually consistent.
+   */
+  private async resolveActivePromotionsForListing(
+    products: any[],
+  ): Promise<Map<number, ActiveProductPromotion>> {
+    if (!Array.isArray(products) || products.length === 0) {
+      return new Map();
+    }
+
+    const inputs: ActivePromotionProductInput[] = products
+      .map((product) => {
+        const productId = Number(product?.id);
+        if (!Number.isFinite(productId)) return null;
+        const unitPrice = this.calculateFinalPrice(product);
+        if (!Number.isFinite(unitPrice) || unitPrice <= 0) return null;
+        const categoryIds: number[] = (product.product_categories ?? [])
+          .map((pc: any) => Number(pc?.categories?.id ?? pc?.category_id))
+          .filter((id: number) => Number.isFinite(id));
+        return {
+          product_id: productId,
+          category_ids: categoryIds,
+          unit_price: unitPrice,
+        } as ActivePromotionProductInput;
+      })
+      .filter((value): value is ActivePromotionProductInput => value !== null);
+
+    if (inputs.length === 0) return new Map();
+
+    try {
+      return await this.promotionEngine.findActiveAutoPromotionsForProducts(
+        inputs,
+      );
+    } catch {
+      // Listing must never fail because of promotions; surface no badge
+      // instead of erroring the whole catalog.
+      return new Map();
+    }
+  }
+
+  /**
    * Calculates the final price of a product including taxes and active offers.
    */
   private calculateFinalPrice(product: any): number {
@@ -2854,8 +2945,9 @@ export class ProductsService {
     return { default_location_id: store?.default_location_id ?? null };
   }
 
-  private async loadMergedSettings(): Promise<StoreSettings> {
+  private async loadMergedSettings(storeId?: number): Promise<StoreSettings> {
     const row = await this.prisma.store_settings.findFirst({
+      ...(storeId && { where: { store_id: storeId } }),
       select: { settings: true },
     });
     return mergeStoreSettingsWithDefaults(row?.settings);

--- a/apps/backend/src/domains/store/promotions/dto/create-promotion.dto.ts
+++ b/apps/backend/src/domains/store/promotions/dto/create-promotion.dto.ts
@@ -9,6 +9,9 @@ import {
   IsDateString,
   Min,
   MaxLength,
+  ValidateIf,
+  ArrayNotEmpty,
+  ArrayUnique,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 
@@ -80,15 +83,23 @@ export class CreatePromotionDto {
   @Type(() => Number)
   priority?: number = 0;
 
-  @IsOptional()
-  @IsArray()
-  @IsInt({ each: true })
+  @ValidateIf((o) => o.scope === 'product')
+  @IsArray({ message: 'Debes proporcionar la lista de productos' })
+  @ArrayNotEmpty({
+    message: 'Selecciona al menos un producto para esta promocion',
+  })
+  @ArrayUnique({ message: 'No se permiten productos duplicados' })
+  @IsInt({ each: true, message: 'Cada producto debe ser un id valido' })
   @Type(() => Number)
   product_ids?: number[];
 
-  @IsOptional()
-  @IsArray()
-  @IsInt({ each: true })
+  @ValidateIf((o) => o.scope === 'category')
+  @IsArray({ message: 'Debes proporcionar la lista de categorias' })
+  @ArrayNotEmpty({
+    message: 'Selecciona al menos una categoria para esta promocion',
+  })
+  @ArrayUnique({ message: 'No se permiten categorias duplicadas' })
+  @IsInt({ each: true, message: 'Cada categoria debe ser un id valido' })
   @Type(() => Number)
   category_ids?: number[];
 }

--- a/apps/backend/src/domains/store/promotions/dto/index.ts
+++ b/apps/backend/src/domains/store/promotions/dto/index.ts
@@ -1,3 +1,15 @@
 export { CreatePromotionDto } from './create-promotion.dto';
 export { UpdatePromotionDto } from './update-promotion.dto';
 export { QueryPromotionsDto } from './query-promotions.dto';
+export type {
+  PromotionQuoteScope,
+  PromotionQuoteType,
+  PromotionQuoteItemInput,
+  PromotionQuoteInput,
+  PromotionQuoteApplied,
+  PromotionQuoteItemBreakdown,
+  PromotionQuoteResult,
+  OrderPromotionSnapshot,
+  ActiveProductPromotion,
+  ActivePromotionProductInput,
+} from './promotion-quote.interface';

--- a/apps/backend/src/domains/store/promotions/dto/promotion-quote.interface.ts
+++ b/apps/backend/src/domains/store/promotions/dto/promotion-quote.interface.ts
@@ -1,0 +1,146 @@
+/**
+ * Input/Output contracts for the reusable promotion quote calculation in
+ * `PromotionEngineService.quoteDiscounts`. This is the single source of truth
+ * consumed by POS, catalog, checkout and orders for promotional pricing.
+ *
+ * Money values are plain `number` (already rounded to 2 decimals). The engine
+ * accepts Decimal-compatible values from Prisma but always normalizes the
+ * output to numbers so consumers can do arithmetic safely.
+ *
+ * Discounts are calculated over the products subtotal BEFORE shipping.
+ */
+
+export type PromotionQuoteScope = 'order' | 'product' | 'category';
+export type PromotionQuoteType = 'percentage' | 'fixed_amount';
+
+/**
+ * Cart/order line items as seen by the promotion engine. Consumers only need
+ * to provide identification + unit price + quantity. Categories may be a
+ * single id or an array (products often belong to multiple categories).
+ */
+export interface PromotionQuoteItemInput {
+  /** Stable identifier of the cart item (used to map output back). */
+  line_id?: string | number;
+  product_id: number;
+  variant_id?: number | null;
+  category_id?: number | null;
+  category_ids?: Array<number | string> | null;
+  unit_price: number;
+  quantity: number;
+}
+
+export interface PromotionQuoteInput {
+  items: PromotionQuoteItemInput[];
+  /**
+   * Optional customer id. Required when promotions have per-customer usage
+   * limits; engine will still try to quote when absent (limit skipped).
+   */
+  customer_id?: number | null;
+  /**
+   * Manual promotion ids submitted explicitly by the caller (e.g. user picked
+   * a non-auto promotion in POS). Manual promotions are ONLY applied when
+   * passed here.
+   */
+  manual_promotion_ids?: number[];
+  /**
+   * Reference date used for date-range eligibility. Defaults to `new Date()`.
+   * Useful for deterministic tests and replays.
+   */
+  now?: Date;
+}
+
+export interface PromotionQuoteApplied {
+  promotion_id: number;
+  name: string;
+  code: string | null;
+  type: PromotionQuoteType;
+  scope: PromotionQuoteScope;
+  value: number;
+  /** Whether this promotion was triggered automatically by `is_auto_apply`. */
+  is_auto_apply: boolean;
+  /** Total discount in money produced by this promotion across the cart. */
+  discount_amount: number;
+  /** Items the discount was prorated against (sorted by line index). */
+  applicable_item_ids: Array<string | number | undefined>;
+}
+
+export interface PromotionQuoteItemBreakdown {
+  line_id?: string | number;
+  product_id: number;
+  variant_id?: number | null;
+  quantity: number;
+  /** Unit price BEFORE any promotional discount. */
+  original_unit_price: number;
+  /** Total promotional discount for this item across all applied promotions. */
+  promotion_discount: number;
+  /** Effective unit price after applying promotions (>= 0). */
+  final_unit_price: number;
+  /** Final line total after promotions (= final_unit_price * quantity). */
+  final_line_total: number;
+  /** All promotion ids that contributed to this item's discount. */
+  promotion_ids: number[];
+}
+
+/**
+ * Persistence-ready snapshot for `order_promotions`. The orders/payments
+ * services map this 1:1 to `order_promotions.create` so promotions, totals
+ * and audit trail stay consistent.
+ */
+export interface OrderPromotionSnapshot {
+  promotion_id: number;
+  discount_amount: number;
+}
+
+export interface PromotionQuoteResult {
+  /** Subtotal of items BEFORE any promotional discount. */
+  subtotal: number;
+  /** Sum of every promotion discount applied. */
+  total_discount: number;
+  /** subtotal - total_discount (>= 0). */
+  promotional_subtotal: number;
+  applied_promotions: PromotionQuoteApplied[];
+  items: PromotionQuoteItemBreakdown[];
+  /** Order_promotions records ready to persist (one per applied promotion). */
+  order_promotions_snapshot: OrderPromotionSnapshot[];
+}
+
+/**
+ * Active promotion descriptor surfaced on product cards (POS + ecommerce).
+ *
+ * Represents the highest-priority auto-apply promotion eligible for a given
+ * product based on scope=product or scope=category. `promotional_price` is
+ * the unit price AFTER applying the promotion (tax-inclusive when the
+ * input was tax-inclusive). Order-scope promotions are NOT included here
+ * because they depend on cart context, not on the product itself.
+ */
+export interface ActiveProductPromotion {
+  id: number;
+  name: string;
+  type: PromotionQuoteType;
+  scope: 'product' | 'category';
+  /** Percentage value when `type === 'percentage'` (0..100), undefined otherwise. */
+  discount_percentage?: number;
+  /** Fixed amount when `type === 'fixed_amount'`, undefined otherwise. */
+  discount_amount?: number;
+  /** Effective unit price after the discount (rounded to 2 decimals). */
+  promotional_price: number;
+  /** Short label that the UI badge can show ("-20% OFF", "$5.000 OFF"). */
+  badge_label: string;
+  priority: number;
+}
+
+/**
+ * Minimal product shape the engine needs to evaluate auto-apply promotions
+ * for listing/cards. Consumers (POS, catalog) build this from their own
+ * Prisma queries without depending on the products domain.
+ */
+export interface ActivePromotionProductInput {
+  product_id: number;
+  category_ids: number[];
+  /**
+   * Base unit price that the promotion discount applies to. Consumers may
+   * pass the already-tax-inclusive `final_price` so the resulting
+   * `promotional_price` stays comparable on the card.
+   */
+  unit_price: number;
+}

--- a/apps/backend/src/domains/store/promotions/promotion-engine/promotion-engine.service.spec.ts
+++ b/apps/backend/src/domains/store/promotions/promotion-engine/promotion-engine.service.spec.ts
@@ -1,0 +1,489 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PromotionEngineService } from './promotion-engine.service';
+import { StorePrismaService } from '../../../../prisma/services/store-prisma.service';
+
+/**
+ * Helper to build a promotion row matching the shape PromotionEngineService
+ * expects (Prisma row + relations).
+ */
+function buildPromotion(overrides: Partial<Record<string, unknown>> = {}) {
+  const start = new Date('2026-01-01T00:00:00Z');
+  const end = new Date('2026-12-31T23:59:59Z');
+  return {
+    id: 1,
+    store_id: 1,
+    name: 'Test Promotion',
+    description: null,
+    code: null,
+    type: 'percentage',
+    value: 10,
+    scope: 'order',
+    min_purchase_amount: null,
+    max_discount_amount: null,
+    usage_limit: null,
+    usage_count: 0,
+    per_customer_limit: null,
+    start_date: start,
+    end_date: end,
+    state: 'active',
+    is_auto_apply: true,
+    priority: 0,
+    promotion_products: [],
+    promotion_categories: [],
+    ...overrides,
+  };
+}
+
+describe('PromotionEngineService - quoteDiscounts', () => {
+  let service: PromotionEngineService;
+  let prisma: {
+    promotions: { findMany: jest.Mock; findFirst: jest.Mock; update: jest.Mock };
+    order_promotions: { count: jest.Mock; create: jest.Mock };
+  };
+
+  const REFERENCE_NOW = new Date('2026-06-01T12:00:00Z');
+
+  beforeEach(async () => {
+    prisma = {
+      promotions: {
+        findMany: jest.fn().mockResolvedValue([]),
+        findFirst: jest.fn(),
+        update: jest.fn(),
+      },
+      order_promotions: {
+        count: jest.fn().mockResolvedValue(0),
+        create: jest.fn(),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PromotionEngineService,
+        {
+          provide: StorePrismaService,
+          useValue: prisma,
+        },
+      ],
+    }).compile();
+
+    service = module.get<PromotionEngineService>(PromotionEngineService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('returns zeroed quote when no items are passed', async () => {
+    const result = await service.quoteDiscounts({ items: [], now: REFERENCE_NOW });
+
+    expect(result.subtotal).toBe(0);
+    expect(result.total_discount).toBe(0);
+    expect(result.promotional_subtotal).toBe(0);
+    expect(result.applied_promotions).toEqual([]);
+    expect(result.items).toEqual([]);
+    expect(result.order_promotions_snapshot).toEqual([]);
+    expect(prisma.promotions.findMany).not.toHaveBeenCalled();
+  });
+
+  it('returns subtotal with empty discounts when no promotions exist', async () => {
+    prisma.promotions.findMany.mockResolvedValue([]);
+
+    const result = await service.quoteDiscounts({
+      items: [
+        { line_id: 'l1', product_id: 10, unit_price: 100, quantity: 2 },
+      ],
+      now: REFERENCE_NOW,
+    });
+
+    expect(result.subtotal).toBe(200);
+    expect(result.total_discount).toBe(0);
+    expect(result.promotional_subtotal).toBe(200);
+    expect(result.items[0].final_unit_price).toBe(100);
+    expect(result.items[0].final_line_total).toBe(200);
+    expect(result.items[0].promotion_ids).toEqual([]);
+  });
+
+  describe('product-scoped promotions', () => {
+    it('applies discount only to matching products', async () => {
+      prisma.promotions.findMany.mockResolvedValue([
+        buildPromotion({
+          id: 11,
+          name: 'Producto A 10% OFF',
+          type: 'percentage',
+          value: 10,
+          scope: 'product',
+          promotion_products: [{ product_id: 10 }],
+        }),
+      ]);
+
+      const result = await service.quoteDiscounts({
+        items: [
+          { line_id: 'l1', product_id: 10, unit_price: 100, quantity: 2 }, // 200
+          { line_id: 'l2', product_id: 20, unit_price: 50, quantity: 1 }, // 50
+        ],
+        now: REFERENCE_NOW,
+      });
+
+      expect(result.subtotal).toBe(250);
+      // 10% of 200 = 20 (only product 10 is in scope)
+      expect(result.total_discount).toBe(20);
+      expect(result.promotional_subtotal).toBe(230);
+
+      const item10 = result.items.find((i) => i.product_id === 10)!;
+      const item20 = result.items.find((i) => i.product_id === 20)!;
+      expect(item10.promotion_discount).toBe(20);
+      expect(item10.promotion_ids).toEqual([11]);
+      expect(item20.promotion_discount).toBe(0);
+      expect(item20.promotion_ids).toEqual([]);
+      expect(result.applied_promotions[0].applicable_item_ids).toEqual(['l1']);
+      expect(result.order_promotions_snapshot).toEqual([
+        { promotion_id: 11, discount_amount: 20 },
+      ]);
+    });
+  });
+
+  describe('category-scoped promotions', () => {
+    it('matches via single category_id or category_ids array', async () => {
+      prisma.promotions.findMany.mockResolvedValue([
+        buildPromotion({
+          id: 21,
+          name: 'Categoria 5 - 10%',
+          type: 'percentage',
+          value: 10,
+          scope: 'category',
+          promotion_categories: [{ category_id: 5 }],
+        }),
+      ]);
+
+      const result = await service.quoteDiscounts({
+        items: [
+          { line_id: 'a', product_id: 1, category_id: 5, unit_price: 200, quantity: 1 },
+          { line_id: 'b', product_id: 2, category_ids: [9, 5], unit_price: 100, quantity: 1 },
+          { line_id: 'c', product_id: 3, category_id: 99, unit_price: 50, quantity: 1 },
+        ],
+        now: REFERENCE_NOW,
+      });
+
+      // Applicable total: 200 + 100 = 300, 10% = 30.
+      expect(result.total_discount).toBe(30);
+      const itemA = result.items.find((i) => i.product_id === 1)!;
+      const itemB = result.items.find((i) => i.product_id === 2)!;
+      const itemC = result.items.find((i) => i.product_id === 3)!;
+      // Proration: 200/300*30 = 20; 100/300*30 = 10
+      expect(itemA.promotion_discount).toBe(20);
+      expect(itemB.promotion_discount).toBe(10);
+      expect(itemC.promotion_discount).toBe(0);
+    });
+  });
+
+  describe('order-scoped promotions', () => {
+    it('applies to the whole cart', async () => {
+      prisma.promotions.findMany.mockResolvedValue([
+        buildPromotion({
+          id: 31,
+          name: 'Compra general 10%',
+          type: 'percentage',
+          value: 10,
+          scope: 'order',
+        }),
+      ]);
+
+      const result = await service.quoteDiscounts({
+        items: [
+          { line_id: 'x', product_id: 1, unit_price: 100, quantity: 1 },
+          { line_id: 'y', product_id: 2, unit_price: 200, quantity: 1 },
+        ],
+        now: REFERENCE_NOW,
+      });
+
+      expect(result.subtotal).toBe(300);
+      expect(result.total_discount).toBe(30);
+      expect(result.promotional_subtotal).toBe(270);
+      expect(result.items.every((i) => i.promotion_ids.includes(31))).toBe(true);
+    });
+  });
+
+  describe('max discount cap', () => {
+    it('caps percentage discount at max_discount_amount', async () => {
+      prisma.promotions.findMany.mockResolvedValue([
+        buildPromotion({
+          id: 41,
+          type: 'percentage',
+          value: 50, // 50% -> would be 500
+          scope: 'order',
+          max_discount_amount: 100,
+        }),
+      ]);
+
+      const result = await service.quoteDiscounts({
+        items: [{ line_id: 'a', product_id: 1, unit_price: 1000, quantity: 1 }],
+        now: REFERENCE_NOW,
+      });
+
+      expect(result.total_discount).toBe(100);
+      expect(result.applied_promotions[0].discount_amount).toBe(100);
+    });
+
+    it('caps fixed_amount discount at applicable total', async () => {
+      prisma.promotions.findMany.mockResolvedValue([
+        buildPromotion({
+          id: 42,
+          type: 'fixed_amount',
+          value: 500,
+          scope: 'order',
+        }),
+      ]);
+
+      const result = await service.quoteDiscounts({
+        items: [{ line_id: 'a', product_id: 1, unit_price: 100, quantity: 1 }],
+        now: REFERENCE_NOW,
+      });
+
+      // Discount cannot exceed applicable_total (100).
+      expect(result.total_discount).toBe(100);
+      expect(result.promotional_subtotal).toBe(0);
+    });
+  });
+
+  describe('min purchase guard', () => {
+    it('does not apply when subtotal is below min_purchase_amount', async () => {
+      prisma.promotions.findMany.mockResolvedValue([
+        buildPromotion({
+          id: 51,
+          type: 'percentage',
+          value: 10,
+          scope: 'order',
+          min_purchase_amount: 500,
+        }),
+      ]);
+
+      const result = await service.quoteDiscounts({
+        items: [{ line_id: 'a', product_id: 1, unit_price: 100, quantity: 1 }],
+        now: REFERENCE_NOW,
+      });
+
+      expect(result.total_discount).toBe(0);
+      expect(result.applied_promotions).toEqual([]);
+      expect(result.promotional_subtotal).toBe(100);
+    });
+
+    it('applies when subtotal meets min_purchase_amount exactly', async () => {
+      prisma.promotions.findMany.mockResolvedValue([
+        buildPromotion({
+          id: 52,
+          type: 'percentage',
+          value: 10,
+          scope: 'order',
+          min_purchase_amount: 200,
+        }),
+      ]);
+
+      const result = await service.quoteDiscounts({
+        items: [{ line_id: 'a', product_id: 1, unit_price: 200, quantity: 1 }],
+        now: REFERENCE_NOW,
+      });
+
+      expect(result.total_discount).toBe(20);
+    });
+  });
+
+  describe('ineligibility', () => {
+    it('ignores promotion when scope does not match any cart item', async () => {
+      prisma.promotions.findMany.mockResolvedValue([
+        buildPromotion({
+          id: 61,
+          scope: 'product',
+          type: 'percentage',
+          value: 25,
+          promotion_products: [{ product_id: 999 }],
+        }),
+      ]);
+
+      const result = await service.quoteDiscounts({
+        items: [{ line_id: 'a', product_id: 1, unit_price: 100, quantity: 1 }],
+        now: REFERENCE_NOW,
+      });
+
+      expect(result.applied_promotions).toEqual([]);
+      expect(result.total_discount).toBe(0);
+    });
+
+    it('ignores expired promotions via query-time filter (no candidates)', async () => {
+      // Simulate Prisma honouring the date predicate: expired promo returns no rows.
+      prisma.promotions.findMany.mockResolvedValue([]);
+
+      const result = await service.quoteDiscounts({
+        items: [{ line_id: 'a', product_id: 1, unit_price: 100, quantity: 1 }],
+        now: REFERENCE_NOW,
+      });
+
+      // Verify the query enforced state + date range predicates.
+      const args = prisma.promotions.findMany.mock.calls[0][0];
+      expect(args.where.state.in).toEqual(['active', 'scheduled']);
+      expect(args.where.start_date.lte).toBe(REFERENCE_NOW);
+      expect(args.where.OR).toEqual([
+        { end_date: null },
+        { end_date: { gte: REFERENCE_NOW } },
+      ]);
+      expect(result.applied_promotions).toEqual([]);
+    });
+
+    it('skips promotion when usage_limit is reached', async () => {
+      prisma.promotions.findMany.mockResolvedValue([
+        buildPromotion({
+          id: 62,
+          usage_limit: 5,
+          usage_count: 5,
+        }),
+      ]);
+
+      const result = await service.quoteDiscounts({
+        items: [{ line_id: 'a', product_id: 1, unit_price: 100, quantity: 1 }],
+        now: REFERENCE_NOW,
+      });
+
+      expect(result.applied_promotions).toEqual([]);
+    });
+
+    it('skips promotion when per_customer_limit is reached', async () => {
+      prisma.promotions.findMany.mockResolvedValue([
+        buildPromotion({
+          id: 63,
+          per_customer_limit: 1,
+        }),
+      ]);
+      prisma.order_promotions.count.mockResolvedValue(1);
+
+      const result = await service.quoteDiscounts({
+        items: [{ line_id: 'a', product_id: 1, unit_price: 100, quantity: 1 }],
+        customer_id: 77,
+        now: REFERENCE_NOW,
+      });
+
+      expect(prisma.order_promotions.count).toHaveBeenCalledWith({
+        where: { promotion_id: 63, customer_id: 77 },
+      });
+      expect(result.applied_promotions).toEqual([]);
+    });
+  });
+
+  describe('stacking', () => {
+    it('combines multiple auto-apply promotions by priority desc', async () => {
+      prisma.promotions.findMany.mockResolvedValue([
+        buildPromotion({
+          id: 71,
+          name: 'Order 5% OFF',
+          type: 'percentage',
+          value: 5,
+          scope: 'order',
+          priority: 10,
+        }),
+        buildPromotion({
+          id: 72,
+          name: 'Producto 10 - $20 OFF',
+          type: 'fixed_amount',
+          value: 20,
+          scope: 'product',
+          priority: 5,
+          promotion_products: [{ product_id: 10 }],
+        }),
+      ]);
+
+      const result = await service.quoteDiscounts({
+        items: [
+          { line_id: 'l1', product_id: 10, unit_price: 100, quantity: 1 },
+          { line_id: 'l2', product_id: 20, unit_price: 100, quantity: 1 },
+        ],
+        now: REFERENCE_NOW,
+      });
+
+      // subtotal = 200
+      // First (priority 10): order scope, 5% of 200 = 10
+      // Second (priority 5): product scope, fixed 20 on product 10
+      expect(result.subtotal).toBe(200);
+      expect(result.total_discount).toBe(30);
+      expect(result.promotional_subtotal).toBe(170);
+      expect(result.applied_promotions.map((p) => p.promotion_id)).toEqual([71, 72]);
+
+      const item10 = result.items.find((i) => i.product_id === 10)!;
+      // Item 10 got order share (5% of 100 = 5) + product (20) = 25
+      expect(item10.promotion_discount).toBe(25);
+      expect(item10.promotion_ids).toEqual([71, 72]);
+    });
+  });
+
+  describe('manual promotions', () => {
+    it('only applies a manual (non-auto) promotion when its id is in manual_promotion_ids', async () => {
+      const manualPromotion = buildPromotion({
+        id: 81,
+        name: 'Manual 15% OFF',
+        type: 'percentage',
+        value: 15,
+        scope: 'order',
+        is_auto_apply: false,
+      });
+      prisma.promotions.findMany.mockResolvedValue([manualPromotion]);
+
+      const withId = await service.quoteDiscounts({
+        items: [{ line_id: 'a', product_id: 1, unit_price: 200, quantity: 1 }],
+        manual_promotion_ids: [81],
+        now: REFERENCE_NOW,
+      });
+      expect(withId.total_discount).toBe(30);
+      expect(withId.applied_promotions[0].promotion_id).toBe(81);
+
+      // Now simulate the same engine call WITHOUT the manual id. Prisma would
+      // not return the promo (because the where clause filters by auto OR id).
+      prisma.promotions.findMany.mockResolvedValue([]);
+      const withoutId = await service.quoteDiscounts({
+        items: [{ line_id: 'a', product_id: 1, unit_price: 200, quantity: 1 }],
+        now: REFERENCE_NOW,
+      });
+      expect(withoutId.total_discount).toBe(0);
+      expect(withoutId.applied_promotions).toEqual([]);
+
+      // Verify the second call filters by `is_auto_apply: true` only.
+      const args = prisma.promotions.findMany.mock.calls[1][0];
+      expect(args.where.is_auto_apply).toBe(true);
+      expect(args.where.AND).toBeUndefined();
+    });
+
+    it('builds a where clause combining auto + manual ids when both are requested', async () => {
+      prisma.promotions.findMany.mockResolvedValue([]);
+
+      await service.quoteDiscounts({
+        items: [{ line_id: 'a', product_id: 1, unit_price: 100, quantity: 1 }],
+        manual_promotion_ids: [81, 82],
+        now: REFERENCE_NOW,
+      });
+
+      const args = prisma.promotions.findMany.mock.calls[0][0];
+      expect(args.where.is_auto_apply).toBeUndefined();
+      expect(args.where.AND).toEqual([
+        { OR: [{ is_auto_apply: true }, { id: { in: [81, 82] } }] },
+      ]);
+    });
+  });
+
+  describe('order_promotions snapshot', () => {
+    it('returns a snapshot ready to persist 1:1 to order_promotions', async () => {
+      prisma.promotions.findMany.mockResolvedValue([
+        buildPromotion({
+          id: 91,
+          type: 'percentage',
+          value: 10,
+          scope: 'order',
+        }),
+      ]);
+
+      const result = await service.quoteDiscounts({
+        items: [{ line_id: 'a', product_id: 1, unit_price: 100, quantity: 1 }],
+        now: REFERENCE_NOW,
+      });
+
+      expect(result.order_promotions_snapshot).toEqual([
+        { promotion_id: 91, discount_amount: 10 },
+      ]);
+    });
+  });
+});

--- a/apps/backend/src/domains/store/promotions/promotion-engine/promotion-engine.service.ts
+++ b/apps/backend/src/domains/store/promotions/promotion-engine/promotion-engine.service.ts
@@ -1,5 +1,39 @@
 import { Injectable, BadRequestException } from '@nestjs/common';
 import { StorePrismaService } from 'src/prisma/services/store-prisma.service';
+import {
+  ActiveProductPromotion,
+  ActivePromotionProductInput,
+  OrderPromotionSnapshot,
+  PromotionQuoteApplied,
+  PromotionQuoteInput,
+  PromotionQuoteItemBreakdown,
+  PromotionQuoteItemInput,
+  PromotionQuoteResult,
+  PromotionQuoteScope,
+  PromotionQuoteType,
+} from '../dto/promotion-quote.interface';
+
+/** Internal helper: represents a promotion row resolved from DB with relations. */
+interface PromotionRecord {
+  id: number;
+  name: string;
+  code: string | null;
+  type: PromotionQuoteType;
+  value: unknown;
+  scope: PromotionQuoteScope;
+  min_purchase_amount: unknown;
+  max_discount_amount: unknown;
+  usage_limit: number | null;
+  usage_count: number;
+  per_customer_limit: number | null;
+  is_auto_apply: boolean;
+  priority: number;
+  start_date: Date;
+  end_date: Date | null;
+  state: string;
+  promotion_products?: Array<{ product_id: number }>;
+  promotion_categories?: Array<{ category_id: number }>;
+}
 
 @Injectable()
 export class PromotionEngineService {
@@ -226,5 +260,400 @@ export class PromotionEngineService {
 
     const discount = this.calculateDiscount(promotion, cartItems);
     return { promotion, discount };
+  }
+
+  /**
+   * Build a structured promotional quote shared by POS, catalog, checkout and
+   * orders. Backend is the single source of truth for discount math; consumers
+   * pass cart items + optional manual promotion ids and receive:
+   *  - applied promotions (auto + manual that survived eligibility)
+   *  - per-item breakdown with original/final unit price
+   *  - totals (subtotal, total_discount, promotional_subtotal)
+   *  - order_promotions_snapshot ready to persist
+   *
+   * Rules:
+   *  - Auto promotions (`is_auto_apply = true`) apply automatically.
+   *  - Manual promotions only apply when their id is in `manual_promotion_ids`.
+   *  - Coupons are handled separately and do NOT enter this quote.
+   *  - Discounts are computed on the products subtotal BEFORE shipping.
+   *  - Date range, scope, min purchase, usage and per-customer limits are
+   *    honoured (same predicates the legacy methods already enforce).
+   *  - Stacking follows promotion `priority` (desc) like `getEligiblePromotions`.
+   */
+  async quoteDiscounts(input: PromotionQuoteInput): Promise<PromotionQuoteResult> {
+    const now = input.now ?? new Date();
+    const items = input.items ?? [];
+    const customerId = input.customer_id ?? null;
+    const manualIds = Array.from(new Set(input.manual_promotion_ids ?? []));
+
+    const subtotal = this.roundMoney(
+      items.reduce(
+        (sum, item) => sum + Number(item.unit_price) * Number(item.quantity),
+        0,
+      ),
+    );
+
+    // Initialize item breakdown — even if no promotions apply we return a
+    // populated breakdown so consumers can rely on the shape unconditionally.
+    const itemBreakdownMap = new Map<number, PromotionQuoteItemBreakdown>();
+    items.forEach((item, index) => {
+      const originalUnitPrice = Number(item.unit_price);
+      const quantity = Number(item.quantity);
+      itemBreakdownMap.set(index, {
+        line_id: item.line_id,
+        product_id: Number(item.product_id),
+        variant_id: item.variant_id ?? null,
+        quantity,
+        original_unit_price: this.roundMoney(originalUnitPrice),
+        promotion_discount: 0,
+        final_unit_price: this.roundMoney(originalUnitPrice),
+        final_line_total: this.roundMoney(originalUnitPrice * quantity),
+        promotion_ids: [],
+      });
+    });
+
+    if (items.length === 0) {
+      return {
+        subtotal: 0,
+        total_discount: 0,
+        promotional_subtotal: 0,
+        applied_promotions: [],
+        items: [],
+        order_promotions_snapshot: [],
+      };
+    }
+
+    // Fetch candidate promotions: auto-apply OR explicitly requested.
+    const candidates = (await this.prisma.promotions.findMany({
+      where: {
+        state: { in: ['active', 'scheduled'] },
+        start_date: { lte: now },
+        OR: [{ end_date: null }, { end_date: { gte: now } }],
+        ...(manualIds.length
+          ? { AND: [{ OR: [{ is_auto_apply: true }, { id: { in: manualIds } }] }] }
+          : { is_auto_apply: true }),
+      },
+      include: {
+        promotion_products: true,
+        promotion_categories: true,
+      },
+      orderBy: { priority: 'desc' },
+    })) as unknown as PromotionRecord[];
+
+    const appliedPromotions: PromotionQuoteApplied[] = [];
+
+    for (const promo of candidates) {
+      const isManual = !promo.is_auto_apply;
+
+      // Manual promotions only apply if caller passed their id.
+      if (isManual && !manualIds.includes(promo.id)) continue;
+
+      // Usage limit (global).
+      if (promo.usage_limit && promo.usage_count >= promo.usage_limit) continue;
+
+      // Per-customer usage limit.
+      if (promo.per_customer_limit && customerId) {
+        const customerUsage = await this.prisma.order_promotions.count({
+          where: {
+            promotion_id: promo.id,
+            customer_id: customerId,
+          },
+        });
+        if (customerUsage >= promo.per_customer_limit) continue;
+      }
+
+      const applicableIndexes = this.resolveApplicableItemIndexes(promo, items);
+      if (applicableIndexes.length === 0) continue;
+
+      const applicableTotal = this.roundMoney(
+        applicableIndexes.reduce((sum, idx) => {
+          const item = items[idx];
+          return sum + Number(item.unit_price) * Number(item.quantity);
+        }, 0),
+      );
+      if (applicableTotal <= 0) continue;
+
+      // Min purchase is evaluated against the cart subtotal (not the scoped
+      // applicable total) to mirror current `getEligiblePromotions` behaviour.
+      if (
+        promo.min_purchase_amount &&
+        subtotal < Number(promo.min_purchase_amount)
+      )
+        continue;
+
+      const discountAmount = this.computeDiscountAmount(promo, applicableTotal);
+      if (discountAmount <= 0) continue;
+
+      // Prorate the discount across applicable items proportional to their
+      // line total so per-item breakdown stays accurate. We track the running
+      // remainder and assign it to the last item to avoid rounding drift.
+      let assigned = 0;
+      applicableIndexes.forEach((idx, i) => {
+        const item = items[idx];
+        const lineTotal = Number(item.unit_price) * Number(item.quantity);
+        const isLast = i === applicableIndexes.length - 1;
+        const share = isLast
+          ? this.roundMoney(discountAmount - assigned)
+          : this.roundMoney((lineTotal / applicableTotal) * discountAmount);
+        assigned = this.roundMoney(assigned + share);
+
+        const current = itemBreakdownMap.get(idx);
+        if (!current) return;
+        const nextDiscount = this.roundMoney(current.promotion_discount + share);
+        // Cap discount per line at the line total so final_unit_price >= 0.
+        const cappedDiscount = Math.min(nextDiscount, lineTotal);
+        const remainingLineTotal = this.roundMoney(lineTotal - cappedDiscount);
+        const nextUnitPrice =
+          item.quantity > 0
+            ? this.roundMoney(remainingLineTotal / Number(item.quantity))
+            : current.original_unit_price;
+
+        itemBreakdownMap.set(idx, {
+          ...current,
+          promotion_discount: cappedDiscount,
+          final_unit_price: Math.max(0, nextUnitPrice),
+          final_line_total: Math.max(0, remainingLineTotal),
+          promotion_ids: current.promotion_ids.includes(promo.id)
+            ? current.promotion_ids
+            : [...current.promotion_ids, promo.id],
+        });
+      });
+
+      appliedPromotions.push({
+        promotion_id: promo.id,
+        name: promo.name,
+        code: promo.code ?? null,
+        type: promo.type,
+        scope: promo.scope,
+        value: Number(promo.value),
+        is_auto_apply: promo.is_auto_apply,
+        discount_amount: this.roundMoney(discountAmount),
+        applicable_item_ids: applicableIndexes
+          .map((idx) => itemBreakdownMap.get(idx)?.line_id)
+          .filter((lineId): lineId is string | number => lineId !== undefined),
+      });
+    }
+
+    const itemBreakdown = Array.from(itemBreakdownMap.values());
+    const totalDiscount = this.roundMoney(
+      appliedPromotions.reduce((sum, p) => sum + p.discount_amount, 0),
+    );
+    const promotionalSubtotal = this.roundMoney(
+      Math.max(0, subtotal - totalDiscount),
+    );
+
+    const snapshot: OrderPromotionSnapshot[] = appliedPromotions.map((p) => ({
+      promotion_id: p.promotion_id,
+      discount_amount: p.discount_amount,
+    }));
+
+    return {
+      subtotal,
+      total_discount: totalDiscount,
+      promotional_subtotal: promotionalSubtotal,
+      applied_promotions: appliedPromotions,
+      items: itemBreakdown,
+      order_promotions_snapshot: snapshot,
+    };
+  }
+
+  /**
+   * Batch-fetch the active auto-apply promotions (scope=product or
+   * scope=category) for product listings. POS and catalog use this to render
+   * the promotional price + badge on cards without re-running the full
+   * `quoteDiscounts` per product.
+   *
+   * Returns a Map<product_id, ActiveProductPromotion> for the products that
+   * have at least one applicable promotion (highest priority wins, with
+   * scope=product preferred over scope=category on ties).
+   *
+   * Notes:
+   *  - Cart-only checks (usage_count vs usage_limit, per_customer_limit,
+   *    min_purchase_amount) are intentionally skipped because we do not have
+   *    a cart at listing time. The cart-time engine (`quoteDiscounts`) still
+   *    enforces them at checkout/POS payment, so this can only over-state
+   *    eligibility in edge cases (e.g. coupon-style usage cap). UI should
+   *    treat the badge as informational; the authoritative discount is the
+   *    one computed at checkout.
+   *  - Order-scope promotions are excluded because they cannot be evaluated
+   *    against a single product card.
+   */
+  async findActiveAutoPromotionsForProducts(
+    products: ActivePromotionProductInput[],
+    now: Date = new Date(),
+  ): Promise<Map<number, ActiveProductPromotion>> {
+    const result = new Map<number, ActiveProductPromotion>();
+    if (!Array.isArray(products) || products.length === 0) return result;
+
+    const promotions = (await this.prisma.promotions.findMany({
+      where: {
+        state: { in: ['active', 'scheduled'] },
+        start_date: { lte: now },
+        OR: [{ end_date: null }, { end_date: { gte: now } }],
+        is_auto_apply: true,
+        scope: { in: ['product', 'category'] },
+      },
+      include: {
+        promotion_products: { select: { product_id: true } },
+        promotion_categories: { select: { category_id: true } },
+      },
+      orderBy: { priority: 'desc' },
+    })) as unknown as PromotionRecord[];
+
+    if (promotions.length === 0) return result;
+
+    for (const input of products) {
+      const productId = Number(input.product_id);
+      if (!Number.isFinite(productId)) continue;
+      const unitPrice = Number(input.unit_price);
+      if (!Number.isFinite(unitPrice) || unitPrice <= 0) continue;
+
+      const categoryIds = (input.category_ids ?? [])
+        .map((id) => Number(id))
+        .filter((id) => Number.isFinite(id));
+
+      // Find the highest priority eligible promotion for this product.
+      // Promotions are pre-ordered by priority desc; among equal priorities,
+      // prefer scope=product over scope=category for clearer UX.
+      let chosen: { promo: PromotionRecord; rank: number } | null = null;
+      for (const promo of promotions) {
+        const productIds = (promo.promotion_products ?? []).map((pp) =>
+          Number(pp.product_id),
+        );
+        const promoCategoryIds = (promo.promotion_categories ?? []).map((pc) =>
+          Number(pc.category_id),
+        );
+
+        const matchesProduct =
+          promo.scope === 'product' && productIds.includes(productId);
+        const matchesCategory =
+          promo.scope === 'category' &&
+          promoCategoryIds.some((cid) => categoryIds.includes(cid));
+
+        if (!matchesProduct && !matchesCategory) continue;
+
+        // Higher rank wins: product scope beats category scope at same priority.
+        const rank =
+          (promo.priority ?? 0) * 10 + (promo.scope === 'product' ? 1 : 0);
+        if (chosen === null || rank > chosen.rank) {
+          chosen = { promo, rank };
+        }
+      }
+
+      if (!chosen) continue;
+      const promo = chosen.promo;
+      const discount = this.computeDiscountAmount(promo, unitPrice);
+      if (discount <= 0) continue;
+
+      const promotionalPrice = this.roundMoney(Math.max(0, unitPrice - discount));
+      const promoType = promo.type as PromotionQuoteType;
+      const isPercentage = promoType === 'percentage';
+      const value = Number(promo.value);
+
+      result.set(productId, {
+        id: promo.id,
+        name: promo.name,
+        type: promoType,
+        scope: promo.scope === 'product' ? 'product' : 'category',
+        discount_percentage: isPercentage ? value : undefined,
+        discount_amount: isPercentage ? undefined : value,
+        promotional_price: promotionalPrice,
+        badge_label: this.buildBadgeLabel(promo, discount, unitPrice),
+        priority: promo.priority ?? 0,
+      });
+    }
+
+    return result;
+  }
+
+  /**
+   * Build a compact badge label for product cards. Prefer percentage when the
+   * promotion is percentage-typed, otherwise show the absolute saved amount.
+   */
+  private buildBadgeLabel(
+    promo: PromotionRecord,
+    discount: number,
+    unitPrice: number,
+  ): string {
+    if (promo.type === 'percentage') {
+      const value = Number(promo.value);
+      if (Number.isFinite(value) && value > 0) {
+        return `-${Math.round(value)}% OFF`;
+      }
+    }
+
+    // Compute effective percentage from the capped discount for fixed_amount
+    // promotions; this is more informative than the raw amount on cards.
+    if (unitPrice > 0) {
+      const effectivePct = Math.round((discount / unitPrice) * 100);
+      if (effectivePct > 0) return `-${effectivePct}% OFF`;
+    }
+
+    return 'OFERTA';
+  }
+
+  /** Resolve which item indexes a promotion applies to based on its scope. */
+  private resolveApplicableItemIndexes(
+    promotion: PromotionRecord,
+    items: PromotionQuoteItemInput[],
+  ): number[] {
+    if (promotion.scope === 'product') {
+      const promoProductIds = (promotion.promotion_products ?? []).map((pp) =>
+        Number(pp.product_id),
+      );
+      return items
+        .map((item, idx) =>
+          promoProductIds.includes(Number(item.product_id)) ? idx : -1,
+        )
+        .filter((idx) => idx >= 0);
+    }
+
+    if (promotion.scope === 'category') {
+      const promoCategoryIds = (promotion.promotion_categories ?? []).map((pc) =>
+        Number(pc.category_id),
+      );
+      return items
+        .map((item, idx) =>
+          this.getItemCategoryIds(item).some((categoryId) =>
+            promoCategoryIds.includes(categoryId),
+          )
+            ? idx
+            : -1,
+        )
+        .filter((idx) => idx >= 0);
+    }
+
+    // Order scope: applies to the whole cart.
+    return items.map((_, idx) => idx);
+  }
+
+  /**
+   * Compute the raw discount amount for a promotion against a scoped total,
+   * honouring `max_discount_amount` cap and the applicable total ceiling.
+   */
+  private computeDiscountAmount(
+    promotion: PromotionRecord,
+    applicableTotal: number,
+  ): number {
+    let discount = 0;
+    if (promotion.type === 'percentage') {
+      discount = applicableTotal * (Number(promotion.value) / 100);
+    } else {
+      discount = Math.min(Number(promotion.value), applicableTotal);
+    }
+
+    const maxDiscount = Number(promotion.max_discount_amount);
+    if (Number.isFinite(maxDiscount) && maxDiscount > 0) {
+      discount = Math.min(discount, maxDiscount);
+    }
+
+    // Never discount more than the applicable scoped total.
+    discount = Math.min(discount, applicableTotal);
+    return this.roundMoney(discount);
+  }
+
+  private roundMoney(value: number): number {
+    if (!Number.isFinite(value)) return 0;
+    return Math.round(value * 100) / 100;
   }
 }

--- a/apps/backend/src/domains/store/promotions/promotions.service.ts
+++ b/apps/backend/src/domains/store/promotions/promotions.service.ts
@@ -160,28 +160,37 @@ export class PromotionsService {
   }
 
   async create(dto: CreatePromotionDto) {
+    const scope = dto.scope || 'order';
     const { product_ids, category_ids, ...promotionData } = dto;
-    this.validateScopeSelection(dto.scope || 'order', product_ids, category_ids);
+
+    // Normalize payload: only keep IDs that match the configured scope.
+    const normalizedProductIds =
+      scope === 'product' ? this.sanitizeIds(product_ids) : [];
+    const normalizedCategoryIds =
+      scope === 'category' ? this.sanitizeIds(category_ids) : [];
+
+    this.validateScopeSelection(scope, normalizedProductIds, normalizedCategoryIds);
 
     const data: any = {
       ...promotionData,
+      scope,
       start_date: new Date(dto.start_date),
       end_date: dto.end_date ? new Date(dto.end_date) : null,
       state: 'draft',
       usage_count: 0,
     };
 
-    // Nested create for product associations
-    if (product_ids?.length) {
+    // Nested create for product associations (only when scope === 'product')
+    if (normalizedProductIds.length) {
       data.promotion_products = {
-        create: product_ids.map((product_id) => ({ product_id })),
+        create: normalizedProductIds.map((product_id) => ({ product_id })),
       };
     }
 
-    // Nested create for category associations
-    if (category_ids?.length) {
+    // Nested create for category associations (only when scope === 'category')
+    if (normalizedCategoryIds.length) {
       data.promotion_categories = {
-        create: category_ids.map((category_id) => ({ category_id })),
+        create: normalizedCategoryIds.map((category_id) => ({ category_id })),
       };
     }
 
@@ -208,28 +217,53 @@ export class PromotionsService {
     }
 
     const { product_ids, category_ids, ...updateData } = dto;
+    const effectiveScope = (dto.scope || existing.scope) as
+      | 'order'
+      | 'product'
+      | 'category';
+
+    // Resolve effective ID arrays after merging with existing values.
+    const mergedProductIds =
+      product_ids ?? existing.promotion_products.map((pp) => pp.product_id);
+    const mergedCategoryIds =
+      category_ids ?? existing.promotion_categories.map((pc) => pc.category_id);
+
+    // Normalize: ignore IDs that do not belong to the effective scope.
+    const normalizedProductIds =
+      effectiveScope === 'product' ? this.sanitizeIds(mergedProductIds) : [];
+    const normalizedCategoryIds =
+      effectiveScope === 'category' ? this.sanitizeIds(mergedCategoryIds) : [];
+
     this.validateScopeSelection(
-      dto.scope || existing.scope,
-      product_ids ?? existing.promotion_products.map((pp) => pp.product_id),
-      category_ids ?? existing.promotion_categories.map((pc) => pc.category_id),
+      effectiveScope,
+      normalizedProductIds,
+      normalizedCategoryIds,
     );
 
     // Prepare date conversions
     const data: any = { ...updateData };
+    if (dto.scope) data.scope = effectiveScope;
     if (dto.start_date) data.start_date = new Date(dto.start_date);
     if (dto.end_date !== undefined) {
       data.end_date = dto.end_date ? new Date(dto.end_date) : null;
     }
 
+    // Decide whether to rewrite each association table.
+    // - If user sent the field explicitly, replace with normalized value.
+    // - If user changed scope away from product/category, clear the now-orphan IDs.
+    const shouldRewriteProducts =
+      product_ids !== undefined || effectiveScope !== 'product';
+    const shouldRewriteCategories =
+      category_ids !== undefined || effectiveScope !== 'category';
+
     return this.prisma.$transaction(async (tx) => {
-      // Replace product associations if provided
-      if (product_ids !== undefined) {
+      if (shouldRewriteProducts) {
         await tx.promotion_products.deleteMany({
           where: { promotion_id: id },
         });
-        if (product_ids.length) {
+        if (normalizedProductIds.length) {
           await tx.promotion_products.createMany({
-            data: product_ids.map((product_id) => ({
+            data: normalizedProductIds.map((product_id) => ({
               promotion_id: id,
               product_id,
             })),
@@ -237,14 +271,13 @@ export class PromotionsService {
         }
       }
 
-      // Replace category associations if provided
-      if (category_ids !== undefined) {
+      if (shouldRewriteCategories) {
         await tx.promotion_categories.deleteMany({
           where: { promotion_id: id },
         });
-        if (category_ids.length) {
+        if (normalizedCategoryIds.length) {
           await tx.promotion_categories.createMany({
-            data: category_ids.map((category_id) => ({
+            data: normalizedCategoryIds.map((category_id) => ({
               promotion_id: id,
               category_id,
             })),
@@ -357,5 +390,33 @@ export class PromotionsService {
         'Selecciona al menos una categoria para esta promocion',
       );
     }
+
+    if (scope !== 'product' && scope !== 'category' && scope !== 'order') {
+      throw new VendixHttpException(
+        ErrorCodes.SYS_VALIDATION_001,
+        'El alcance de la promocion no es valido',
+      );
+    }
+  }
+
+  /**
+   * Sanitize a list of incoming IDs:
+   * - drops null/undefined/NaN/<=0 entries
+   * - coerces numeric strings to numbers
+   * - removes duplicates preserving order
+   */
+  private sanitizeIds(ids?: Array<number | string | null | undefined>): number[] {
+    if (!Array.isArray(ids)) return [];
+    const seen = new Set<number>();
+    const out: number[] = [];
+    for (const raw of ids) {
+      const n = Number(raw);
+      if (!Number.isFinite(n) || n <= 0) continue;
+      const intVal = Math.trunc(n);
+      if (seen.has(intVal)) continue;
+      seen.add(intVal);
+      out.push(intVal);
+    }
+    return out;
   }
 }

--- a/apps/backend/src/domains/superadmin/help-center/help-center-admin.service.ts
+++ b/apps/backend/src/domains/superadmin/help-center/help-center-admin.service.ts
@@ -1,12 +1,9 @@
-import {
-  Injectable,
-  NotFoundException,
-  BadRequestException,
-} from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { GlobalPrismaService } from '../../../prisma/services/global-prisma.service';
 import { S3Service } from '../../../common/services/s3.service';
 import { S3PathHelper } from '../../../common/helpers/s3-path.helper';
 import { ImageContext } from '@common/config/image-presets';
+import { VendixHttpException, ErrorCodes } from '../../../common/errors';
 import {
   CreateArticleDto,
   UpdateArticleDto,
@@ -92,7 +89,7 @@ export class HelpCenterAdminService {
     });
 
     if (!article) {
-      throw new NotFoundException('Article not found');
+      throw new VendixHttpException(ErrorCodes.HELP_ARTICLE_NOT_FOUND);
     }
 
     return {
@@ -122,7 +119,7 @@ export class HelpCenterAdminService {
     );
 
     if (!category) {
-      throw new BadRequestException('Category not found');
+      throw new VendixHttpException(ErrorCodes.HELP_CATEGORY_NOT_FOUND);
     }
 
     // Sanitize cover_image_url before storage
@@ -168,7 +165,7 @@ export class HelpCenterAdminService {
     });
 
     if (!article) {
-      throw new NotFoundException('Article not found');
+      throw new VendixHttpException(ErrorCodes.HELP_ARTICLE_NOT_FOUND);
     }
 
     // If title changed, regenerate slug
@@ -188,7 +185,7 @@ export class HelpCenterAdminService {
           where: { id: dto.category_id },
         });
       if (!category) {
-        throw new BadRequestException('Category not found');
+        throw new VendixHttpException(ErrorCodes.HELP_CATEGORY_NOT_FOUND);
       }
     }
 
@@ -239,7 +236,7 @@ export class HelpCenterAdminService {
     });
 
     if (!article) {
-      throw new NotFoundException('Article not found');
+      throw new VendixHttpException(ErrorCodes.HELP_ARTICLE_NOT_FOUND);
     }
 
     await this.globalPrisma.help_articles.delete({ where: { id } });
@@ -311,7 +308,7 @@ export class HelpCenterAdminService {
     );
 
     if (!category) {
-      throw new NotFoundException('Category not found');
+      throw new VendixHttpException(ErrorCodes.HELP_CATEGORY_NOT_FOUND);
     }
 
     // If name changed, regenerate slug
@@ -350,13 +347,11 @@ export class HelpCenterAdminService {
     );
 
     if (!category) {
-      throw new NotFoundException('Category not found');
+      throw new VendixHttpException(ErrorCodes.HELP_CATEGORY_NOT_FOUND);
     }
 
     if (category._count.articles > 0) {
-      throw new BadRequestException(
-        'Cannot delete category with associated articles. Remove or reassign articles first.',
-      );
+      throw new VendixHttpException(ErrorCodes.HELP_CATEGORY_HAS_ARTICLES);
     }
 
     await this.globalPrisma.help_article_categories.delete({ where: { id } });
@@ -370,7 +365,7 @@ export class HelpCenterAdminService {
 
   async uploadArticleImage(file: Express.Multer.File) {
     if (!file) {
-      throw new BadRequestException('Image file is required');
+      throw new VendixHttpException(ErrorCodes.HELP_IMAGE_REQUIRED);
     }
 
     const allowedMimes = [
@@ -386,14 +381,12 @@ export class HelpCenterAdminService {
       'image/avif',
     ];
     if (!allowedMimes.includes(file.mimetype)) {
-      throw new BadRequestException(
-        'Only image files are allowed (JPEG, PNG, WebP, GIF, BMP, TIFF, SVG, HEIC, AVIF)',
-      );
+      throw new VendixHttpException(ErrorCodes.HELP_IMAGE_TYPE_INVALID);
     }
 
     const MAX_SIZE = 10 * 1024 * 1024; // 10MB
     if (file.size > MAX_SIZE) {
-      throw new BadRequestException('Image file must be smaller than 10MB');
+      throw new VendixHttpException(ErrorCodes.HELP_IMAGE_TOO_LARGE);
     }
 
     const path = this.s3PathHelper.buildHelpCenterPath();

--- a/apps/frontend/public/push-sw.js
+++ b/apps/frontend/public/push-sw.js
@@ -5,29 +5,45 @@
  * Anti-spam: tag 'vendix-latest' ensures only the most recent notification is shown.
  */
 
-self.addEventListener('push', (event) => {
-  const payload = event.data ? event.data.json() : { title: 'Vendix' };
+self.addEventListener("push", (event) => {
+  const payload = event.data ? event.data.json() : { title: "Vendix" };
 
   event.waitUntil(
-    self.registration.showNotification(payload.title || 'Vendix', {
-      body: payload.body || '',
-      icon: '/vlogo.png',
-      tag: 'vendix-latest',
+    self.registration.showNotification(payload.title || "Vendix", {
+      body: payload.body || "",
+      icon: "/vlogo.png",
+      tag: "vendix-latest",
       renotify: true,
       data: payload.data,
-    })
+    }),
   );
 });
 
-self.addEventListener('notificationclick', (event) => {
+self.addEventListener("notificationclick", (event) => {
   event.notification.close();
+  const route =
+    event.notification.data?.route || event.notification.data?.url || "/";
+  const target_url =
+    typeof route === "string" &&
+    route.startsWith("/") &&
+    !route.startsWith("//")
+      ? new URL(route, self.location.origin).href
+      : new URL("/", self.location.origin).href;
 
   event.waitUntil(
-    clients.matchAll({ type: 'window', includeUncontrolled: true }).then((client_list) => {
-      for (const client of client_list) {
-        if ('focus' in client) return client.focus();
-      }
-      return clients.openWindow('/');
-    })
+    clients
+      .matchAll({ type: "window", includeUncontrolled: true })
+      .then((client_list) => {
+        for (const client of client_list) {
+          if (new URL(client.url).origin !== self.location.origin) continue;
+          if ("navigate" in client && client.url !== target_url) {
+            return client.navigate(target_url).then((navigated_client) => {
+              return navigated_client?.focus();
+            });
+          }
+          if ("focus" in client) return client.focus();
+        }
+        return clients.openWindow(target_url);
+      }),
   );
 });

--- a/apps/frontend/src/app/core/utils/error-messages.ts
+++ b/apps/frontend/src/app/core/utils/error-messages.ts
@@ -18,6 +18,16 @@ export const ERROR_MESSAGES: Record<string, string> = {
   BRAND_DELETE_HAS_PRODUCTS:
     'Esta marca tiene productos asignados. Elimínala con la opción de desligar para conservar los productos sin esta marca.',
 
+  // Help Center
+  HELP_ARTICLE_NOT_FOUND: 'El artículo no fue encontrado.',
+  HELP_CATEGORY_NOT_FOUND: 'La categoría no fue encontrada.',
+  HELP_CATEGORY_HAS_ARTICLES:
+    'No se puede eliminar la categoría porque tiene artículos asociados. Reasigna o elimina los artículos primero.',
+  HELP_IMAGE_REQUIRED: 'Debes seleccionar una imagen.',
+  HELP_IMAGE_TYPE_INVALID:
+    'Tipo de imagen no soportado. Usa JPEG, PNG, WebP, GIF, BMP, TIFF, SVG, HEIC o AVIF.',
+  HELP_IMAGE_TOO_LARGE: 'La imagen supera el tamaño máximo permitido (10 MB).',
+
   // Uploads
   UPLOAD_FILE_001: 'Seleccione un archivo para subir.',
   UPLOAD_CONTEXT_001: 'Debe seleccionar una organizacion para subir archivos.',

--- a/apps/frontend/src/app/private/layouts/store-ecommerce/store-ecommerce-layout.component.ts
+++ b/apps/frontend/src/app/private/layouts/store-ecommerce/store-ecommerce-layout.component.ts
@@ -310,9 +310,13 @@ export class StoreEcommerceLayoutComponent {
     this.router.navigate(['/cart']);
   }
 
+  private previous_path: string | null = null;
+
   private shouldScrollToTopOnNavigation(url: string): boolean {
     const path = url.split(/[?#]/)[0].replace(/\/+$/, '') || '/';
-    return path === '/cart' || path === '/checkout';
+    const changed = path !== this.previous_path;
+    this.previous_path = path;
+    return changed;
   }
 
   private scrollToTop(): void {

--- a/apps/frontend/src/app/private/modules/ecommerce/components/product-card/product-card.component.ts
+++ b/apps/frontend/src/app/private/modules/ecommerce/components/product-card/product-card.component.ts
@@ -120,14 +120,14 @@ import { BadgeComponent } from '../../../../../shared/components/badge/badge.com
           }
           <div class="product-price">
             <span class="price" [class.sale-price]="hasActiveDiscount()">
-              {{ product().final_price | currency }}
+              {{ displayPrice() | currency }}
             </span>
             @if (product().pricing_type === 'weight') {
               <span class="weight-unit">/kg</span>
             }
             @if (hasActiveDiscount()) {
               <span class="original-price">{{ product().base_price | currency }}</span>
-              <span class="discount-badge">-{{ discountPercentage() }}% OFF</span>
+              <span class="discount-badge">{{ promotionBadgeLabel() }}</span>
             }
           </div>
         </div>
@@ -548,16 +548,36 @@ export class ProductCardComponent {
 
   hasActiveDiscount(): boolean {
     const product = this.product();
-    if (!product.is_on_sale) return false;
-
     const basePrice = Number(product.base_price) || 0;
     const promoPrice = this.promoPrice();
 
+    // An active backend-resolved promotion ALWAYS wins, regardless of the
+    // legacy `is_on_sale` flag. Without a promotion we still honour the
+    // existing sale_price flow.
+    if (product.active_promotion) {
+      return basePrice > 0 && promoPrice > 0 && promoPrice < basePrice;
+    }
+
+    if (!product.is_on_sale) return false;
     return basePrice > 0 && promoPrice > 0 && promoPrice < basePrice;
   }
 
   discountPercentage(): number {
-    const basePrice = Number(this.product().base_price) || 0;
+    const product = this.product();
+
+    // Prefer the engine-provided percentage when the promotion is
+    // percentage-typed; otherwise compute from prices for parity with the
+    // sale_price path.
+    if (
+      product.active_promotion?.type === 'percentage' &&
+      product.active_promotion.discount_percentage !== undefined
+    ) {
+      return Math.round(
+        Number(product.active_promotion.discount_percentage) || 0,
+      );
+    }
+
+    const basePrice = Number(product.base_price) || 0;
     const promoPrice = this.promoPrice();
 
     if (basePrice <= 0 || promoPrice <= 0 || promoPrice >= basePrice) return 0;
@@ -565,8 +585,44 @@ export class ProductCardComponent {
     return Math.round(((basePrice - promoPrice) / basePrice) * 100);
   }
 
+  promotionBadgeLabel(): string {
+    const promo = this.product().active_promotion;
+    return promo?.badge_label ?? `-${this.discountPercentage()}% OFF`;
+  }
+
+  /**
+   * Price shown front-and-center on the card. Falls back to the existing
+   * `final_price` (already tax-inclusive) when there is no promotional
+   * override so non-discounted products keep their previous layout.
+   */
+  displayPrice(): number {
+    const product = this.product();
+    const promo = product.active_promotion;
+    const promoPrice = promo ? Number(promo.promotional_price) : NaN;
+    if (Number.isFinite(promoPrice) && promoPrice > 0) {
+      return promoPrice;
+    }
+
+    // sale_price path retained for backward compatibility — only when the
+    // backend marks the product on sale and the sale price is lower.
+    const salePrice = Number(product.sale_price) || 0;
+    const basePrice = Number(product.base_price) || 0;
+    if (product.is_on_sale && salePrice > 0 && salePrice < basePrice) {
+      return Number(product.final_price);
+    }
+
+    return Number(product.final_price) || 0;
+  }
+
   private promoPrice(): number {
     const product = this.product();
+
+    // Backend-resolved promotion takes priority for the displayed final price.
+    const promotionalPrice = Number(product.active_promotion?.promotional_price);
+    if (Number.isFinite(promotionalPrice) && promotionalPrice > 0) {
+      return promotionalPrice;
+    }
+
     const salePrice = Number(product.sale_price) || 0;
     const finalPrice = Number(product.final_price) || 0;
 

--- a/apps/frontend/src/app/private/modules/ecommerce/pages/account/order-detail/order-detail.component.html
+++ b/apps/frontend/src/app/private/modules/ecommerce/pages/account/order-detail/order-detail.component.html
@@ -320,9 +320,43 @@
               <span>Subtotal</span>
               <span>{{ order.subtotal_amount | currency }}</span>
             </div>
+
+            <!-- Applied promotions (persisted snapshot) -->
+            @for (promo of appliedPromotions(); track promo.id) {
+              <div class="summary-row discount">
+                <span class="discount-label">
+                  <app-icon name="tag" [size]="14"></app-icon>
+                  <span>
+                    {{ promo.name }}
+                    @if (promo.code) {
+                      <small>({{ promo.code }})</small>
+                    }
+                  </span>
+                </span>
+                <span>-{{ promo.discount_amount | currency }}</span>
+              </div>
+            }
+
+            <!-- Applied coupons (persisted snapshot) -->
+            @for (cp of appliedCoupons(); track cp.id) {
+              <div class="summary-row discount">
+                <span class="discount-label">
+                  <app-icon name="ticket" [size]="14"></app-icon>
+                  <span>
+                    Cupón <strong>{{ cp.code }}</strong>
+                    @if (cp.name) {
+                      <small>— {{ cp.name }}</small>
+                    }
+                  </span>
+                </span>
+                <span>-{{ cp.discount_applied | currency }}</span>
+              </div>
+            }
+
+            <!-- Total discount (legacy/fallback or aggregated) -->
             @if (order.discount_amount > 0) {
               <div class="summary-row discount">
-                <span>Descuento</span>
+                <span>Descuento total</span>
                 <span>-{{ order.discount_amount | currency }}</span>
               </div>
             }

--- a/apps/frontend/src/app/private/modules/ecommerce/pages/account/order-detail/order-detail.component.ts
+++ b/apps/frontend/src/app/private/modules/ecommerce/pages/account/order-detail/order-detail.component.ts
@@ -114,6 +114,26 @@ export class OrderDetailComponent implements OnInit, OnDestroy {
     };
   });
 
+  // ── Discount snapshots (read-only from order; never recalculated) ──
+  readonly appliedPromotions = computed(() =>
+    (this.order()?.applied_promotions ?? []).map((p) => ({
+      ...p,
+      discount_amount: Number(p.discount_amount || 0),
+    })),
+  );
+
+  readonly appliedCoupons = computed(() =>
+    (this.order()?.applied_coupons ?? []).map((c) => ({
+      ...c,
+      discount_applied: Number(c.discount_applied || 0),
+    })),
+  );
+
+  readonly hasDiscountSnapshot = computed(
+    () =>
+      this.appliedPromotions().length > 0 || this.appliedCoupons().length > 0,
+  );
+
   readonly orderTimelineSteps = computed(() => {
     const o = this.order();
     if (!o) return [];

--- a/apps/frontend/src/app/private/modules/ecommerce/pages/cart/cart.component.ts
+++ b/apps/frontend/src/app/private/modules/ecommerce/pages/cart/cart.component.ts
@@ -292,7 +292,16 @@ export class CartComponent implements OnInit {
     }));
 
     this.checkoutService
-      .whatsappCheckout(undefined, items, this.toGuestCustomer(data), null)
+      .whatsappCheckout(
+        undefined,
+        items,
+        this.toGuestCustomer(data),
+        null,
+        // Cart page doesn't currently expose a coupon input — leave it
+        // null so the backend computes only automatic promotional
+        // discounts. Coupon entry lives on the checkout page.
+        null,
+      )
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (response) => {

--- a/apps/frontend/src/app/private/modules/ecommerce/pages/checkout/checkout.component.html
+++ b/apps/frontend/src/app/private/modules/ecommerce/pages/checkout/checkout.component.html
@@ -505,12 +505,35 @@
               </div>
             }
 
+            <div class="summary-coupon">
+              <label for="coupon-code">¿Tienes un cupón?</label>
+              <input
+                id="coupon-code"
+                type="text"
+                class="coupon-input"
+                placeholder="Código de cupón"
+                [value]="coupon_code()"
+                (input)="
+                  coupon_code.set(
+                    $any($event.target).value.toUpperCase().trim()
+                  )
+                "
+                autocomplete="off"
+              />
+              <small class="summary-coupon-hint">
+                El descuento se calcula al confirmar la compra.
+              </small>
+            </div>
+
             <hr />
 
             <div class="summary-row total">
-              <span>Total</span>
+              <span>Total estimado</span>
               <span>{{ cart()!.subtotal + shipping_cost | currency }}</span>
             </div>
+            <small class="summary-total-hint">
+              Las promociones automáticas y cupones se aplican al confirmar.
+            </small>
           }
         </div>
       </div>

--- a/apps/frontend/src/app/private/modules/ecommerce/pages/checkout/checkout.component.ts
+++ b/apps/frontend/src/app/private/modules/ecommerce/pages/checkout/checkout.component.ts
@@ -101,6 +101,11 @@ export class CheckoutComponent implements OnInit {
 
   address_form!: FormGroup;
   readonly notes = signal('');
+  /**
+   * Optional coupon code typed by the customer. We only send the raw string
+   * to the backend; totals are recomputed there. Empty string = no coupon.
+   */
+  readonly coupon_code = signal('');
 
   readonly etaPreview = signal<{
     readyAt: string;
@@ -905,6 +910,9 @@ export class CheckoutComponent implements OnInit {
         quantity: item.quantity,
       })),
       guest_customer: this.toGuestCustomer(this.guest_checkout_data),
+      // Send coupon code as raw string; backend validates and recomputes
+      // the total. Frontend never sends a precomputed grand_total.
+      coupon_code: this.coupon_code().trim() || undefined,
     };
 
     if (!this.cartHasOnlyServices && this.use_new_address()) {
@@ -950,8 +958,10 @@ export class CheckoutComponent implements OnInit {
             this.orderPlaced = true;
             const orderId = response.data.order_id;
             const publicOrderToken = response.data.public_order_token;
-            const totalAmount =
-              (this.cart()?.subtotal ?? 0) + this.shipping_cost;
+            // Use the backend-authoritative total returned in the order
+            // creation response — never recompute on the client because
+            // promotions + coupon discounts only exist server-side.
+            const totalAmount = Number(response.data.total);
 
             this.checkout_service
               .prepareWompiPayment(

--- a/apps/frontend/src/app/private/modules/ecommerce/services/account.service.ts
+++ b/apps/frontend/src/app/private/modules/ecommerce/services/account.service.ts
@@ -44,6 +44,29 @@ export interface Order {
   item_count: number;
 }
 
+export interface OrderAppliedPromotion {
+  id: number;
+  promotion_id: number;
+  name: string | null;
+  code: string | null;
+  type: string | null;
+  scope: string | null;
+  value: number | string | null;
+  discount_amount: number | string;
+  created_at: string | null;
+}
+
+export interface OrderAppliedCoupon {
+  id: number;
+  coupon_id: number;
+  code: string | null;
+  name: string | null;
+  discount_type: string | null;
+  discount_value: number | string | null;
+  discount_applied: number | string;
+  used_at: string | null;
+}
+
 export interface OrderDetail extends Order {
   subtotal_amount: number;
   discount_amount: number;
@@ -81,6 +104,9 @@ export interface OrderDetail extends Order {
     product_id: number;
     product_name: string;
   }[];
+  // Persisted discount snapshots — read-only, never recalculated client-side.
+  applied_promotions?: OrderAppliedPromotion[];
+  applied_coupons?: OrderAppliedCoupon[];
 }
 
 @Injectable({

--- a/apps/frontend/src/app/private/modules/ecommerce/services/catalog.service.ts
+++ b/apps/frontend/src/app/private/modules/ecommerce/services/catalog.service.ts
@@ -4,6 +4,24 @@ import { Observable } from 'rxjs';
 import { TenantFacade } from '../../../../core/store/tenant/tenant.facade';
 import { environment } from '../../../../../environments/environment';
 
+/**
+ * Promotional descriptor returned by the catalog endpoints for product
+ * cards. Mirrors backend `ActiveProductPromotion`. The card uses
+ * `promotional_price` + `badge_label` for the visual discount; the real
+ * discount is recomputed in backend at checkout.
+ */
+export interface ActiveProductPromotion {
+  id: number;
+  name: string;
+  type: 'percentage' | 'fixed_amount';
+  scope: 'product' | 'category';
+  discount_percentage?: number;
+  discount_amount?: number;
+  promotional_price: number;
+  badge_label: string;
+  priority: number;
+}
+
 export interface EcommerceProduct {
   id: number;
   name: string;
@@ -13,6 +31,7 @@ export interface EcommerceProduct {
   sale_price?: number;
   is_on_sale?: boolean;
   is_featured?: boolean;
+  active_promotion?: ActiveProductPromotion | null;
   sku: string | null;
   stock_quantity: number | null;
   track_inventory?: boolean;

--- a/apps/frontend/src/app/private/modules/ecommerce/services/checkout.service.ts
+++ b/apps/frontend/src/app/private/modules/ecommerce/services/checkout.service.ts
@@ -67,6 +67,12 @@ export interface CheckoutRequest {
     quantity: number;
   }>;
   guest_customer?: GuestCheckoutCustomer;
+  /**
+   * Optional coupon code typed by the customer. Backend validates against
+   * {@link CouponsService.validate} and rejects the checkout if invalid.
+   * The frontend NEVER sends precomputed totals.
+   */
+  coupon_code?: string;
 }
 
 export interface CheckoutResponse {
@@ -78,11 +84,25 @@ export interface CheckoutResponse {
   public_order_token?: string | null;
   invoice_data_token?: string | null;
   invoice_id?: number | null;
+  // Backend-authoritative totals — the frontend renders these instead of
+  // recomputing on its own to avoid drift.
+  subtotal?: number;
+  tax_amount?: number;
+  discount_amount?: number;
+  promotion_discount?: number;
+  coupon_discount?: number;
+  shipping_cost?: number;
 }
 
 export interface WhatsappCheckoutResponse extends CheckoutResponse {
   subtotal: number;
   tax: number;
+  // Detailed discount totals so the WhatsApp UI surfaces promos + coupons
+  // and the message can include the final price the customer will pay.
+  discount_amount?: number;
+  promotion_discount?: number;
+  coupon_discount?: number;
+  shipping_cost?: number;
   item_count: number;
   items: Array<{
     name: string;
@@ -234,6 +254,7 @@ export class CheckoutService {
     }>,
     guestCustomer?: GuestCheckoutCustomer | null,
     shippingAddress?: CheckoutShippingAddress | null,
+    couponCode?: string | null,
   ): Observable<{ success: boolean; data: WhatsappCheckoutResponse }> {
     return this.http.post<{ success: boolean; data: WhatsappCheckoutResponse }>(
       `${this.api_url}/whatsapp`,
@@ -242,6 +263,7 @@ export class CheckoutService {
         items,
         guest_customer: guestCustomer,
         shipping_address: shippingAddress,
+        coupon_code: couponCode || undefined,
       },
       { headers: this.getHeaders() },
     );

--- a/apps/frontend/src/app/private/modules/store/cash-registers/cash-registers.component.ts
+++ b/apps/frontend/src/app/private/modules/store/cash-registers/cash-registers.component.ts
@@ -38,6 +38,7 @@ import { PosSessionDetailModalComponent } from '../pos/components/pos-session-de
 import { CurrencyFormatService } from '../../../../shared/pipes/currency';
 import { LocationsService } from '../inventory/services/locations.service';
 import { InventoryLocation } from '../inventory/interfaces';
+import { extractApiErrorMessage } from '../../../../core/utils/api-error-handler';
 
 @Component({
   selector: 'app-cash-registers',
@@ -803,7 +804,7 @@ export class CashRegistersComponent {
           this.is_loading_registers.set(false);
         },
         error: (error: any) => {
-          this.toast_service.error('Error al cargar cajas: ' + error.message);
+          this.toast_service.error(extractApiErrorMessage(error));
           this.registers.set([]);
           this.is_loading_registers.set(false);
         },
@@ -821,9 +822,7 @@ export class CashRegistersComponent {
           this.is_loading_sessions.set(false);
         },
         error: (error: any) => {
-          this.toast_service.error(
-            'Error al cargar sesiones: ' + error.message,
-          );
+          this.toast_service.error(extractApiErrorMessage(error));
           this.sessions.set([]);
           this.is_loading_sessions.set(false);
         },
@@ -899,9 +898,7 @@ export class CashRegistersComponent {
       },
       error: (err: any) => {
         this.is_saving_register.set(false);
-        this.toast_service.error(
-          err.error?.message || 'Error al guardar la caja',
-        );
+        this.toast_service.error(extractApiErrorMessage(err));
       },
     });
   }
@@ -926,9 +923,7 @@ export class CashRegistersComponent {
                 this.loadRegisters();
               },
               error: (err: any) => {
-                this.toast_service.error(
-                  err.error?.message || 'Error al desactivar la caja',
-                );
+                this.toast_service.error(extractApiErrorMessage(err));
               },
             });
         }

--- a/apps/frontend/src/app/private/modules/store/customers/components/customer-list/customer-list.component.ts
+++ b/apps/frontend/src/app/private/modules/store/customers/components/customer-list/customer-list.component.ts
@@ -24,6 +24,7 @@ import {
 } from '../../../../../../shared/components';
 import { Customer } from '../../models/customer.model';
 import { CurrencyFormatService } from '../../../../../../shared/pipes/currency';
+import { getDocumentTypeLabel } from '../../../../../../shared/constants/document-types';
 
 @Component({
   selector: 'app-customer-list',
@@ -39,7 +40,7 @@ import { CurrencyFormatService } from '../../../../../../shared/pipes/currency';
     PaginationComponent,
   ],
   template: `
-    <!-- Customer List Container - Mobile First -->
+    <!-- Contenedor de lista de clientes - Mobile First -->
     <app-card [responsive]="true" [padding]="false" overflow="visible">
       <!-- Search Section: sticky below stats on mobile -->
       <div
@@ -78,7 +79,7 @@ import { CurrencyFormatService } from '../../../../../../shared/pipes/currency';
         </div>
       </div>
 
-      <!-- Loading State -->
+      <!-- Estado de carga -->
       @if (loading()) {
         <div class="p-6 text-center">
           <div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
@@ -86,7 +87,7 @@ import { CurrencyFormatService } from '../../../../../../shared/pipes/currency';
         </div>
       }
 
-      <!-- Empty State -->
+      <!-- Estado vacío -->
       @if (!loading() && customers().length === 0) {
         <div class="p-12 text-center text-gray-500">
           <app-icon name="users" [size]="48" class="mx-auto mb-4 text-gray-300"></app-icon>
@@ -112,7 +113,7 @@ import { CurrencyFormatService } from '../../../../../../shared/pipes/currency';
             [loading]="loading()"
             [hoverable]="true"
             [striped]="true"
-            [emptyMessage]="'No se encontraron clientes'"
+            [emptyMessage]="'No hay clientes para mostrar'"
             [emptyIcon]="'users'"
             tableSize="md"
           ></app-responsive-data-view>
@@ -192,15 +193,59 @@ export class CustomerListComponent {
   ];
 
   columns: TableColumn[] = [
-    { key: 'first_name', label: 'Nombre', sortable: true, priority: 1 },
-    { key: 'last_name', label: 'Apellido', sortable: true, priority: 1 },
-    { key: 'email', label: 'Correo', sortable: true, priority: 2 },
-    { key: 'phone', label: 'Teléfono', priority: 3 },
-    { key: 'document_number', label: 'Número de ID', priority: 2 },
+    {
+      key: 'first_name',
+      label: 'Cliente',
+      sortable: true,
+      priority: 1,
+      transform: (_val: any, row?: any) => {
+        const parts = [row?.first_name, row?.last_name].filter(Boolean);
+        return parts.length > 0 ? parts.join(' ') : '-';
+      },
+    },
+    {
+      key: 'document_number',
+      label: 'Documento',
+      priority: 2,
+      transform: (_val: any, row?: any) => {
+        const docNumber = row?.document_number;
+        const docType = row?.document_type;
+        if (!docNumber) return 'Sin documento';
+        return docType ? `${getDocumentTypeLabel(docType)} ${docNumber}` : docNumber;
+      },
+    },
+    {
+      key: 'email',
+      label: 'Correo',
+      sortable: true,
+      priority: 2,
+      transform: (val: any) => val || 'Sin correo',
+    },
+    {
+      key: 'phone',
+      label: 'Teléfono',
+      priority: 3,
+      transform: (val: any) => val || 'Sin teléfono',
+    },
     { key: 'total_orders', label: 'Pedidos', sortable: true, priority: 3 },
     {
+      key: 'last_order_date',
+      label: 'Última compra',
+      sortable: true,
+      priority: 3,
+      transform: (val: any) => (val ? new Date(val).toLocaleDateString() : 'Nunca'),
+    },
+    {
+      key: 'state',
+      label: 'Estado',
+      priority: 2,
+      badge: true,
+      badgeConfig: { type: 'status', size: 'sm' },
+      badgeTransform: (v: any) => (v === 'active' ? 'Activo' : 'Inactivo'),
+    },
+    {
       key: 'created_at',
-      label: 'Unido',
+      label: 'Registrado',
       sortable: true,
       priority: 3,
       transform: (val: any) => (val ? new Date(val).toLocaleDateString() : '-'),
@@ -209,17 +254,41 @@ export class CustomerListComponent {
 
   cardConfig: ItemListCardConfig = {
     titleKey: 'first_name',
-    titleTransform: (item: any) => `${item.first_name} ${item.last_name}`,
+    titleTransform: (item: any) => {
+      const parts = [item?.first_name, item?.last_name].filter(Boolean);
+      return parts.length > 0 ? parts.join(' ') : '-';
+    },
     subtitleKey: 'email',
+    subtitleTransform: (item: any) => item?.email || 'Sin correo',
     avatarFallbackIcon: 'user',
     avatarShape: 'circle',
     badgeKey: 'state',
     badgeConfig: { type: 'status', size: 'sm' },
     badgeTransform: (v: any) => (v === 'active' ? 'Activo' : 'Inactivo'),
     detailKeys: [
-      { key: 'phone', label: 'Teléfono', icon: 'phone' },
-      { key: 'document_number', label: 'Documento', icon: 'credit-card' },
+      {
+        key: 'phone',
+        label: 'Teléfono',
+        icon: 'phone',
+        transform: (v: any) => v || 'Sin teléfono',
+      },
+      {
+        key: 'document_number',
+        label: 'Documento',
+        icon: 'credit-card',
+        transform: (_v: any, item?: any) => {
+          const docNumber = item?.document_number;
+          const docType = item?.document_type;
+          if (!docNumber) return 'Sin documento';
+          return docType ? `${getDocumentTypeLabel(docType)} ${docNumber}` : docNumber;
+        },
+      },
       { key: 'total_orders', label: 'Pedidos' },
+      {
+        key: 'last_order_date',
+        label: 'Última compra',
+        transform: (v: any) => (v ? new Date(v).toLocaleDateString() : 'Nunca'),
+      },
       {
         key: 'created_at',
         label: 'Registrado',
@@ -235,18 +304,21 @@ export class CustomerListComponent {
   actions: TableAction[] = [
     {
       label: 'Ver',
+      tooltip: 'Ver detalle',
       icon: 'eye',
       variant: 'secondary',
       action: (row: any) => this.viewDetail.emit(row),
     },
     {
       label: 'Editar',
+      tooltip: 'Editar',
       icon: 'edit',
       variant: 'info',
       action: (row: any) => this.edit.emit(row),
     },
     {
       label: 'Eliminar',
+      tooltip: 'Eliminar',
       icon: 'trash-2',
       variant: 'danger',
       action: (row: any) => this.delete.emit(row),

--- a/apps/frontend/src/app/private/modules/store/customers/components/customer-modal/customer-modal.component.ts
+++ b/apps/frontend/src/app/private/modules/store/customers/components/customer-modal/customer-modal.component.ts
@@ -1,4 +1,5 @@
 import { Component, inject, input, output, effect, signal, computed } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
 import {
   ModalComponent,
@@ -6,7 +7,16 @@ import {
   InputComponent,
   SelectorComponent,
 } from '../../../../../../shared/components';
+import {
+  DOCUMENT_TYPES,
+  findDocumentType,
+  DocumentTypeOption,
+} from '../../../../../../shared/constants/document-types';
 import { Customer, CreateCustomerRequest } from '../../models/customer.model';
+
+// Re-export del traductor centralizado para compatibilidad con consumidores
+// que importaban `translateCustomerError` desde este archivo.
+export { translateCustomerError } from '../../utils/customer-error.translator';
 
 @Component({
   selector: 'app-customer-modal',
@@ -16,7 +26,7 @@ import { Customer, CreateCustomerRequest } from '../../models/customer.model';
     ModalComponent,
     ButtonComponent,
     InputComponent,
-    SelectorComponent
+    SelectorComponent,
   ],
   template: `
     <app-modal
@@ -24,15 +34,15 @@ import { Customer, CreateCustomerRequest } from '../../models/customer.model';
       (isOpenChange)="isOpenChange.emit($event)"
       (cancel)="onCancel()"
       [size]="'md'"
-      [title]="customer() ? 'Editar cliente' : 'Nuevo cliente'"
+      [title]="modalTitle()"
       subtitle="Administra la información del cliente"
     >
       <form [formGroup]="form" class="space-y-4">
         <!-- Email -->
         <app-input
           formControlName="email"
-          label="Email"
-          placeholder="john.doe@example.com"
+          label="Correo electrónico *"
+          placeholder="cliente@ejemplo.com"
           type="email"
           [required]="true"
           [error]="getFieldError('email')"
@@ -44,8 +54,8 @@ import { Customer, CreateCustomerRequest } from '../../models/customer.model';
         <div class="grid grid-cols-2 gap-4">
           <app-input
             formControlName="first_name"
-            label="Nombre"
-            placeholder="John"
+            label="Nombre *"
+            placeholder="Ej. María"
             [required]="true"
             [error]="getFieldError('first_name')"
             (blur)="onFieldBlur('first_name')"
@@ -54,8 +64,8 @@ import { Customer, CreateCustomerRequest } from '../../models/customer.model';
 
           <app-input
             formControlName="last_name"
-            label="Apellido"
-            placeholder="Rodriguez"
+            label="Apellido *"
+            placeholder="Ej. Rodríguez"
             [required]="true"
             [error]="getFieldError('last_name')"
             (blur)="onFieldBlur('last_name')"
@@ -68,7 +78,7 @@ import { Customer, CreateCustomerRequest } from '../../models/customer.model';
           formControlName="phone"
           label="Teléfono"
           type="tel"
-          placeholder="+57 300 567 8900"
+          placeholder="+57 300 000 0000"
           [error]="getFieldError('phone')"
           (blur)="onFieldBlur('phone')"
           customWrapperClass="mt-0"
@@ -78,15 +88,15 @@ import { Customer, CreateCustomerRequest } from '../../models/customer.model';
         <div class="grid grid-cols-2 gap-4">
           <app-selector
             formControlName="document_type"
-            label="Tipo documento"
-            placeholder="Seleccionar tipo"
-            [options]="documentTypes"
+            label="Tipo de documento"
+            placeholder="Selecciona un tipo"
+            [options]="documentTypeOptions"
           ></app-selector>
 
           <app-input
             formControlName="document_number"
-            label="Nº documento"
-            placeholder="12345678"
+            label="Número de documento"
+            [placeholder]="documentNumberPlaceholder()"
             [error]="getFieldError('document_number')"
             (blur)="onFieldBlur('document_number')"
             customWrapperClass="mt-0"
@@ -103,11 +113,11 @@ import { Customer, CreateCustomerRequest } from '../../models/customer.model';
           [loading]="loading()"
           (clicked)="onSubmit()"
         >
-          {{ customer() ? 'Actualizar' : 'Crear' }}
+          {{ submitLabel() }}
         </app-button>
       </div>
     </app-modal>
-  `
+  `,
 })
 export class CustomerModalComponent {
   private fb = inject(FormBuilder);
@@ -123,11 +133,32 @@ export class CustomerModalComponent {
 
   form: FormGroup;
 
-  documentTypes = [
-    { value: 'DNI', label: 'DNI' },
-    { value: 'PASSPORT', label: 'Passport' },
-    { value: 'LICENSE', label: 'Driver License' }
-  ];
+  /** Opciones (catalog -> SelectorOption shape: value/label). */
+  readonly documentTypeOptions = DOCUMENT_TYPES.map((opt) => ({
+    value: opt.code,
+    label: opt.label,
+  }));
+
+  /** Acceso al catálogo completo si se necesita (placeholder, regex, etc). */
+  readonly documentTypes: ReadonlyArray<DocumentTypeOption> = DOCUMENT_TYPES;
+
+  /** Tipo de documento seleccionado (reactivo a cambios del FormControl). */
+  readonly selectedDocumentType = signal<DocumentTypeOption | undefined>(undefined);
+
+  /** Placeholder dinámico para el input de número de documento. */
+  readonly documentNumberPlaceholder = computed(() => {
+    const type = this.selectedDocumentType();
+    return type?.placeholder ?? 'Selecciona primero el tipo';
+  });
+
+  /** Título del modal según modo crear/editar. */
+  readonly isEditMode = computed(() => this.customer() !== null);
+  readonly modalTitle = computed(() =>
+    this.isEditMode() ? 'Editar cliente' : 'Crear cliente',
+  );
+  readonly submitLabel = computed(() =>
+    this.isEditMode() ? 'Guardar cambios' : 'Crear cliente',
+  );
 
   constructor() {
     this.form = this.fb.group({
@@ -136,10 +167,43 @@ export class CustomerModalComponent {
       last_name: ['', [Validators.required, Validators.minLength(2)]],
       phone: [''],
       document_type: [''],
-      document_number: ['']
+      document_number: [''],
     });
 
-    // Reemplaza ngOnChanges para customer y isOpen
+    // Bridge document_type valueChanges -> signal (Zoneless-safe reactive read).
+    const documentTypeControl = this.form.controls['document_type'];
+    const documentTypeValue = toSignal(documentTypeControl.valueChanges, {
+      initialValue: documentTypeControl.value as string | null,
+    });
+
+    // Mantener `selectedDocumentType` sincronizado con el FormControl.
+    effect(() => {
+      const code = documentTypeValue();
+      this.selectedDocumentType.set(findDocumentType(code));
+    });
+
+    // Validadores dinámicos del número de documento según el tipo elegido.
+    effect(() => {
+      const ctrl = this.form.controls['document_number'];
+      const type = this.selectedDocumentType();
+      if (type) {
+        ctrl.setValidators([
+          Validators.pattern(type.regex),
+          Validators.maxLength(type.maxLength),
+        ]);
+        if (ctrl.disabled) {
+          ctrl.enable({ emitEvent: false });
+        }
+      } else {
+        ctrl.clearValidators();
+        if (!ctrl.disabled) {
+          ctrl.disable({ emitEvent: false });
+        }
+      }
+      ctrl.updateValueAndValidity({ emitEvent: false });
+    });
+
+    // Reemplaza ngOnChanges para customer y isOpen.
     effect(() => {
       const customer = this.customer();
       if (customer) {
@@ -149,7 +213,7 @@ export class CustomerModalComponent {
           last_name: customer.last_name,
           phone: customer.phone,
           document_type: customer.document_type,
-          document_number: customer.document_number
+          document_number: customer.document_number,
         });
       }
     });
@@ -173,7 +237,10 @@ export class CustomerModalComponent {
 
   onSubmit() {
     if (this.form.valid) {
-      this.save.emit(this.form.value);
+      // `getRawValue()` para incluir controles deshabilitados (document_number
+      // se deshabilita cuando no hay tipo seleccionado, pero igual queremos
+      // emitir el valor actual del formulario).
+      this.save.emit(this.form.getRawValue() as CreateCustomerRequest);
     } else {
       this.form.markAllAsTouched();
     }
@@ -181,11 +248,51 @@ export class CustomerModalComponent {
 
   getFieldError(field: string): string {
     const control = this.form.get(field);
-    if (control?.touched && control?.errors) {
-      if (control.errors['required']) return 'This field is required';
-      if (control.errors['email']) return 'Invalid email address';
-      if (control.errors['minlength']) return `Min length is ${control.errors['minlength'].requiredLength}`;
+    if (!control?.touched || !control?.errors) return '';
+
+    const errors = control.errors;
+
+    if (errors['required']) {
+      switch (field) {
+        case 'email':
+          return 'El correo es obligatorio';
+        case 'first_name':
+          return 'El nombre es obligatorio';
+        case 'last_name':
+          return 'El apellido es obligatorio';
+        default:
+          return 'Este campo es obligatorio';
+      }
     }
+
+    if (errors['email']) {
+      return 'Ingresa un correo válido';
+    }
+
+    if (errors['minlength']) {
+      switch (field) {
+        case 'first_name':
+          return 'El nombre debe tener al menos 2 caracteres';
+        case 'last_name':
+          return 'El apellido debe tener al menos 2 caracteres';
+        default:
+          return `Debe tener al menos ${errors['minlength'].requiredLength} caracteres`;
+      }
+    }
+
+    if (errors['maxlength']) {
+      const type = this.selectedDocumentType();
+      if (field === 'document_number' && type) {
+        return `Máximo ${type.maxLength} caracteres`;
+      }
+      return `Máximo ${errors['maxlength'].requiredLength} caracteres`;
+    }
+
+    if (errors['pattern'] && field === 'document_number') {
+      const type = this.selectedDocumentType();
+      return `Número de documento inválido para ${type?.label ?? 'el tipo seleccionado'}`;
+    }
+
     return '';
   }
 

--- a/apps/frontend/src/app/private/modules/store/customers/customers.component.ts
+++ b/apps/frontend/src/app/private/modules/store/customers/customers.component.ts
@@ -3,6 +3,7 @@ import { Router } from '@angular/router';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { finalize } from 'rxjs';
 import { CustomerListComponent, CustomerModalComponent, CustomerBulkUploadModalComponent } from './components';
+import { translateCustomerError } from './utils/customer-error.translator';
 import { StatsComponent } from '../../../../shared/components/stats/stats.component';
 import { CustomersService } from './services/customers.service';
 import {
@@ -14,7 +15,6 @@ import {
 import { ToastService, DialogService } from '../../../../shared/components';
 import { AuthFacade } from '../../../../core/store/auth/auth.facade';
 import { CurrencyFormatService } from '../../../../shared/pipes/currency';
-import { extractApiErrorMessage } from '../../../../core/utils/api-error-handler';
 
 @Component({
   selector: 'app-customers',
@@ -30,36 +30,36 @@ import { extractApiErrorMessage } from '../../../../core/utils/api-error-handler
       <!-- Stats Grid -->
       <div class="stats-container sticky top-0 z-20 bg-background md:static md:bg-transparent">
         <app-stats
-          title="Total de Clientes"
+          title="Total clientes"
           [value]="stats()?.total_customers || 0"
-          smallText="+12% vs last month"
+          smallText="+12% vs el mes pasado"
           iconName="users"
           iconBgColor="bg-primary/10"
           iconColor="text-primary"
         ></app-stats>
 
         <app-stats
-          title="Clientes Activos"
+          title="Clientes activos"
           [value]="stats()?.active_customers || 0"
-          smallText="+5% vs last month"
+          smallText="+5% vs el mes pasado"
           iconName="user-check"
           iconBgColor="bg-green-100"
           iconColor="text-green-600"
         ></app-stats>
 
         <app-stats
-          title="Nuevos Este Mes"
+          title="Nuevos este mes"
           [value]="stats()?.new_customers_this_month || 0"
-          smallText="+8% vs last month"
+          smallText="+8% vs el mes pasado"
           iconName="user-plus"
           iconBgColor="bg-blue-100"
           iconColor="text-blue-600"
         ></app-stats>
 
         <app-stats
-          title="Ingresos Totales"
+          title="Ingresos totales"
           [value]="formatRevenue(stats()?.total_revenue || 0)"
-          smallText="+15% vs last month"
+          smallText="+15% vs el mes pasado"
           iconName="dollar-sign"
           iconBgColor="bg-purple-100"
           iconColor="text-purple-600"
@@ -158,7 +158,7 @@ export class CustomersComponent {
         error: (error: any) => {
           console.error('Error loading stats:', error);
           this.toastService.error(
-            extractApiErrorMessage(error),
+            translateCustomerError(error, 'No se pudieron cargar las estadísticas'),
             'Error al cargar estadísticas',
           );
         },
@@ -180,7 +180,7 @@ export class CustomersComponent {
         },
         error: (error) => {
           this.toastService.error(
-            extractApiErrorMessage(error),
+            translateCustomerError(error, 'No se pudieron cargar los clientes'),
             'Error al cargar clientes',
           );
         },
@@ -231,7 +231,9 @@ export class CustomersComponent {
       .subscribe({
         next: () => {
           this.toastService.success(
-            `Cliente ${this.selectedCustomer() ? 'actualizado' : 'creado'} exitosamente`,
+            this.selectedCustomer()
+              ? 'Cliente actualizado correctamente'
+              : 'Cliente creado correctamente',
           );
           this.closeModal();
           this.loadCustomers();
@@ -240,8 +242,10 @@ export class CustomersComponent {
         error: (error) => {
           console.error('Error saving customer:', error);
           this.toastService.error(
-            extractApiErrorMessage(error),
-            `Error al ${this.selectedCustomer() ? 'actualizar' : 'crear'} cliente`,
+            translateCustomerError(error),
+            this.selectedCustomer()
+              ? 'Error al actualizar cliente'
+              : 'Error al crear cliente',
           );
         },
       });
@@ -258,10 +262,11 @@ export class CustomersComponent {
   onDelete(customer: Customer) {
     this.dialogService
       .confirm({
-        title: 'Eliminar Cliente',
-        message: `¿Estás seguro de que quieres eliminar ${customer.first_name} ${customer.last_name}?`,
+        title: '¿Eliminar cliente?',
+        message: `Esta acción no se puede deshacer. Se eliminará a ${customer.first_name} ${customer.last_name}.`,
         confirmVariant: 'danger',
         confirmText: 'Eliminar',
+        cancelText: 'Cancelar',
       })
       .then((confirmed) => {
         if (confirmed) {
@@ -276,7 +281,7 @@ export class CustomersComponent {
               },
               error: (error) => {
                 this.toastService.error(
-                  extractApiErrorMessage(error),
+                  translateCustomerError(error, 'No se pudo eliminar el cliente'),
                   'Error al eliminar cliente',
                 );
               },

--- a/apps/frontend/src/app/private/modules/store/customers/details/customer-details.component.ts
+++ b/apps/frontend/src/app/private/modules/store/customers/details/customer-details.component.ts
@@ -1,5 +1,4 @@
 import { Component, signal, computed, inject, DestroyRef } from '@angular/core';
-import { DatePipe } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
 import { HttpClient } from '@angular/common/http';
 import {
@@ -14,11 +13,10 @@ import { environment } from '../../../../../../environments/environment';
 import { CustomersService } from '../services/customers.service';
 import { MetadataFieldsService } from '../../data-collection/services/metadata-fields.service';
 import { CustomerHistoryService, ConsultationHistoryEntry } from '../services/customer-history.service';
-import {
-  CurrencyPipe,
-  CurrencyFormatService,
-} from '../../../../../../app/shared/pipes/currency';
-import { extractApiErrorMessage } from '../../../../../core/utils/api-error-handler';
+import { CurrencyPipe } from '../../../../../../app/shared/pipes/currency';
+import { translateCustomerError } from '../utils/customer-error.translator';
+import { getDocumentTypeLabel } from '../../../../../shared/constants/document-types';
+import { formatDateOnlyUTC } from '../../../../../shared/utils/date.util';
 import {
   CardComponent,
   ButtonComponent,
@@ -37,7 +35,6 @@ import { StickyHeaderComponent } from '../../../../../../app/shared/components/s
   imports: [
     FormsModule,
     ReactiveFormsModule,
-    DatePipe,
     CurrencyPipe,
     CardComponent,
     ButtonComponent,
@@ -113,28 +110,30 @@ import { StickyHeaderComponent } from '../../../../../../app/shared/components/s
               class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-4 pt-4"
               style="border-top: 1px solid var(--color-border)"
               >
-              @if (customer().document_number) {
-                <div class="flex flex-col gap-1">
-                  <span class="text-xs" style="color: var(--color-text-muted)">Documento</span>
-                  <span class="text-sm font-semibold" style="color: var(--color-text-primary)">
-                    {{ customer().document_type || 'CC' }} {{ customer().document_number }}
-                  </span>
-                </div>
-              }
+              <div class="flex flex-col gap-1">
+                <span class="text-xs" style="color: var(--color-text-muted)">Documento</span>
+                <span class="text-sm font-semibold" style="color: var(--color-text-primary)">
+                  @if (customer().document_number) {
+                    {{ getDocumentLabel(customer().document_type) }} {{ customer().document_number }}
+                  } @else {
+                    Sin documento
+                  }
+                </span>
+              </div>
               <div class="flex flex-col gap-1">
                 <span class="text-xs" style="color: var(--color-text-muted)">Cliente desde</span>
                 <span class="text-sm font-semibold" style="color: var(--color-text-primary)">
-                  {{ customer().created_at | date:'mediumDate' }}
+                  {{ formatDate(customer().created_at) }}
                 </span>
               </div>
               <div class="flex flex-col gap-1">
                 <span class="text-xs" style="color: var(--color-text-muted)">Última compra</span>
                 <span class="text-sm font-semibold" style="color: var(--color-text-primary)">
-                  {{ customer().last_order_date ? (customer().last_order_date | date:'mediumDate') : 'Sin compras' }}
+                  {{ customer().last_order_date ? formatDate(customer().last_order_date) : 'Sin compras' }}
                 </span>
               </div>
               <div class="flex flex-col gap-1">
-                <span class="text-xs" style="color: var(--color-text-muted)">Órdenes</span>
+                <span class="text-xs" style="color: var(--color-text-muted)">Pedidos</span>
                 <span class="text-sm font-semibold" style="color: var(--color-text-primary)">
                   {{ customer().total_orders || 0 }}
                 </span>
@@ -220,11 +219,11 @@ import { StickyHeaderComponent } from '../../../../../../app/shared/components/s
                     <span class="text-xs px-2 py-0.5 rounded-full flex-shrink-0"
                       [style.background]="entry.status === 'completed' ? '#dcfce7' : entry.status === 'confirmed' ? '#dbeafe' : '#fee2e2'"
                       [style.color]="entry.status === 'completed' ? '#166534' : entry.status === 'confirmed' ? '#1e40af' : '#991b1b'">
-                      {{ entry.status }}
+                      {{ getBookingStatusLabel(entry.status) }}
                     </span>
                   </div>
                   <div class="text-xs mt-1" style="color: var(--color-text-muted)">
-                    {{ entry.date | date:'mediumDate' }} · {{ entry.start_time }}
+                    {{ formatDate(entry.date) }} · {{ entry.start_time }}
                     @if (entry.provider) { · {{ entry.provider.display_name }} }
                     </div>
                     <div class="flex gap-2 mt-1.5 flex-wrap">
@@ -264,7 +263,7 @@ import { StickyHeaderComponent } from '../../../../../../app/shared/components/s
                     class="text-lg font-bold"
                     style="color: var(--color-text-primary)"
                     >
-                    Wallet
+                    Billetera
                   </h3>
                 </div>
                 @if (wallet()) {
@@ -345,7 +344,7 @@ import { StickyHeaderComponent } from '../../../../../../app/shared/components/s
                               <span
                                 class="text-xs block"
                                 style="color: var(--color-text-muted)"
-                                >Balance total</span
+                                >Saldo total</span
                                 >
                                 <span
                                   class="text-xl font-bold"
@@ -367,7 +366,7 @@ import { StickyHeaderComponent } from '../../../../../../app/shared/components/s
                                     class="font-semibold mb-3"
                                     style="color: var(--color-text-primary)"
                                     >
-                                    Recargar Wallet
+                                    Recargar saldo
                                   </h4>
                                   <form [formGroup]="topUpForm" (ngSubmit)="topUpWallet()">
                                     <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
@@ -430,7 +429,7 @@ import { StickyHeaderComponent } from '../../../../../../app/shared/components/s
                                       style="background: var(--color-background); border: 1px solid var(--color-border);"
                                       >
                                       <h4 class="font-semibold mb-3" style="color: var(--color-text-primary)">
-                                        Ajustar Wallet
+                                        Ajustar saldo
                                       </h4>
                                       <form [formGroup]="adjustForm" (ngSubmit)="adjustWallet()">
                                         <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
@@ -556,7 +555,7 @@ import { StickyHeaderComponent } from '../../../../../../app/shared/components/s
                                       @if (walletHistory().length === 0) {
                                         <app-empty-state
                                           icon="inbox"
-                                          message="No hay movimientos aún"
+                                          message="Sin movimientos en la billetera"
                                         ></app-empty-state>
                                       }
                                       @if (walletHistory().length > 0) {
@@ -622,7 +621,7 @@ import { StickyHeaderComponent } from '../../../../../../app/shared/components/s
                                                   class="text-xs"
                                                   style="color: var(--color-text-muted)"
                                                   >
-                                                  {{ tx.created_at | date : 'short' }}
+                                                  {{ formatDateTime(tx.created_at) }}
                                                 </p>
                                               </div>
                                             </div>
@@ -653,14 +652,14 @@ import { StickyHeaderComponent } from '../../../../../../app/shared/components/s
                                   >
                                   <app-empty-state
                                     icon="wallet"
-                                    message="Este cliente no tiene wallet aún."
+                                    message="Este cliente aún no tiene billetera."
                                   ></app-empty-state>
                                   <app-button
                                     variant="primary"
                                     size="sm"
                                     class="mt-3"
                                     (clicked)="createAndLoadWallet()"
-                                    >Crear Wallet</app-button
+                                    >Crear billetera</app-button
                                     >
                                   </div>
                                 }
@@ -780,7 +779,9 @@ export class CustomerDetailsComponent {
         },
         error: (err) => {
           this.loadingCustomer.set(false);
-          this.errorMessage.set(extractApiErrorMessage(err));
+          this.errorMessage.set(
+            translateCustomerError(err, 'No se pudo cargar el cliente'),
+          );
         },
       });
   }
@@ -799,7 +800,9 @@ export class CustomerDetailsComponent {
         error: (err) => {
           this.wallet.set(null);
           this.loadingWallet.set(false);
-          this.walletError.set(extractApiErrorMessage(err));
+          this.walletError.set(
+            translateCustomerError(err, 'No se pudo cargar el saldo'),
+          );
         },
       });
   }
@@ -855,7 +858,9 @@ export class CustomerDetailsComponent {
         },
         error: (err) => {
           this.topUpLoading.set(false);
-          this.topUpError.set(extractApiErrorMessage(err));
+          this.topUpError.set(
+            translateCustomerError(err, 'No se pudo recargar el saldo'),
+          );
         },
       });
   }
@@ -894,6 +899,46 @@ export class CustomerDetailsComponent {
     return labels[type] || type;
   }
 
+  getBookingStatusLabel(status: string): string {
+    const labels: Record<string, string> = {
+      pending: 'Pendiente',
+      confirmed: 'Confirmada',
+      completed: 'Completada',
+      cancelled: 'Cancelada',
+      no_show: 'No asistió',
+      in_progress: 'En curso',
+    };
+    return labels[status] || status;
+  }
+
+  getDocumentLabel(code: string | null | undefined): string {
+    return getDocumentTypeLabel(code);
+  }
+
+  formatDate(value: string | Date | null | undefined): string {
+    if (!value) return '';
+    try {
+      return formatDateOnlyUTC(value);
+    } catch {
+      return String(value);
+    }
+  }
+
+  formatDateTime(value: string | Date | null | undefined): string {
+    if (!value) return '';
+    try {
+      return new Date(value).toLocaleString('es-CO', {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+    } catch {
+      return String(value);
+    }
+  }
+
   adjustWallet(): void {
     if (!this.adjustForm.valid || !this.customerId()) return;
     this.adjustLoading.set(true);
@@ -916,7 +961,9 @@ export class CustomerDetailsComponent {
         },
         error: (err) => {
           this.adjustLoading.set(false);
-          this.adjustError.set(extractApiErrorMessage(err));
+          this.adjustError.set(
+            translateCustomerError(err, 'No se pudo ajustar el saldo'),
+          );
         },
       });
   }

--- a/apps/frontend/src/app/private/modules/store/customers/reviews/reviews.component.ts
+++ b/apps/frontend/src/app/private/modules/store/customers/reviews/reviews.component.ts
@@ -1,7 +1,8 @@
 import { Component, inject, signal, DestroyRef } from '@angular/core';
-import { DecimalPipe, DatePipe } from '@angular/common';
+import { DecimalPipe } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, Router } from '@angular/router';
 
 import { AdminReviewsService } from './services/reviews.service';
 import { Review, ReviewStats, ReviewFilters } from './models/review.model';
@@ -23,14 +24,14 @@ import {
 import { PaginationComponent } from '../../../../../shared/components/pagination/pagination.component';
 import { IconComponent } from '../../../../../shared/components/icon/icon.component';
 import { ModalComponent } from '../../../../../shared/components/modal/modal.component';
-import { extractApiErrorMessage } from '../../../../../core/utils/api-error-handler';
+import { translateCustomerError } from '../utils/customer-error.translator';
+import { formatDateOnlyUTC } from '../../../../../shared/utils/date.util';
 
 @Component({
   selector: 'app-reviews',
   standalone: true,
   imports: [
     DecimalPipe,
-    DatePipe,
     FormsModule,
     StatsComponent,
     CardComponent,
@@ -66,7 +67,7 @@ import { extractApiErrorMessage } from '../../../../../core/utils/api-error-hand
         ></app-stats>
 
         <app-stats
-          title="Rating Promedio"
+          title="Calificación promedio"
           [value]="
             stats()!.average_rating !== null
               ? (stats()!.average_rating! | number: '1.1-1') + ' ★'
@@ -132,7 +133,9 @@ import { extractApiErrorMessage } from '../../../../../core/utils/api-error-hand
       }
 
       @if (listError()) {
-        <div class="mx-2 mt-3 rounded-lg bg-red-50 p-3 text-sm text-red-700 md:mx-4">
+        <div
+          class="mx-2 mt-3 rounded-lg bg-red-50 p-3 text-sm text-red-700 md:mx-4"
+        >
           {{ listError() }}
         </div>
       }
@@ -146,7 +149,7 @@ import { extractApiErrorMessage } from '../../../../../core/utils/api-error-hand
             [cardConfig]="cardConfig"
             [actions]="actions"
             [loading]="loading()"
-            emptyMessage="No hay reseñas registradas"
+            emptyMessage="No hay reseñas para mostrar"
             emptyIcon="star"
             (rowClick)="openDetail($event)"
           ></app-responsive-data-view>
@@ -239,7 +242,7 @@ import { extractApiErrorMessage } from '../../../../../core/utils/api-error-hand
           </div>
 
           <div class="flex flex-wrap items-center gap-4 text-xs text-gray-500">
-            <span>{{ review.created_at | date: 'dd/MM/yyyy' }}</span>
+            <span>{{ formatDate(review.created_at) }}</span>
             <span>{{ review.helpful_count }} votos útiles</span>
             <span [class.text-red-600]="review.report_count > 0">
               {{ review.report_count }} reportes
@@ -302,7 +305,7 @@ import { extractApiErrorMessage } from '../../../../../core/utils/api-error-hand
                     <p class="mt-1 text-xs text-red-600">
                       {{ report.users?.first_name || 'Cliente' }}
                       {{ report.users?.last_name || '' }} ·
-                      {{ report.created_at | date: 'dd/MM/yyyy HH:mm' }}
+                      {{ formatDateTime(report.created_at) }}
                     </p>
                   </div>
                 }
@@ -349,7 +352,7 @@ import { extractApiErrorMessage } from '../../../../../core/utils/api-error-hand
                   {{ review.review_responses.content }}
                 </p>
                 <p class="mt-2 text-xs text-blue-600">
-                  {{ review.review_responses.created_at | date: 'dd/MM/yyyy HH:mm' }}
+                  {{ formatDateTime(review.review_responses.created_at) }}
                 </p>
               </div>
             } @else {
@@ -375,11 +378,17 @@ import { extractApiErrorMessage } from '../../../../../core/utils/api-error-hand
                   (click)="submitResponse()"
                 >
                   @if (responseSubmitting()) {
-                    <app-icon name="loader-2" [size]="16" [spin]="true"></app-icon>
+                    <app-icon
+                      name="loader-2"
+                      [size]="16"
+                      [spin]="true"
+                    ></app-icon>
                   } @else {
                     <app-icon name="save" [size]="16"></app-icon>
                   }
-                  {{ responseEditing() ? 'Guardar respuesta' : 'Enviar respuesta' }}
+                  {{
+                    responseEditing() ? 'Guardar respuesta' : 'Enviar respuesta'
+                  }}
                 </button>
               </div>
             }
@@ -400,6 +409,8 @@ import { extractApiErrorMessage } from '../../../../../core/utils/api-error-hand
 export class ReviewsComponent {
   private reviewsService = inject(AdminReviewsService);
   private destroyRef = inject(DestroyRef);
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
 
   // State signals
   reviews = signal<Review[]>([]);
@@ -423,6 +434,7 @@ export class ReviewsComponent {
   responseSubmitting = signal(false);
   responseError = signal<string | null>(null);
   listError = signal<string | null>(null);
+  private routedReviewId = signal<number | null>(null);
 
   // Filters
   filters = signal<ReviewFilters>({ page: 1, limit: 10 });
@@ -444,7 +456,7 @@ export class ReviewsComponent {
     },
     {
       key: 'rating',
-      label: 'Rating',
+      label: 'Calificación',
       type: 'select',
       placeholder: 'Todos',
       options: [
@@ -474,7 +486,7 @@ export class ReviewsComponent {
     },
     {
       key: 'rating',
-      label: 'Rating',
+      label: 'Calificación',
       transform: (v: any) => '\u2605'.repeat(v) + '\u2606'.repeat(5 - v),
     },
     {
@@ -501,12 +513,7 @@ export class ReviewsComponent {
     {
       key: 'created_at',
       label: 'Fecha',
-      transform: (v: any) =>
-        new Date(v).toLocaleDateString('es', {
-          day: '2-digit',
-          month: '2-digit',
-          year: 'numeric',
-        }),
+      transform: (v: any) => (v ? formatDateOnlyUTC(v) : ''),
     },
   ];
 
@@ -533,7 +540,7 @@ export class ReviewsComponent {
     detailKeys: [
       {
         key: 'rating',
-        label: 'Rating',
+        label: 'Calificaci\u00f3n',
         transform: (v: any) => '\u2605'.repeat(v) + '\u2606'.repeat(5 - v),
       },
       {
@@ -544,12 +551,7 @@ export class ReviewsComponent {
     footerKey: 'created_at',
     footerLabel: 'Fecha',
     footerStyle: 'prominent',
-    footerTransform: (v: any) =>
-      new Date(v).toLocaleDateString('es', {
-        day: '2-digit',
-        month: '2-digit',
-        year: 'numeric',
-      }),
+    footerTransform: (v: any) => (v ? formatDateOnlyUTC(v) : ''),
   };
 
   // Table actions
@@ -584,6 +586,7 @@ export class ReviewsComponent {
   ];
 
   constructor() {
+    this.watchRouteReviewId();
     this.loadStats();
     this.loadReviews();
   }
@@ -596,7 +599,13 @@ export class ReviewsComponent {
         next: (res) => {
           this.stats.set(res.data || res);
         },
-        error: (error) => this.listError.set(extractApiErrorMessage(error)),
+        error: (error) =>
+          this.listError.set(
+            translateCustomerError(
+              error,
+              'No se pudieron cargar las estadísticas de reseñas',
+            ),
+          ),
       });
   }
 
@@ -619,7 +628,9 @@ export class ReviewsComponent {
           this.loading.set(false);
         },
         error: (error) => {
-          this.listError.set(extractApiErrorMessage(error));
+          this.listError.set(
+            translateCustomerError(error, 'No se pudieron cargar las reseñas'),
+          );
           this.loading.set(false);
         },
       });
@@ -656,7 +667,10 @@ export class ReviewsComponent {
           this.loadStats();
           this.closeDetail();
         },
-        error: (error) => this.listError.set(extractApiErrorMessage(error)),
+        error: (error) =>
+          this.listError.set(
+            translateCustomerError(error, 'No se pudo aprobar la rese\u00f1a'),
+          ),
       });
   }
 
@@ -670,7 +684,10 @@ export class ReviewsComponent {
           this.loadStats();
           this.closeDetail();
         },
-        error: (error) => this.listError.set(extractApiErrorMessage(error)),
+        error: (error) =>
+          this.listError.set(
+            translateCustomerError(error, 'No se pudo rechazar la rese\u00f1a'),
+          ),
       });
   }
 
@@ -684,7 +701,10 @@ export class ReviewsComponent {
           this.loadStats();
           this.closeDetail();
         },
-        error: (error) => this.listError.set(extractApiErrorMessage(error)),
+        error: (error) =>
+          this.listError.set(
+            translateCustomerError(error, 'No se pudo ocultar la rese\u00f1a'),
+          ),
       });
   }
 
@@ -700,13 +720,20 @@ export class ReviewsComponent {
           this.loadStats();
           this.closeDetail();
         },
-        error: (error) => this.listError.set(extractApiErrorMessage(error)),
+        error: (error) =>
+          this.listError.set(
+            translateCustomerError(error, 'No se pudo eliminar la rese\u00f1a'),
+          ),
       });
   }
 
   openDetail(review: Review): void {
+    this.openDetailById(review.id, review);
+  }
+
+  private openDetailById(reviewId: number, seedReview?: Review): void {
     this.detailOpen.set(true);
-    this.selectedReview.set(review);
+    this.selectedReview.set(seedReview ?? null);
     this.responseContent.set('');
     this.responseEditing.set(false);
     this.responseError.set(null);
@@ -714,7 +741,7 @@ export class ReviewsComponent {
     this.detailLoading.set(true);
 
     this.reviewsService
-      .getOne(review.id)
+      .getOne(reviewId)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (res) => {
@@ -722,7 +749,12 @@ export class ReviewsComponent {
           this.detailLoading.set(false);
         },
         error: (error) => {
-          this.detailError.set(extractApiErrorMessage(error));
+          this.detailError.set(
+            translateCustomerError(
+              error,
+              'No se pudo cargar el detalle de la reseña',
+            ),
+          );
           this.detailLoading.set(false);
         },
       });
@@ -730,10 +762,12 @@ export class ReviewsComponent {
 
   closeDetail(): void {
     this.detailOpen.set(false);
+    this.clearRoutedReviewId();
     this.clearDetailState();
   }
 
   onDetailClosed(): void {
+    this.clearRoutedReviewId();
     this.clearDetailState();
   }
 
@@ -764,21 +798,21 @@ export class ReviewsComponent {
             this.responseContent().trim(),
           );
 
-    request
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        next: () => {
-          this.responseSubmitting.set(false);
-          this.responseEditing.set(false);
-          this.responseContent.set('');
-          this.reloadSelectedReview(review.id);
-          this.loadReviews();
-        },
-        error: (error) => {
-          this.responseSubmitting.set(false);
-          this.responseError.set(extractApiErrorMessage(error));
-        },
-      });
+    request.pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: () => {
+        this.responseSubmitting.set(false);
+        this.responseEditing.set(false);
+        this.responseContent.set('');
+        this.reloadSelectedReview(review.id);
+        this.loadReviews();
+      },
+      error: (error) => {
+        this.responseSubmitting.set(false);
+        this.responseError.set(
+          translateCustomerError(error, 'No se pudo guardar la respuesta'),
+        );
+      },
+    });
   }
 
   onDeleteResponse(reviewId: number): void {
@@ -794,7 +828,9 @@ export class ReviewsComponent {
           this.loadReviews();
         },
         error: (error) => {
-          this.responseError.set(extractApiErrorMessage(error));
+          this.responseError.set(
+            translateCustomerError(error, 'No se pudo eliminar la respuesta'),
+          );
         },
       });
   }
@@ -818,9 +854,54 @@ export class ReviewsComponent {
       .subscribe({
         next: (res) => this.selectedReview.set(res.data || res),
         error: (error) => {
-          this.detailError.set(extractApiErrorMessage(error));
+          this.detailError.set(
+            translateCustomerError(
+              error,
+              'No se pudo recargar el detalle de la reseña',
+            ),
+          );
         },
       });
+  }
+
+  private watchRouteReviewId(): void {
+    this.route.queryParamMap
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((params) => {
+        const reviewId = this.parseReviewId(
+          params.get('review_id') ?? params.get('reviewId'),
+        );
+
+        if (!reviewId) {
+          this.routedReviewId.set(null);
+          return;
+        }
+
+        if (this.routedReviewId() === reviewId && this.detailOpen()) return;
+
+        this.routedReviewId.set(reviewId);
+        this.openDetailById(
+          reviewId,
+          this.reviews().find((review) => review.id === reviewId),
+        );
+      });
+  }
+
+  private parseReviewId(value: string | null): number | null {
+    const reviewId = Number(value);
+    return Number.isInteger(reviewId) && reviewId > 0 ? reviewId : null;
+  }
+
+  private clearRoutedReviewId(): void {
+    if (!this.routedReviewId()) return;
+
+    this.routedReviewId.set(null);
+    void this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { review_id: null, reviewId: null },
+      queryParamsHandling: 'merge',
+      replaceUrl: true,
+    });
   }
 
   getStars(rating: number): string {
@@ -847,5 +928,29 @@ export class ReviewsComponent {
       flagged: 'bg-red-100 text-red-800',
     };
     return classes[state] || 'bg-gray-100 text-gray-800';
+  }
+
+  formatDate(value: string | Date | null | undefined): string {
+    if (!value) return '';
+    try {
+      return formatDateOnlyUTC(value);
+    } catch {
+      return String(value);
+    }
+  }
+
+  formatDateTime(value: string | Date | null | undefined): string {
+    if (!value) return '';
+    try {
+      return new Date(value).toLocaleString('es-CO', {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+    } catch {
+      return String(value);
+    }
   }
 }

--- a/apps/frontend/src/app/private/modules/store/customers/utils/customer-error.translator.ts
+++ b/apps/frontend/src/app/private/modules/store/customers/utils/customer-error.translator.ts
@@ -1,0 +1,155 @@
+import { HttpErrorResponse } from '@angular/common/http';
+
+/**
+ * Traductor centralizado de errores HTTP del módulo de clientes a mensajes
+ * en español listos para mostrar en toasts.
+ *
+ * Vendix backend response shape (ver `AllExceptionsFilter`):
+ *   {
+ *     statusCode: number,
+ *     error_code?: string,      // p.ej. 'SYS_CONFLICT_001', 'CUST_FIND_001'
+ *     message: string,
+ *     details?: any,
+ *     timestamp: string,
+ *     path: string
+ *   }
+ *
+ * Códigos relevantes (ver `apps/backend/src/common/errors/error-codes.ts`):
+ *   - SYS_CONFLICT_001       (409) -> documento duplicado en organización
+ *   - SYS_VALIDATION_001     (422) -> validación de DTO (class-validator)
+ *   - SYS_NOT_FOUND_001      (404) -> recurso no encontrado
+ *   - SYS_FORBIDDEN_001      (403) -> acceso denegado
+ *   - SYS_UNAUTHORIZED_001   (401) -> sesión expirada
+ *   - SYS_INTERNAL_001       (500) -> error interno
+ *   - CUST_FIND_001          (404) -> cliente no encontrado
+ *   - CUST_CREATE_001        (400) -> error creando cliente
+ *   - CUST_VALIDATE_001      (400) -> validación de cliente falló
+ *   - CUST_PERM_001          (403) -> acceso denegado al cliente
+ *   - CUST_BULK_001..004     (400/409) -> errores de bulk upload
+ */
+
+type AnyError =
+  | HttpErrorResponse
+  | { status?: number; error?: any; message?: string }
+  | unknown;
+
+const ERROR_CODE_MESSAGES: Record<string, string> = {
+  // Customers domain
+  CUST_FIND_001: 'No se encontró el cliente',
+  CUST_CREATE_001: 'No se pudo crear el cliente. Revisa los datos.',
+  CUST_VALIDATE_001:
+    'Datos del cliente inválidos. Revisa los campos marcados.',
+  CUST_PERM_001: 'No tienes permisos para acceder a este cliente',
+  CUST_BULK_001: 'El archivo excede el límite de filas permitido',
+  CUST_BULK_002: 'Algunas filas del archivo no son válidas',
+  CUST_BULK_003: 'Hay correos duplicados en el archivo',
+  CUST_BULK_004: 'Se requiere contexto de tienda para la carga masiva',
+
+  // System (used by customers domain)
+  SYS_CONFLICT_001:
+    'Ya existe un cliente con este documento en la organización',
+  SYS_VALIDATION_001:
+    'Datos del formulario inválidos. Revisa los campos marcados.',
+  SYS_NOT_FOUND_001: 'No se encontró el recurso solicitado',
+  SYS_FORBIDDEN_001: 'No tienes permisos para realizar esta acción',
+  SYS_UNAUTHORIZED_001: 'Tu sesión expiró. Vuelve a iniciar sesión.',
+  SYS_INTERNAL_001:
+    'Error del servidor. Inténtalo de nuevo en un momento.',
+
+  // Legacy/granular codes that may appear from older endpoints
+  CUSTOMER_DOCUMENT_DUPLICATE: 'Ya existe un cliente con este documento',
+  CUSTOMER_DOCUMENT_INVALID:
+    'Datos del documento inválidos. Revisa el tipo y número.',
+};
+
+/**
+ * Traduce un error HTTP a un mensaje en español listo para mostrar al usuario.
+ *
+ * @param err Error capturado por RxJS / HttpClient (HttpErrorResponse o similar).
+ * @param fallback Mensaje a usar cuando no se puede mapear el error a una copia conocida.
+ * @returns Mensaje en español.
+ */
+export function translateCustomerError(
+  err: AnyError,
+  fallback = 'Ocurrió un error. Inténtalo de nuevo.',
+): string {
+  if (!err) return fallback;
+  const e = err as any;
+
+  // Vendix backend shape: HttpErrorResponse.error = { statusCode, error_code, message, details }
+  const status: number | undefined =
+    typeof e?.status === 'number' ? e.status : e?.error?.statusCode;
+
+  const code: string | undefined =
+    typeof e?.error?.error_code === 'string'
+      ? e.error.error_code
+      : typeof e?.error?.code === 'string'
+        ? e.error.code
+        : typeof e?.error?.error?.code === 'string'
+          ? e.error.error.code
+          : undefined;
+
+  const apiMessage: string | undefined =
+    typeof e?.error?.message === 'string'
+      ? e.error.message
+      : typeof e?.error?.error?.message === 'string'
+        ? e.error.error.message
+        : undefined;
+
+  const details = e?.error?.details ?? e?.error?.error?.details;
+  const fields: string[] = Array.isArray(details?.fields)
+    ? details.fields
+    : Array.isArray(details)
+      ? details
+      : [];
+
+  // 1. Specific known codes
+  if (code && ERROR_CODE_MESSAGES[code]) {
+    // For validation, if the message touches the document fields use a more
+    // specific copy regardless of generic mapping.
+    if (code === 'SYS_VALIDATION_001' || code === 'CUST_VALIDATE_001') {
+      const touchesDocument =
+        fields.includes('document_type') ||
+        fields.includes('document_number') ||
+        (typeof apiMessage === 'string' && /document/i.test(apiMessage));
+      if (touchesDocument) {
+        return 'Datos del documento inválidos. Revisa el tipo y número.';
+      }
+    }
+    return ERROR_CODE_MESSAGES[code];
+  }
+
+  // 2. HTTP-status fallbacks
+  if (status === 409) {
+    return 'Ya existe un cliente con este documento';
+  }
+  if (status === 404) {
+    return 'No se encontró el cliente';
+  }
+  if (status === 400 || status === 422) {
+    const touchesDocument =
+      fields.includes('document_type') ||
+      fields.includes('document_number') ||
+      (typeof apiMessage === 'string' && /document/i.test(apiMessage));
+    if (touchesDocument) {
+      return 'Datos del documento inválidos. Revisa el tipo y número.';
+    }
+    return 'Datos del formulario inválidos. Revisa los campos marcados.';
+  }
+  if (status === 403) {
+    return 'No tienes permisos para realizar esta acción';
+  }
+  if (status === 401) {
+    return 'Tu sesión expiró. Vuelve a iniciar sesión.';
+  }
+  if (typeof status === 'number' && status >= 500) {
+    return 'Error del servidor. Inténtalo de nuevo en un momento.';
+  }
+
+  // 3. Last-resort: backend message if it looks like a human sentence (starts with letter)
+  if (apiMessage && /^[A-Za-zÁÉÍÓÚÑáéíóúñ]/.test(apiMessage)) {
+    return apiMessage;
+  }
+
+  return fallback;
+}

--- a/apps/frontend/src/app/private/modules/store/inventory/interfaces/inventory.interface.ts
+++ b/apps/frontend/src/app/private/modules/store/inventory/interfaces/inventory.interface.ts
@@ -171,6 +171,7 @@ export interface PurchaseOrder {
   total_amount?: number;
   discount_amount?: number;
   notes?: string;
+  internal_notes?: string;
   created_by_user_id?: number;
   approved_by_user_id?: number;
   created_at?: string;
@@ -534,7 +535,7 @@ export interface PurchaseOrderReception {
   received_by_user_id: number | null;
   notes: string | null;
   received_at: string;
-  received_by?: { id: number; user_name: string; first_name: string; last_name: string };
+  received_by?: { id: number; username?: string; user_name?: string; first_name: string; last_name: string };
   items: PurchaseOrderReceptionItem[];
 }
 
@@ -557,7 +558,7 @@ export interface PurchaseOrderAttachment {
   supplier_invoice_date: string | null;
   supplier_invoice_amount: number | null;
   notes: string | null;
-  uploaded_by?: { id: number; user_name: string; first_name: string; last_name: string };
+  uploaded_by?: { id: number; username?: string; user_name?: string; first_name: string; last_name: string };
   download_url?: string;
   created_at: string;
 }
@@ -570,12 +571,12 @@ export interface PurchaseOrderPayment {
   payment_method: string;
   reference: string | null;
   notes: string | null;
-  created_by?: { id: number; user_name: string; first_name: string; last_name: string };
+  created_by?: { id: number; username?: string; user_name?: string; first_name: string; last_name: string };
   created_at: string;
 }
 
 export interface PurchaseOrderTimelineEntry {
-  type: 'audit' | 'reception' | 'payment';
+  type: 'audit' | 'reception' | 'payment' | 'attachment';
   date: string;
   data: Record<string, unknown>;
 }

--- a/apps/frontend/src/app/private/modules/store/inventory/pop/components/po-detail-modal/po-detail-modal.component.ts
+++ b/apps/frontend/src/app/private/modules/store/inventory/pop/components/po-detail-modal/po-detail-modal.component.ts
@@ -1,6 +1,5 @@
 import {Component, inject, input, output, signal, computed, effect, DestroyRef} from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { DatePipe } from '@angular/common';
 import { ModalComponent } from '../../../../../../../shared/components/modal/modal.component';
 import { ButtonComponent } from '../../../../../../../shared/components/button/button.component';
 import { IconComponent } from '../../../../../../../shared/components/icon/icon.component';
@@ -19,12 +18,12 @@ import { PoReceiveModalComponent } from '../po-receive-modal/po-receive-modal.co
 import { PoPaymentModalComponent } from '../po-payment-modal/po-payment-modal.component';
 import { PoTimelineComponent } from '../po-timeline/po-timeline.component';
 import { CurrencyFormatService } from '../../../../../../../shared/pipes/currency/currency.pipe';
+import { formatDateOnlyUTC } from '../../../../../../../shared/utils/date.util';
 
 @Component({
   selector: 'app-po-detail-modal',
   standalone: true,
   imports: [
-    DatePipe,
     ModalComponent,
     ButtonComponent,
     IconComponent,
@@ -47,12 +46,10 @@ import { CurrencyFormatService } from '../../../../../../../shared/pipes/currenc
             [class]="orderStatusClass()">
             {{ orderStatusLabel() }}
           </span>
-          @if (order()?.payment_status && order()!.payment_status !== 'unpaid') {
-            <span class="inline-flex items-center px-2.5 py-1 rounded-full text-[11px] font-semibold uppercase tracking-wide"
-              [class]="paymentStatusClass()">
-              {{ paymentStatusLabel() }}
-            </span>
-          }
+          <span class="inline-flex items-center px-2.5 py-1 rounded-full text-[11px] font-semibold uppercase tracking-wide"
+            [class]="paymentStatusClass()">
+            {{ paymentStatusLabel() }}
+          </span>
         </div>
       </div>
 
@@ -72,23 +69,23 @@ import { CurrencyFormatService } from '../../../../../../../shared/pipes/currenc
       @if (activeTab() === 'detail') {
         <div class="space-y-5">
           <!-- Summary cards row -->
-          <div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-3">
             <div class="p-3 rounded-lg bg-muted/20 border border-border/50">
               <p class="text-[10px] text-text-muted uppercase tracking-wider font-medium">Proveedor</p>
-              <p class="text-sm font-semibold text-text-primary mt-1 truncate">
+              <p class="text-sm font-semibold text-text-primary mt-1 break-words">
                 {{ order()?.supplier?.name || order()?.suppliers?.name || '—' }}
               </p>
             </div>
             <div class="p-3 rounded-lg bg-muted/20 border border-border/50">
               <p class="text-[10px] text-text-muted uppercase tracking-wider font-medium">Bodega</p>
-              <p class="text-sm font-semibold text-text-primary mt-1 truncate">
+              <p class="text-sm font-semibold text-text-primary mt-1 break-words">
                 {{ order()?.location?.name || '—' }}
               </p>
             </div>
             <div class="p-3 rounded-lg bg-muted/20 border border-border/50">
-              <p class="text-[10px] text-text-muted uppercase tracking-wider font-medium">Fecha</p>
+              <p class="text-[10px] text-text-muted uppercase tracking-wider font-medium">Fecha de orden</p>
               <p class="text-sm font-semibold text-text-primary mt-1">
-                {{ order()?.order_date | date:'dd MMM yyyy' }}
+                {{ formatDate(order()?.order_date) }}
               </p>
             </div>
             <div class="p-3 rounded-lg bg-primary/5 border border-primary/20">
@@ -96,6 +93,69 @@ import { CurrencyFormatService } from '../../../../../../../shared/pipes/currenc
               <p class="text-sm font-bold text-primary mt-1">
                 {{ formatCurrency(order()?.total_amount || 0) }}
               </p>
+            </div>
+          </div>
+
+          <!-- Order metadata -->
+          <div class="grid grid-cols-1 md:grid-cols-[1fr_280px] gap-4">
+            <div class="rounded-lg border border-border/60 overflow-hidden">
+              <div class="px-3 py-2.5 bg-muted/20 border-b border-border/50">
+                <h4 class="text-xs text-text-muted uppercase tracking-wider font-semibold">Información de la orden</h4>
+              </div>
+              <dl class="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-3 p-3">
+                <div>
+                  <dt class="text-[10px] text-text-muted uppercase tracking-wider">Fecha esperada</dt>
+                  <dd class="text-sm text-text-primary mt-0.5">{{ formatDate(order()?.expected_date) }}</dd>
+                </div>
+                <div>
+                  <dt class="text-[10px] text-text-muted uppercase tracking-wider">Fecha recibida</dt>
+                  <dd class="text-sm text-text-primary mt-0.5">{{ formatDate(order()?.received_date) }}</dd>
+                </div>
+                <div>
+                  <dt class="text-[10px] text-text-muted uppercase tracking-wider">Vencimiento de pago</dt>
+                  <dd class="text-sm text-text-primary mt-0.5">{{ formatDate(order()?.payment_due_date) }}</dd>
+                </div>
+                <div>
+                  <dt class="text-[10px] text-text-muted uppercase tracking-wider">Condiciones de pago</dt>
+                  <dd class="text-sm text-text-primary mt-0.5">{{ order()?.payment_terms || '—' }}</dd>
+                </div>
+                <div>
+                  <dt class="text-[10px] text-text-muted uppercase tracking-wider">Método de envío</dt>
+                  <dd class="text-sm text-text-primary mt-0.5">{{ order()?.shipping_method || '—' }}</dd>
+                </div>
+                <div>
+                  <dt class="text-[10px] text-text-muted uppercase tracking-wider">Actualizada</dt>
+                  <dd class="text-sm text-text-primary mt-0.5">{{ formatDateTime(order()?.updated_at) }}</dd>
+                </div>
+              </dl>
+            </div>
+
+            <div class="rounded-lg border border-border/60 overflow-hidden">
+              <div class="px-3 py-2.5 bg-muted/20 border-b border-border/50">
+                <h4 class="text-xs text-text-muted uppercase tracking-wider font-semibold">Resumen financiero</h4>
+              </div>
+              <div class="p-3 space-y-2 text-sm">
+                <div class="flex justify-between gap-3">
+                  <span class="text-text-secondary">Subtotal</span>
+                  <span class="font-medium text-text-primary tabular-nums">{{ formatCurrency(order()?.subtotal_amount || 0) }}</span>
+                </div>
+                <div class="flex justify-between gap-3">
+                  <span class="text-text-secondary">Descuento</span>
+                  <span class="font-medium text-text-primary tabular-nums">{{ formatCurrency(order()?.discount_amount || 0) }}</span>
+                </div>
+                <div class="flex justify-between gap-3">
+                  <span class="text-text-secondary">Impuestos</span>
+                  <span class="font-medium text-text-primary tabular-nums">{{ formatCurrency(order()?.tax_amount || 0) }}</span>
+                </div>
+                <div class="flex justify-between gap-3">
+                  <span class="text-text-secondary">Envío</span>
+                  <span class="font-medium text-text-primary tabular-nums">{{ formatCurrency(order()?.shipping_cost || 0) }}</span>
+                </div>
+                <div class="flex justify-between gap-3 border-t border-border pt-2">
+                  <span class="font-semibold text-text-primary">Total</span>
+                  <span class="font-bold text-primary tabular-nums">{{ formatCurrency(order()?.total_amount || 0) }}</span>
+                </div>
+              </div>
             </div>
           </div>
 
@@ -118,6 +178,7 @@ import { CurrencyFormatService } from '../../../../../../../shared/pipes/currenc
                     <th class="py-2.5 px-3">Producto</th>
                     <th class="py-2.5 px-3 text-right w-16">Cant.</th>
                     <th class="py-2.5 px-3 text-right w-20 hidden sm:table-cell">Recibido</th>
+                    <th class="py-2.5 px-3 text-right w-20 hidden md:table-cell">Pendiente</th>
                     <th class="py-2.5 px-3 text-right w-24">Costo</th>
                     <th class="py-2.5 px-3 text-right w-24">Subtotal</th>
                   </tr>
@@ -129,6 +190,15 @@ import { CurrencyFormatService } from '../../../../../../../shared/pipes/currenc
                         <span class="font-medium text-text-primary">{{ getItemProductName(item) }}</span>
                         @if (item.product_variants?.sku) {
                           <span class="text-[11px] text-text-muted block mt-0.5">SKU: {{ item.product_variants!.sku }}</span>
+                        }
+                        @if (item.product_variants?.name) {
+                          <span class="text-[11px] text-text-muted block mt-0.5">Variante: {{ item.product_variants!.name }}</span>
+                        }
+                        @if (getItemLotDetails(item)) {
+                          <span class="text-[11px] text-text-muted block mt-0.5">{{ getItemLotDetails(item) }}</span>
+                        }
+                        @if (item.notes) {
+                          <span class="text-[11px] text-text-secondary block mt-1">{{ item.notes }}</span>
                         }
                         <!-- Reception progress bar per item (mobile-visible) -->
                         @if (getItemReceived(item) > 0) {
@@ -158,6 +228,9 @@ import { CurrencyFormatService } from '../../../../../../../shared/pipes/currenc
                           </span>
                         </div>
                       </td>
+                      <td class="py-2.5 px-3 text-right hidden md:table-cell text-text-secondary tabular-nums">
+                        {{ getItemPending(item) }}
+                      </td>
                       <td class="py-2.5 px-3 text-right text-text-secondary tabular-nums">
                         {{ formatCurrency(item.unit_price || item.unit_cost || 0) }}
                       </td>
@@ -170,14 +243,14 @@ import { CurrencyFormatService } from '../../../../../../../shared/pipes/currenc
                 <tfoot>
                   @if (order()?.shipping_cost) {
                     <tr class="border-t border-border/50">
-                      <td [attr.colspan]="4" class="py-2 px-3 text-right text-xs text-text-muted">Envio</td>
+                      <td [attr.colspan]="5" class="py-2 px-3 text-right text-xs text-text-muted">Envío</td>
                       <td class="py-2 px-3 text-right text-sm text-text-secondary tabular-nums">
                         {{ formatCurrency(order()!.shipping_cost || 0) }}
                       </td>
                     </tr>
                   }
                   <tr class="border-t-2 border-border">
-                    <td [attr.colspan]="4" class="py-3 px-3 text-right font-semibold text-text-primary">Total</td>
+                    <td [attr.colspan]="5" class="py-3 px-3 text-right font-semibold text-text-primary">Total</td>
                     <td class="py-3 px-3 text-right font-bold text-primary text-base tabular-nums">
                       {{ formatCurrency(order()?.total_amount || 0) }}
                     </td>
@@ -188,30 +261,18 @@ import { CurrencyFormatService } from '../../../../../../../shared/pipes/currenc
           </div>
 
           <!-- Notes + extra info -->
-          @if (order()?.notes || order()?.expected_date || order()?.payment_due_date) {
+          @if (order()?.notes || order()?.internal_notes) {
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-              @if (order()?.expected_date) {
-                <div class="flex items-center gap-2 p-2.5 rounded-lg bg-muted/10 border border-border/30">
-                  <app-icon name="calendar" [size]="14" class="text-text-muted flex-shrink-0"></app-icon>
-                  <div>
-                    <span class="text-[10px] text-text-muted uppercase">Entrega esperada</span>
-                    <p class="text-sm text-text-primary">{{ order()!.expected_date | date:'dd MMM yyyy' }}</p>
-                  </div>
-                </div>
-              }
-              @if (order()?.payment_due_date) {
-                <div class="flex items-center gap-2 p-2.5 rounded-lg bg-muted/10 border border-border/30">
-                  <app-icon name="clock" [size]="14" class="text-text-muted flex-shrink-0"></app-icon>
-                  <div>
-                    <span class="text-[10px] text-text-muted uppercase">Vencimiento pago</span>
-                    <p class="text-sm text-text-primary">{{ order()!.payment_due_date | date:'dd MMM yyyy' }}</p>
-                  </div>
-                </div>
-              }
               @if (order()?.notes) {
-                <div class="sm:col-span-2 p-2.5 rounded-lg bg-muted/10 border border-border/30">
-                  <span class="text-[10px] text-text-muted uppercase font-medium">Notas</span>
-                  <p class="text-sm text-text-secondary mt-0.5">{{ order()!.notes }}</p>
+                <div class="p-3 rounded-lg bg-muted/10 border border-border/30">
+                  <span class="text-[10px] text-text-muted uppercase font-medium">Notas proveedor</span>
+                  <p class="text-sm text-text-secondary mt-1 whitespace-pre-line">{{ order()!.notes }}</p>
+                </div>
+              }
+              @if (order()?.internal_notes) {
+                <div class="p-3 rounded-lg bg-muted/10 border border-border/30">
+                  <span class="text-[10px] text-text-muted uppercase font-medium">Notas internas</span>
+                  <p class="text-sm text-text-secondary mt-1 whitespace-pre-line">{{ order()!.internal_notes }}</p>
                 </div>
               }
             </div>
@@ -288,13 +349,13 @@ import { CurrencyFormatService } from '../../../../../../../shared/pipes/currenc
                       <div>
                         <span class="text-sm font-medium text-text-primary">Recepcion #{{ reception.id }}</span>
                         <span class="text-[11px] text-text-muted block">
-                          {{ reception.received_at | date:'dd MMM yyyy, HH:mm' }}
+                          {{ formatDateTime(reception.received_at) }}
                         </span>
                       </div>
                     </div>
                     @if (reception.received_by) {
                       <span class="text-[11px] text-text-muted bg-muted/20 px-2 py-0.5 rounded-full">
-                        {{ reception.received_by.first_name || reception.received_by.user_name }}
+                        {{ getUserDisplayName(reception.received_by) }}
                       </span>
                     }
                   </div>
@@ -323,8 +384,13 @@ import { CurrencyFormatService } from '../../../../../../../shared/pipes/currenc
         <div class="space-y-4">
           <!-- Header with action -->
           <div class="flex justify-between items-center">
-            <h4 class="text-sm font-semibold text-text-primary">Pagos</h4>
-            @if (order()?.payment_status !== 'paid' && order()?.status !== 'cancelled') {
+            <h4 class="text-sm font-semibold text-text-primary">
+              Pagos
+              @if (payments().length > 0) {
+                <span class="text-text-muted font-normal ml-1">({{ payments().length }})</span>
+              }
+            </h4>
+            @if (canRegisterPayment()) {
               <app-button variant="primary" size="sm" (clicked)="showPaymentModal.set(true)">
                 <app-icon name="dollar-sign" [size]="14" slot="icon"></app-icon>
                 Registrar Pago
@@ -392,7 +458,7 @@ import { CurrencyFormatService } from '../../../../../../../shared/pipes/currenc
                         {{ formatCurrency(payment.amount) }}
                       </span>
                       <span class="text-[11px] text-text-muted">
-                        {{ payment.payment_date | date:'dd MMM yyyy' }}
+                        {{ formatDate(payment.payment_date) }}
                       </span>
                     </div>
                     <div class="text-xs text-text-secondary mt-0.5">
@@ -401,13 +467,16 @@ import { CurrencyFormatService } from '../../../../../../../shared/pipes/currenc
                         <span class="text-text-muted"> · Ref: {{ payment.reference }}</span>
                       }
                     </div>
+                    <div class="text-[11px] text-text-muted mt-1">
+                      Registrado: {{ formatDateTime(payment.created_at) }}
+                    </div>
                     @if (payment.notes) {
-                      <p class="text-xs text-text-muted mt-1 italic">{{ payment.notes }}</p>
+                      <p class="text-xs text-text-muted mt-1 whitespace-pre-line">{{ payment.notes }}</p>
                     }
                   </div>
                   @if (payment.created_by) {
                     <span class="text-[10px] text-text-muted bg-muted/20 px-2 py-0.5 rounded-full whitespace-nowrap flex-shrink-0">
-                      {{ payment.created_by.first_name || payment.created_by.user_name }}
+                      {{ getUserDisplayName(payment.created_by) }}
                     </span>
                   }
                 </div>
@@ -479,7 +548,7 @@ import { CurrencyFormatService } from '../../../../../../../shared/pipes/currenc
                   <div class="flex-1 min-w-0">
                     <p class="text-sm font-medium text-text-primary truncate">{{ attachment.file_name }}</p>
                     <p class="text-[11px] text-text-muted">
-                      {{ formatFileSize(attachment.file_size) }} · {{ attachment.created_at | date:'dd MMM yyyy' }}
+                      {{ formatFileSize(attachment.file_size) }} · {{ formatDateTime(attachment.created_at) }}
                     </p>
                     @if (attachment.supplier_invoice_number) {
                       <p class="text-[11px] text-primary font-medium mt-0.5">
@@ -538,7 +607,7 @@ import { CurrencyFormatService } from '../../../../../../../shared/pipes/currenc
             Recibir
           </app-button>
         }
-        @if (order()?.payment_status !== 'paid' && order()?.status !== 'cancelled' && activeTab() === 'detail') {
+        @if (canRegisterPayment() && activeTab() === 'detail') {
           <app-button variant="outline" (clicked)="showPaymentModal.set(true)">
             <app-icon name="dollar-sign" [size]="14" slot="icon"></app-icon>
             Pagar
@@ -634,6 +703,19 @@ export class PoDetailModalComponent {
     return Math.round((this.totalPaid() / total) * 100);
   });
 
+  readonly effectivePaymentStatus = computed<'unpaid' | 'partial' | 'paid'>(() => {
+    const total = Number(this.order()?.total_amount || 0);
+    const paid = this.totalPaid();
+
+    if (this.paymentsLoaded() && total > 0) {
+      if (paid >= total) return 'paid';
+      if (paid > 0) return 'partial';
+      return 'unpaid';
+    }
+
+    return this.order()?.payment_status || 'unpaid';
+  });
+
   readonly receptionProgress = computed(() => {
     const items = this.orderItems();
     if (items.length === 0) return 0;
@@ -646,6 +728,13 @@ export class PoDetailModalComponent {
   readonly canReceive = computed(() => {
     const status = this.order()?.status;
     return status === 'approved' || status === 'partial' || status === 'ordered';
+  });
+
+  readonly canRegisterPayment = computed(() => {
+    const po = this.order();
+    if (!po || po.status === 'cancelled') return false;
+    if (this.effectivePaymentStatus() === 'paid') return false;
+    return this.remainingBalance() > 0;
   });
 
   constructor() {
@@ -718,7 +807,7 @@ export class PoDetailModalComponent {
   }
 
   paymentStatusClass(): string {
-    const status = this.order()?.payment_status;
+    const status = this.effectivePaymentStatus();
     const map: Record<string, string> = {
       unpaid: 'bg-red-100 text-red-700',
       partial: 'bg-amber-100 text-amber-700',
@@ -728,7 +817,7 @@ export class PoDetailModalComponent {
   }
 
   paymentStatusLabel(): string {
-    const status = this.order()?.payment_status;
+    const status = this.effectivePaymentStatus();
     const map: Record<string, string> = {
       unpaid: 'Sin pagar',
       partial: 'Pago parcial',
@@ -897,10 +986,22 @@ export class PoDetailModalComponent {
     return item.quantity_received ?? 0;
   }
 
+  getItemPending(item: PurchaseOrderItem): number {
+    return Math.max(0, this.getItemOrdered(item) - this.getItemReceived(item));
+  }
+
   getItemProgress(item: PurchaseOrderItem): number {
     const ordered = this.getItemOrdered(item);
     if (ordered <= 0) return 0;
     return Math.min(100, Math.round((this.getItemReceived(item) / ordered) * 100));
+  }
+
+  getItemLotDetails(item: PurchaseOrderItem): string {
+    const details: string[] = [];
+    if (item.batch_number) details.push(`Lote: ${item.batch_number}`);
+    if (item.manufacturing_date) details.push(`Fabricación: ${this.formatDate(item.manufacturing_date)}`);
+    if (item.expiration_date) details.push(`Vence: ${this.formatDate(item.expiration_date)}`);
+    return details.join(' · ');
   }
 
   getReceptionItemName(rItem: any): string {
@@ -909,8 +1010,27 @@ export class PoDetailModalComponent {
       || 'Producto';
   }
 
-  formatCurrency(amount: number): string {
+  formatCurrency(amount: number | string | null | undefined): string {
     return this.currencyService.format(Number(amount) || 0);
+  }
+
+  formatDate(value?: string | null): string {
+    if (!value) return '—';
+    return formatDateOnlyUTC(value);
+  }
+
+  formatDateTime(value?: string | null): string {
+    if (!value) return '—';
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return value;
+
+    return new Intl.DateTimeFormat('es-CO', {
+      day: '2-digit',
+      month: 'short',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    }).format(date);
   }
 
   formatFileSize(bytes: number): string {
@@ -933,8 +1053,15 @@ export class PoDetailModalComponent {
       cash: 'Efectivo',
       bank_transfer: 'Transferencia bancaria',
       check: 'Cheque',
-      credit_card: 'Tarjeta de credito',
+      credit_card: 'Tarjeta de crédito',
     };
-    return labels[method] || method;
+    return labels[method] || method || 'Sin método';
+  }
+
+  getUserDisplayName(user: { first_name?: string | null; last_name?: string | null; username?: string | null; user_name?: string | null } | null | undefined): string {
+    if (!user) return 'Sistema';
+
+    const name = `${user.first_name || ''} ${user.last_name || ''}`.trim();
+    return name || user.username || user.user_name || 'Sistema';
   }
 }

--- a/apps/frontend/src/app/private/modules/store/inventory/pop/components/po-payment-modal/po-payment-modal.component.ts
+++ b/apps/frontend/src/app/private/modules/store/inventory/pop/components/po-payment-modal/po-payment-modal.component.ts
@@ -38,8 +38,11 @@ import { toLocalDateString } from '../../../../../../../shared/utils/date.util';
             placeholder="0.00"
           >
           <p class="text-xs text-text-muted mt-1">
-            Total orden: {{ formatCurrency(totalAmount()) }} · Pagado: {{ formatCurrency(paidAmount()) }}
+            Total orden: {{ formatCurrency(totalAmount()) }} · Pagado: {{ formatCurrency(paidAmount()) }} · Pendiente: {{ formatCurrency(remaining()) }}
           </p>
+          @if (amount > remaining()) {
+            <p class="text-xs text-destructive mt-1">El monto no puede superar el saldo pendiente.</p>
+          }
         </div>
 
         <!-- Date -->
@@ -171,7 +174,7 @@ export class PoPaymentModalComponent {
   }
 
   isValid(): boolean {
-    return this.amount > 0 && !!this.paymentDate;
+    return this.amount > 0 && this.amount <= this.remaining() && !!this.paymentDate;
   }
 
   formatCurrency(value: number): string {

--- a/apps/frontend/src/app/private/modules/store/inventory/pop/components/po-timeline/po-timeline.component.ts
+++ b/apps/frontend/src/app/private/modules/store/inventory/pop/components/po-timeline/po-timeline.component.ts
@@ -1,13 +1,18 @@
-import {Component, inject, input, signal, effect, DestroyRef} from '@angular/core';
+import { Component, DestroyRef, effect, inject, input, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { DatePipe } from '@angular/common';
 import { IconComponent } from '../../../../../../../shared/components/icon/icon.component';
 import { PurchaseOrdersService } from '../../../services';
 import { PurchaseOrderTimelineEntry } from '../../../interfaces';
 import { CurrencyFormatService } from '../../../../../../../shared/pipes/currency/currency.pipe';
+import { formatDateOnlyUTC } from '../../../../../../../shared/utils/date.util';
+
+interface TimelineDetail {
+  label: string;
+  value: string;
+}
 
 interface TimelineDisplayItem {
-  type: 'audit' | 'reception' | 'payment';
+  type: 'audit' | 'reception' | 'payment' | 'attachment';
   icon: string;
   color: string;
   bg_color: string;
@@ -15,12 +20,13 @@ interface TimelineDisplayItem {
   description: string;
   date: string;
   user: string;
+  details: TimelineDetail[];
 }
 
 @Component({
   selector: 'app-po-timeline',
   standalone: true,
-  imports: [DatePipe, IconComponent],
+  imports: [IconComponent],
   template: `
     @if (loading()) {
       <div class="flex items-center justify-center py-8">
@@ -33,12 +39,10 @@ interface TimelineDisplayItem {
       </div>
     } @else {
       <div class="relative pl-6 md:pl-8">
-        <!-- Vertical line -->
         <div class="absolute left-[11px] md:left-[15px] top-2 bottom-2 w-0.5 bg-border"></div>
 
         @for (item of displayItems(); track $index) {
           <div class="relative pb-6 last:pb-0">
-            <!-- Icon dot -->
             <div
               class="absolute -left-6 md:-left-8 w-6 h-6 md:w-8 md:h-8 rounded-full flex items-center justify-center border-2 border-surface"
               [class]="item.bg_color"
@@ -46,15 +50,30 @@ interface TimelineDisplayItem {
               <app-icon [name]="item.icon" [size]="12" [class]="item.color"></app-icon>
             </div>
 
-            <!-- Content -->
-            <div class="ml-2 md:ml-4">
-              <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1">
-                <h4 class="text-sm font-medium text-text-primary">{{ item.title }}</h4>
-                <time class="text-xs text-text-muted">{{ item.date | date:'dd/MM/yyyy HH:mm' }}</time>
+            <div class="ml-2 md:ml-4 rounded-lg border border-border/50 bg-surface/40 p-3">
+              <div class="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between">
+                <div>
+                  <h4 class="text-sm font-semibold text-text-primary">{{ item.title }}</h4>
+                  <p class="text-xs text-text-secondary mt-0.5">{{ item.description }}</p>
+                </div>
+                <time class="text-[11px] text-text-muted whitespace-nowrap">
+                  {{ formatDateTime(item.date) }}
+                </time>
               </div>
-              <p class="text-xs text-text-secondary mt-0.5">{{ item.description }}</p>
+
+              @if (item.details.length > 0) {
+                <dl class="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-1.5 mt-3">
+                  @for (detail of item.details; track detail.label) {
+                    <div class="min-w-0">
+                      <dt class="text-[10px] text-text-muted uppercase tracking-wider">{{ detail.label }}</dt>
+                      <dd class="text-xs text-text-primary break-words">{{ detail.value }}</dd>
+                    </div>
+                  }
+                </dl>
+              }
+
               @if (item.user) {
-                <p class="text-[10px] text-text-muted mt-0.5">por {{ item.user }}</p>
+                <p class="text-[10px] text-text-muted mt-3">por {{ item.user }}</p>
               }
             </div>
           </div>
@@ -79,6 +98,8 @@ export class PoTimelineComponent {
       const id = this.orderId();
       if (id) {
         this.loadTimeline(id);
+      } else {
+        this.displayItems.set([]);
       }
     });
   }
@@ -100,6 +121,20 @@ export class PoTimelineComponent {
     });
   }
 
+  formatDateTime(value: string): string {
+    if (!value) return '—';
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return value;
+
+    return new Intl.DateTimeFormat('es-CO', {
+      day: '2-digit',
+      month: 'short',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    }).format(date);
+  }
+
   private mapEntry(entry: PurchaseOrderTimelineEntry): TimelineDisplayItem {
     const data = entry.data as Record<string, unknown>;
 
@@ -110,10 +145,11 @@ export class PoTimelineComponent {
           icon: 'package-check',
           color: 'text-success',
           bg_color: 'bg-success/10',
-          title: 'Recepcion de mercancia',
+          title: 'Recepción de mercancía',
           description: this.getReceptionDescription(data),
           date: entry.date,
           user: this.getUserName(data),
+          details: this.getReceptionDetails(data),
         };
 
       case 'payment':
@@ -126,6 +162,20 @@ export class PoTimelineComponent {
           description: this.getPaymentDescription(data),
           date: entry.date,
           user: this.getUserName(data),
+          details: this.getPaymentDetails(data),
+        };
+
+      case 'attachment':
+        return {
+          type: 'attachment',
+          icon: 'paperclip',
+          color: 'text-primary',
+          bg_color: 'bg-primary/10',
+          title: 'Adjunto agregado',
+          description: this.getAttachmentDescription(data),
+          date: entry.date,
+          user: this.getUserName(data),
+          details: this.getAttachmentDetails(data),
         };
 
       case 'audit':
@@ -136,91 +186,233 @@ export class PoTimelineComponent {
           color: this.getAuditColor(data),
           bg_color: this.getAuditBg(data),
           title: this.getAuditTitle(data),
-          description: (data['description'] as string) || '',
+          description: this.getAuditDescription(data),
           date: entry.date,
           user: this.getUserName(data),
+          details: this.getAuditDetails(data),
         };
     }
   }
 
   private getReceptionDescription(data: Record<string, unknown>): string {
-    const items = data['items'] as Array<Record<string, unknown>> | undefined;
-    if (items?.length) {
-      const totalQty = items.reduce((sum, i) => sum + (Number(i['quantity_received']) || 0), 0);
-      return `${totalQty} unidad(es) recibida(s) en ${items.length} linea(s)`;
+    const items = this.getArray(data['items']);
+    const totalQty = items.reduce((sum, item) => sum + (Number(item['quantity_received']) || 0), 0);
+
+    if (items.length > 0) {
+      return `${totalQty} unidad(es) recibida(s) en ${items.length} línea(s)`;
     }
-    const notes = data['notes'] as string;
-    return notes || 'Mercancia recibida';
+
+    return this.toText(data['notes']) || 'Mercancía recibida';
+  }
+
+  private getReceptionDetails(data: Record<string, unknown>): TimelineDetail[] {
+    const items = this.getArray(data['items']);
+    const details = items
+      .map((item) => {
+        const orderItem = this.asRecord(item['purchase_order_item']);
+        const product = this.asRecord(orderItem?.['products']) || this.asRecord(orderItem?.['product']);
+        const variant = this.asRecord(orderItem?.['product_variants']);
+        const name = this.toText(product?.['name']) || 'Producto';
+        const sku = this.toText(variant?.['sku']) || this.toText(product?.['sku']);
+        const quantity = Number(item['quantity_received']) || 0;
+        return {
+          label: sku ? `${name} (${sku})` : name,
+          value: `${quantity} unidad(es)`,
+        };
+      });
+
+    return this.withOptionalDetails(details, [
+      { label: 'Notas', value: this.toText(data['notes']) },
+    ]);
   }
 
   private getPaymentDescription(data: Record<string, unknown>): string {
-    const amount = data['amount'] as number;
-    const method = data['payment_method'] as string;
-    const methodLabels: Record<string, string> = {
-      cash: 'Efectivo',
-      bank_transfer: 'Transferencia',
-      check: 'Cheque',
-      credit_card: 'Tarjeta',
-    };
-    const label = methodLabels[method] || method || '';
-    return amount ? `${this.currencyService.format(Number(amount) || 0)} - ${label}` : label;
+    const amount = this.formatCurrencyValue(data['amount']);
+    const method = this.getPaymentMethodLabel(this.toText(data['payment_method']));
+    return `${amount} por ${method}`;
+  }
+
+  private getPaymentDetails(data: Record<string, unknown>): TimelineDetail[] {
+    return this.withOptionalDetails([], [
+      { label: 'Fecha de pago', value: this.formatDateOnly(data['payment_date']) },
+      { label: 'Método', value: this.getPaymentMethodLabel(this.toText(data['payment_method'])) },
+      { label: 'Referencia', value: this.toText(data['reference']) },
+      { label: 'Notas', value: this.toText(data['notes']) },
+    ]);
+  }
+
+  private getAttachmentDescription(data: Record<string, unknown>): string {
+    return this.toText(data['file_name']) || 'Archivo adjunto';
+  }
+
+  private getAttachmentDetails(data: Record<string, unknown>): TimelineDetail[] {
+    return this.withOptionalDetails([], [
+      { label: 'Tipo', value: this.toText(data['file_type']) },
+      { label: 'Tamaño', value: this.formatFileSize(Number(data['file_size']) || 0) },
+      { label: 'Factura proveedor', value: this.toText(data['supplier_invoice_number']) },
+      { label: 'Fecha factura', value: this.formatDateOnly(data['supplier_invoice_date']) },
+      { label: 'Valor factura', value: this.formatCurrencyValue(data['supplier_invoice_amount']) },
+      { label: 'Notas', value: this.toText(data['notes']) },
+    ]);
   }
 
   private getAuditIcon(data: Record<string, unknown>): string {
-    const action = (data['action'] as string) || '';
-    if (action.includes('create')) return 'plus-circle';
-    if (action.includes('approve')) return 'check-circle';
-    if (action.includes('cancel')) return 'x-circle';
-    if (action.includes('submit')) return 'send';
+    const action = this.normalizedAction(data);
+    if (action.includes('payment')) return 'dollar-sign';
+    if (action.includes('attachment')) return 'paperclip';
+    if (action.includes('received')) return 'package-check';
+    if (action.includes('created') || action.includes('create')) return 'plus-circle';
+    if (action.includes('approved') || action.includes('approve')) return 'check-circle';
+    if (action.includes('cancelled') || action.includes('cancel')) return 'x-circle';
+    if (action.includes('submitted') || action.includes('submit')) return 'send';
     return 'clock';
   }
 
   private getAuditColor(data: Record<string, unknown>): string {
-    const action = (data['action'] as string) || '';
+    const action = this.normalizedAction(data);
     if (action.includes('cancel')) return 'text-destructive';
-    if (action.includes('approve')) return 'text-success';
-    if (action.includes('create')) return 'text-primary';
+    if (action.includes('approve') || action.includes('received')) return 'text-success';
+    if (action.includes('created') || action.includes('payment') || action.includes('attachment')) return 'text-primary';
     return 'text-text-secondary';
   }
 
   private getAuditBg(data: Record<string, unknown>): string {
-    const action = (data['action'] as string) || '';
+    const action = this.normalizedAction(data);
     if (action.includes('cancel')) return 'bg-destructive/10';
-    if (action.includes('approve')) return 'bg-success/10';
-    if (action.includes('create')) return 'bg-primary/10';
+    if (action.includes('approve') || action.includes('received')) return 'bg-success/10';
+    if (action.includes('created') || action.includes('payment') || action.includes('attachment')) return 'bg-primary/10';
     return 'bg-muted/30';
   }
 
   private getAuditTitle(data: Record<string, unknown>): string {
-    const action = (data['action'] as string) || '';
-    if (action.includes('create')) return 'Orden creada';
-    if (action.includes('approve')) return 'Orden aprobada';
-    if (action.includes('cancel')) return 'Orden cancelada';
-    if (action.includes('submit')) return 'Orden enviada';
-    if (action.includes('update')) return 'Orden actualizada';
-    return (data['title'] as string) || 'Evento';
+    const action = this.normalizedAction(data);
+    if (action.includes('created')) return 'Orden creada';
+    if (action.includes('approved')) return 'Orden aprobada';
+    if (action.includes('cancelled')) return 'Orden cancelada';
+    if (action.includes('submitted')) return 'Orden enviada';
+    if (action.includes('updated')) return 'Orden actualizada';
+    if (action.includes('partially_received')) return 'Recepción parcial registrada';
+    if (action.includes('received')) return 'Recepción completada';
+    if (action.includes('payment_registered')) return 'Pago registrado';
+    if (action.includes('attachment_added')) return 'Adjunto agregado';
+    return this.toText(data['title']) || this.toText(data['action']) || 'Evento';
+  }
+
+  private getAuditDescription(data: Record<string, unknown>): string {
+    const action = this.normalizedAction(data);
+    const values = this.asRecord(data['new_values']) || this.asRecord(data['old_values']);
+
+    if (action.includes('payment_registered')) {
+      if (!values) return 'Pago registrado en la orden';
+      const amount = this.formatCurrencyValue(values?.['amount']);
+      const method = this.getPaymentMethodLabel(this.toText(values?.['method']));
+      return `${amount} por ${method}`;
+    }
+
+    if (action.includes('attachment_added')) {
+      return this.toText(values?.['file_name']) || 'Archivo adjunto agregado';
+    }
+
+    if (action.includes('partially_received')) {
+      const count = this.toText(values?.['items_count']);
+      return count ? `${count} línea(s) recibida(s) parcialmente` : 'Recepción parcial registrada';
+    }
+
+    if (action.includes('received')) {
+      const count = this.toText(values?.['items_count']);
+      return count ? `${count} línea(s) recibida(s)` : 'Orden recibida completamente';
+    }
+
+    if (action.includes('created')) return 'Se creó la orden de compra';
+    if (action.includes('approved')) return 'La orden quedó aprobada para recepción';
+    if (action.includes('cancelled')) return 'La orden fue cancelada';
+    if (action.includes('updated')) return 'Se actualizaron datos de la orden';
+
+    return this.toText(data['description']) || 'Evento de auditoría registrado';
+  }
+
+  private getAuditDetails(data: Record<string, unknown>): TimelineDetail[] {
+    const values = this.asRecord(data['new_values']) || this.asRecord(data['old_values']);
+    if (!values) return [];
+
+    return this.withOptionalDetails([], [
+      { label: 'Orden', value: this.toText(values['order_number']) || this.toText(values['purchase_order_id']) },
+      { label: 'Monto', value: this.formatCurrencyValue(values['amount']) },
+      { label: 'Método', value: this.getPaymentMethodLabel(this.toText(values['method'])) },
+      { label: 'Archivo', value: this.toText(values['file_name']) },
+      { label: 'Líneas', value: this.toText(values['items_count']) },
+    ]);
   }
 
   private getUserName(data: Record<string, unknown>): string {
-    const user = data['user'] as Record<string, unknown> | undefined;
-    if (user) {
-      const first = (user['first_name'] as string) || '';
-      const last = (user['last_name'] as string) || '';
-      const userName = (user['user_name'] as string) || '';
-      return first || last ? `${first} ${last}`.trim() : userName;
-    }
-    const receivedBy = data['received_by'] as Record<string, unknown> | undefined;
-    if (receivedBy) {
-      const first = (receivedBy['first_name'] as string) || '';
-      const last = (receivedBy['last_name'] as string) || '';
-      return `${first} ${last}`.trim();
-    }
-    const createdBy = data['created_by'] as Record<string, unknown> | undefined;
-    if (createdBy) {
-      const first = (createdBy['first_name'] as string) || '';
-      const last = (createdBy['last_name'] as string) || '';
-      return `${first} ${last}`.trim();
-    }
-    return '';
+    const user =
+      this.asRecord(data['user']) ||
+      this.asRecord(data['users']) ||
+      this.asRecord(data['received_by']) ||
+      this.asRecord(data['created_by']) ||
+      this.asRecord(data['uploaded_by']);
+
+    if (!user) return '';
+
+    const first = this.toText(user['first_name']);
+    const last = this.toText(user['last_name']);
+    const username = this.toText(user['username']) || this.toText(user['user_name']);
+    const email = this.toText(user['email']);
+
+    return first || last ? `${first} ${last}`.trim() : username || email;
+  }
+
+  private getPaymentMethodLabel(method: string): string {
+    const labels: Record<string, string> = {
+      cash: 'Efectivo',
+      bank_transfer: 'Transferencia bancaria',
+      check: 'Cheque',
+      credit_card: 'Tarjeta de crédito',
+    };
+    return labels[method] || method || 'Sin método';
+  }
+
+  private normalizedAction(data: Record<string, unknown>): string {
+    return this.toText(data['action']).toLowerCase();
+  }
+
+  private withOptionalDetails(base: TimelineDetail[], optional: TimelineDetail[]): TimelineDetail[] {
+    return [
+      ...base,
+      ...optional.filter((detail) => detail.value && detail.value !== '—' && detail.value !== '$0'),
+    ];
+  }
+
+  private formatCurrencyValue(value: unknown): string {
+    if (value === null || value === undefined || value === '') return '—';
+    return this.currencyService.format(Number(value) || 0);
+  }
+
+  private formatDateOnly(value: unknown): string {
+    if (!value) return '—';
+    return formatDateOnlyUTC(String(value));
+  }
+
+  private formatFileSize(bytes: number): string {
+    if (!bytes) return '0 B';
+    const k = 1024;
+    const sizes = ['B', 'KB', 'MB', 'GB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return `${parseFloat((bytes / Math.pow(k, i)).toFixed(1))} ${sizes[i]}`;
+  }
+
+  private getArray(value: unknown): Array<Record<string, unknown>> {
+    return Array.isArray(value) ? value.filter((item): item is Record<string, unknown> => !!item && typeof item === 'object') : [];
+  }
+
+  private asRecord(value: unknown): Record<string, unknown> | undefined {
+    return value && typeof value === 'object' && !Array.isArray(value)
+      ? value as Record<string, unknown>
+      : undefined;
+  }
+
+  private toText(value: unknown): string {
+    if (value === null || value === undefined) return '';
+    return String(value);
   }
 }

--- a/apps/frontend/src/app/private/modules/store/inventory/pop/components/pop-product-config-modal.component.ts
+++ b/apps/frontend/src/app/private/modules/store/inventory/pop/components/pop-product-config-modal.component.ts
@@ -1,4 +1,13 @@
-import {Component, input, output, signal, computed, effect, inject, DestroyRef} from '@angular/core';
+import {
+  Component,
+  input,
+  output,
+  signal,
+  computed,
+  effect,
+  inject,
+  DestroyRef,
+} from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { FormsModule } from '@angular/forms';
@@ -16,6 +25,7 @@ import { InputComponent } from '../../../../../../shared/components/input/input.
 import { CurrencyFormatService } from '../../../../../../shared/pipes/currency';
 import { ProductsService } from '../../../products/services/products.service';
 import { ToastService } from '../../../../../../shared/components/toast/toast.service';
+import { StoreSettingsFacade } from '../../../../../../core/store/store-settings/store-settings.facade';
 import {
   PopProduct,
   PopProductVariant,
@@ -41,8 +51,8 @@ export interface PopProductConfigResult {
     SettingToggleComponent,
     IconComponent,
     ButtonComponent,
-    InputComponent
-],
+    InputComponent,
+  ],
   template: `
     <app-modal
       [isOpen]="isOpen()"
@@ -410,7 +420,7 @@ export interface PopProductConfigResult {
                       <span
                         class="text-xs mt-0.5"
                         [class]="
-                          variant.stock_quantity <= 5
+                          isVariantLowStock(variant)
                             ? 'text-warning'
                             : 'text-text-muted'
                         "
@@ -544,6 +554,7 @@ export class PopProductConfigModalComponent {
 
   private productsService = inject(ProductsService);
   private toastService = inject(ToastService);
+  private storeSettingsFacade = inject(StoreSettingsFacade);
   private currencyService: CurrencyFormatService;
 
   tabItems = computed<ScrollableTab[]>(() => {
@@ -583,7 +594,8 @@ export class PopProductConfigModalComponent {
   get allVariantsSelected(): boolean {
     return (
       !!this.product()?.product_variants?.length &&
-      this.selectedVariantIds.size === (this.product()?.product_variants?.length ?? 0)
+      this.selectedVariantIds.size ===
+        (this.product()?.product_variants?.length ?? 0)
     );
   }
 
@@ -617,6 +629,34 @@ export class PopProductConfigModalComponent {
 
   formatCurrency(amount: number): string {
     return this.currencyService.format(amount || 0);
+  }
+
+  isVariantLowStock(variant: PopProductVariant): boolean {
+    const stock = Number(variant.stock_quantity ?? 0);
+    return stock > 0 && stock <= this.getProductLowStockThreshold();
+  }
+
+  private getProductLowStockThreshold(): number {
+    const product = this.product();
+    const productThreshold = [product?.reorder_point, product?.min_stock_level]
+      .map((value) => Number(value))
+      .find((value) => Number.isFinite(value) && value > 0);
+
+    if (productThreshold !== undefined) {
+      return productThreshold;
+    }
+
+    const apiThreshold = Number(product?.low_stock_threshold);
+    if (Number.isFinite(apiThreshold) && apiThreshold >= 0) {
+      return apiThreshold;
+    }
+
+    const configuredThreshold = Number(
+      this.storeSettingsFacade.settings()?.inventory?.low_stock_threshold,
+    );
+    return Number.isFinite(configuredThreshold) && configuredThreshold >= 0
+      ? configuredThreshold
+      : 10;
   }
 
   isVariantSelected(variantId: number): boolean {
@@ -684,60 +724,62 @@ export class PopProductConfigModalComponent {
           .pipe(catchError(() => of(null))),
       );
 
-      forkJoin(createRequests).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
-        next: (results) => {
-          const createdVariants = results
-            .filter((r): r is any => r !== null)
-            .map((r) => ({
-              id: r.id,
-              name: r.name,
-              sku: r.sku,
-              cost_price: r.cost_price ? Number(r.cost_price) : undefined,
-              stock_quantity: r.stock_quantity || 0,
-              attributes: r.attributes,
-            }));
+      forkJoin(createRequests)
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe({
+          next: (results) => {
+            const createdVariants = results
+              .filter((r): r is any => r !== null)
+              .map((r) => ({
+                id: r.id,
+                name: r.name,
+                sku: r.sku,
+                cost_price: r.cost_price ? Number(r.cost_price) : undefined,
+                stock_quantity: r.stock_quantity || 0,
+                attributes: r.attributes,
+              }));
 
-          if (createdVariants.length === 0) {
+            if (createdVariants.length === 0) {
+              this.creatingVariants.set(false);
+              this.toastService.error('No se pudieron crear las variantes');
+              return;
+            }
+
+            const failedCount =
+              this.generatedVariants.length - createdVariants.length;
+            if (failedCount > 0) {
+              this.toastService.warning(
+                `Se crearon ${createdVariants.length} variantes, ${failedCount} fallaron`,
+              );
+            }
+
+            // Update local product reference
+            const currentProduct = this.product();
+            if (currentProduct) {
+              currentProduct.product_variants = createdVariants;
+            }
+
+            const lotInfo = this.buildLotInfo();
+            const pricingType = this.selectedPricingType();
+
+            this.confirmed.emit({
+              variants: createdVariants,
+              quantity: 1,
+              unit_cost: Number(
+                this.product()?.cost || this.product()?.cost_price || 0,
+              ),
+              pricing_type: pricingType,
+              lot_info: lotInfo,
+            });
+
             this.creatingVariants.set(false);
-            this.toastService.error('No se pudieron crear las variantes');
-            return;
-          }
-
-          const failedCount =
-            this.generatedVariants.length - createdVariants.length;
-          if (failedCount > 0) {
-            this.toastService.warning(
-              `Se crearon ${createdVariants.length} variantes, ${failedCount} fallaron`,
-            );
-          }
-
-          // Update local product reference
-          const currentProduct = this.product();
-          if (currentProduct) {
-            currentProduct.product_variants = createdVariants;
-          }
-
-          const lotInfo = this.buildLotInfo();
-          const pricingType = this.selectedPricingType();
-
-          this.confirmed.emit({
-            variants: createdVariants,
-            quantity: 1,
-            unit_cost: Number(
-              this.product()?.cost || this.product()?.cost_price || 0,
-            ),
-            pricing_type: pricingType,
-            lot_info: lotInfo,
-          });
-
-          this.creatingVariants.set(false);
-          this.closed.emit();
-        },
-        error: () => {
-          this.creatingVariants.set(false);
-          this.toastService.error('Error al crear variantes');
-        },
-      });
+            this.closed.emit();
+          },
+          error: () => {
+            this.creatingVariants.set(false);
+            this.toastService.error('Error al crear variantes');
+          },
+        });
       return;
     }
 
@@ -746,8 +788,8 @@ export class PopProductConfigModalComponent {
     const pricingType = this.selectedPricingType();
 
     if (this.hasVariantsToggle() && this.product()?.product_variants) {
-      const selectedVariants = (this.product()?.product_variants ?? []).filter((v) =>
-        this.selectedVariantIds.has(v.id),
+      const selectedVariants = (this.product()?.product_variants ?? []).filter(
+        (v) => this.selectedVariantIds.has(v.id),
       );
 
       if (this.isEditing()) {
@@ -775,7 +817,9 @@ export class PopProductConfigModalComponent {
     } else {
       this.confirmed.emit({
         quantity: 1,
-        unit_cost: Number(this.product()?.cost || this.product()?.cost_price || 0),
+        unit_cost: Number(
+          this.product()?.cost || this.product()?.cost_price || 0,
+        ),
         pricing_type: pricingType,
         lot_info: lotInfo,
       });
@@ -933,14 +977,10 @@ export class PopProductConfigModalComponent {
       this.requiresLotToggle.set(true);
       this.lotBatchNumber = lotInfo.batch_number || '';
       this.lotManufacturingDate = lotInfo.manufacturing_date
-        ? new Date(lotInfo.manufacturing_date)
-            .toISOString()
-            .split('T')[0]
+        ? new Date(lotInfo.manufacturing_date).toISOString().split('T')[0]
         : '';
       this.lotExpirationDate = lotInfo.expiration_date
-        ? new Date(lotInfo.expiration_date)
-            .toISOString()
-            .split('T')[0]
+        ? new Date(lotInfo.expiration_date).toISOString().split('T')[0]
         : '';
     } else if (this.product()?.requires_batch_tracking) {
       this.requiresLotToggle.set(true);

--- a/apps/frontend/src/app/private/modules/store/inventory/pop/components/pop-product-selection.component.ts
+++ b/apps/frontend/src/app/private/modules/store/inventory/pop/components/pop-product-selection.component.ts
@@ -2,6 +2,7 @@ import {
   Component,
   NO_ERRORS_SCHEMA,
   signal,
+  computed,
   output,
   inject,
   DestroyRef,
@@ -9,13 +10,13 @@ import {
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Subject, debounceTime, distinctUntilChanged } from 'rxjs';
 
-
 import { IconComponent } from '../../../../../../shared/components/icon/icon.component';
 import { InputsearchComponent } from '../../../../../../shared/components/inputsearch/inputsearch.component';
 import { OptionsDropdownComponent } from '../../../../../../shared/components/options-dropdown/options-dropdown.component';
 import { DropdownAction } from '../../../../../../shared/components/options-dropdown/options-dropdown.interfaces';
 import { BadgeComponent } from '../../../../../../shared/components/badge/badge.component';
 import { ToastService } from '../../../../../../shared/components/toast/toast.service';
+import { StoreSettingsFacade } from '../../../../../../core/store/store-settings/store-settings.facade';
 
 import { PopCartService } from '../services/pop-cart.service';
 import { ProductsService } from '../../../products/services/products.service';
@@ -34,17 +35,17 @@ import {
     OptionsDropdownComponent,
     BadgeComponent,
     PopBulkDataModalComponent,
-    PopProductConfigModalComponent
-],
+    PopProductConfigModalComponent,
+  ],
   schemas: [NO_ERRORS_SCHEMA],
   template: `
     <div
       class="h-full flex flex-col bg-surface rounded-card shadow-card border border-border"
-      >
+    >
       <!-- Products Header - Outside overflow container -->
       <div
         class="products-header flex-none px-4 lg:px-6 py-3 lg:py-4 border-b border-border bg-surface rounded-t-card"
-        >
+      >
         <!-- Desktop Header -->
         <div class="hidden lg:flex justify-between items-center gap-4">
           <div class="flex-1 min-w-0">
@@ -52,7 +53,7 @@ import {
               Productos Disponibles ({{ filteredProducts().length }})
             </h2>
           </div>
-    
+
           <div class="flex items-center gap-3">
             <app-inputsearch
               class="w-64"
@@ -60,8 +61,8 @@ import {
               placeholder="Buscar productos..."
               [debounceTime]="300"
               (searchChange)="onSearch($event)"
-              />
-    
+            />
+
             <app-options-dropdown
               [actions]="dropdownActions"
               triggerIcon="package-plus"
@@ -71,7 +72,7 @@ import {
             ></app-options-dropdown>
           </div>
         </div>
-    
+
         <!-- Mobile Header (Compact) -->
         <div class="lg:hidden flex items-center gap-2">
           <app-inputsearch
@@ -80,8 +81,8 @@ import {
             placeholder="Buscar..."
             [debounceTime]="300"
             (searchChange)="onSearch($event)"
-            />
-    
+          />
+
           <app-options-dropdown
             [actions]="dropdownActions"
             triggerIcon="package-plus"
@@ -91,7 +92,7 @@ import {
           ></app-options-dropdown>
         </div>
       </div>
-    
+
       <!-- Products Content -->
       <div class="flex-1 overflow-y-auto p-6">
         <!-- Loading State -->
@@ -103,15 +104,15 @@ import {
             <p class="mt-2 text-text-secondary">Cargando productos...</p>
           </div>
         }
-    
+
         <!-- Empty State -->
         @if (!loading() && filteredProducts().length === 0) {
           <div
             class="flex flex-col items-center justify-center h-64 text-center p-8"
-            >
+          >
             <div
               class="w-16 h-16 bg-muted rounded-full flex items-center justify-center mb-4"
-              >
+            >
               <app-icon
                 name="package"
                 [size]="32"
@@ -126,22 +127,25 @@ import {
             </p>
           </div>
         }
-    
+
         <!-- Modern Compact Products Grid (Responsive) -->
         @if (!loading() && filteredProducts().length > 0) {
           <div
             class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-2 sm:gap-3"
-            >
+          >
             <!-- Modern Product Card -->
-            @for (product of filteredProducts(); track trackByProductId($index, product)) {
+            @for (
+              product of filteredProducts();
+              track trackByProductId($index, product)
+            ) {
               <div
                 (click)="onAddToCart(product)"
                 class="group relative bg-surface border border-border rounded-card shadow-card hover:shadow-lg transition-all duration-200 hover:scale-[1.02] cursor-pointer overflow-hidden"
-                >
+              >
                 <!-- Product Image or Icon -->
                 <div
                   class="aspect-square bg-gradient-to-br from-surface to-muted/30 relative overflow-hidden"
-                  >
+                >
                   <!-- Product Image -->
                   @if (product.image_url) {
                     <img
@@ -149,16 +153,16 @@ import {
                       [alt]="product.name"
                       class="w-full h-full object-cover transition-transform duration-300 group-hover:scale-110"
                       (error)="onImageError($event)"
-                      />
+                    />
                   }
                   <!-- Placeholder Icon -->
                   @if (!product.image_url) {
                     <div
                       class="absolute inset-0 flex items-center justify-center text-muted-foreground/30 group-hover:text-primary/30 transition-colors"
-                      >
+                    >
                       <div
                         class="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center"
-                        >
+                      >
                         <app-icon
                           name="image"
                           [size]="24"
@@ -170,14 +174,20 @@ import {
                   <!-- Compact Stock Badge -->
                   @if (product.track_inventory !== false) {
                     <app-badge
-                      [variant]="product.stock_quantity === 0 ? 'error' : product.stock_quantity <= 10 ? 'warning' : 'success'"
+                      [variant]="getStockBadgeVariant(product)"
                       size="xs"
                       badgeStyle="outline"
-                      class="absolute top-2 right-2 z-[1]">
+                      class="absolute top-2 right-2 z-[1]"
+                    >
                       {{ product.stock_quantity }}
                     </app-badge>
                   } @else {
-                    <app-badge variant="info" size="xs" badgeStyle="outline" class="absolute top-2 right-2 z-[1]">
+                    <app-badge
+                      variant="info"
+                      size="xs"
+                      badgeStyle="outline"
+                      class="absolute top-2 right-2 z-[1]"
+                    >
                       Disponible
                     </app-badge>
                   }
@@ -187,27 +197,27 @@ import {
                   <h3
                     class="text-sm font-medium text-text-primary line-clamp-2 min-h-[2.5em] mb-1 group-hover:text-primary transition-colors"
                     [title]="product.name"
-                    >
+                  >
                     {{ product.name }}
                   </h3>
                   <div class="flex items-center justify-between mt-auto">
                     <div class="flex items-center gap-1 min-w-0">
                       <span
                         class="text-xs text-text-secondary font-mono truncate max-w-[60%]"
-                        >
+                      >
                         {{ product.sku }}
                       </span>
                       @if (product.pricing_type === 'weight') {
                         <span
                           class="inline-flex items-center px-1 py-0.5 rounded text-[9px] font-semibold bg-blue-50 text-blue-600 shrink-0"
-                          >
+                        >
                           Peso
                         </span>
                       }
                     </div>
                     <button
                       class="w-6 h-6 rounded-full bg-primary/10 hover:bg-primary/20 text-primary flex items-center justify-center transition-colors"
-                      >
+                    >
                       <app-icon name="plus" [size]="14"></app-icon>
                     </button>
                   </div>
@@ -218,7 +228,7 @@ import {
         }
       </div>
     </div>
-    
+
     <app-pop-bulk-data-modal
       [isOpen]="bulkModalOpen()"
       (close)="bulkModalOpen.set(false)"
@@ -231,7 +241,7 @@ import {
       (confirmed)="onProductConfigConfirmed($event)"
       (closed)="configModalOpen.set(false)"
     ></app-pop-product-config-modal>
-    `,
+  `,
   styles: [
     `
       :host {
@@ -314,7 +324,15 @@ export class PopProductSelectionComponent {
   private productsService = inject(ProductsService);
   private cartService = inject(PopCartService);
   private toastService = inject(ToastService);
+  private storeSettingsFacade = inject(StoreSettingsFacade);
   private searchSubject$ = new Subject<string>(); // LEGÍTIMO — debounceTime+distinctUntilChanged search stream
+
+  readonly lowStockThreshold = computed(() => {
+    const threshold = Number(
+      this.storeSettingsFacade.settings()?.inventory?.low_stock_threshold,
+    );
+    return Number.isFinite(threshold) && threshold >= 0 ? threshold : 10;
+  });
 
   constructor() {
     this.setupSearchSubscription();
@@ -323,7 +341,11 @@ export class PopProductSelectionComponent {
 
   private setupSearchSubscription(): void {
     this.searchSubject$
-      .pipe(debounceTime(300), distinctUntilChanged(), takeUntilDestroyed(this.destroyRef))
+      .pipe(
+        debounceTime(300),
+        distinctUntilChanged(),
+        takeUntilDestroyed(this.destroyRef),
+      )
       .subscribe((query) => {
         this.searchQuery = query;
         this.filterProducts();
@@ -389,7 +411,8 @@ export class PopProductSelectionComponent {
 
     const product = {
       ...this.configModalProduct(),
-      pricing_type: result.pricing_type || this.configModalProduct()?.pricing_type,
+      pricing_type:
+        result.pricing_type || this.configModalProduct()?.pricing_type,
     };
 
     if (result.variants?.length) {
@@ -435,7 +458,7 @@ export class PopProductSelectionComponent {
         (p: any) => p.id === this.configModalProduct()?.id,
       );
       if (productIndex >= 0) {
-        this.filteredProducts.update(products => {
+        this.filteredProducts.update((products) => {
           const updated = [...products];
           updated[productIndex] = {
             ...updated[productIndex],
@@ -454,6 +477,31 @@ export class PopProductSelectionComponent {
     event.target.style.display = 'none';
   }
 
+  getStockBadgeVariant(product: any): 'error' | 'warning' | 'success' {
+    const stock = Number(product?.stock_quantity ?? product?.stock ?? 0);
+    if (stock === 0) return 'error';
+    return stock <= this.getProductLowStockThreshold(product)
+      ? 'warning'
+      : 'success';
+  }
+
+  private getProductLowStockThreshold(product: any): number {
+    const productThreshold = [product?.reorder_point, product?.min_stock_level]
+      .map((value) => Number(value))
+      .find((value) => Number.isFinite(value) && value > 0);
+
+    if (productThreshold !== undefined) {
+      return productThreshold;
+    }
+
+    const apiThreshold = Number(product?.low_stock_threshold);
+    if (Number.isFinite(apiThreshold) && apiThreshold >= 0) {
+      return apiThreshold;
+    }
+
+    return this.lowStockThreshold();
+  }
+
   trackByProductId(index: number, product: any): string {
     return product.id;
   }
@@ -463,7 +511,7 @@ export class PopProductSelectionComponent {
       (p: any) => p.id === productId,
     );
     if (productIndex >= 0) {
-      this.filteredProducts.update(products => {
+      this.filteredProducts.update((products) => {
         const updated = [...products];
         updated[productIndex] = {
           ...updated[productIndex],

--- a/apps/frontend/src/app/private/modules/store/inventory/pop/interfaces/pop-cart.interface.ts
+++ b/apps/frontend/src/app/private/modules/store/inventory/pop/interfaces/pop-cart.interface.ts
@@ -11,57 +11,63 @@
  * Product interface (simplified for POP)
  */
 export interface PopProduct {
-    id: number;
-    name: string;
-    code?: string;
-    price?: number;
-    cost?: number;
-    cost_price?: number;
-    stock?: number;
-    image_url?: string;
-    category_id?: number;
-    is_active?: boolean;
-    is_on_sale?: boolean;
-    sale_price?: number;
-    pricing_type?: 'unit' | 'weight';
-    product_variants?: PopProductVariant[];
-    requires_batch_tracking?: boolean;
+  id: number;
+  name: string;
+  code?: string;
+  price?: number;
+  cost?: number;
+  cost_price?: number;
+  stock?: number;
+  stock_quantity?: number;
+  min_stock_level?: number | null;
+  reorder_point?: number | null;
+  low_stock_threshold?: number | null;
+  track_inventory?: boolean;
+  image_url?: string;
+  category_id?: number;
+  is_active?: boolean;
+  is_on_sale?: boolean;
+  sale_price?: number;
+  pricing_type?: 'unit' | 'weight';
+  product_variants?: PopProductVariant[];
+  requires_batch_tracking?: boolean;
 }
 
 /**
  * Product variant for POP selection
  */
 export interface PopProductVariant {
-    id: number;
-    name?: string;
-    sku: string;
-    cost_price?: number;
-    stock_quantity?: number;
-    attributes?: Record<string, any>;
+  id: number;
+  name?: string;
+  sku: string;
+  cost_price?: number;
+  stock_quantity?: number;
+  low_stock_threshold?: number | null;
+  attributes?: Record<string, any>;
 }
 
 /**
  * Supplier interface for header selection
  */
 export interface PopSupplier {
-    id: number;
-    name: string;
-    code?: string;
-    email?: string;
-    phone?: string;
-    tax_id?: string;
-    is_active?: boolean;
+  id: number;
+  name: string;
+  code?: string;
+  email?: string;
+  phone?: string;
+  tax_id?: string;
+  is_active?: boolean;
 }
 
 /**
  * Location/Warehouse interface for header selection
  */
 export interface PopLocation {
-    id: number;
-    name: string;
-    code?: string;
-    type?: string;
-    is_active?: boolean;
+  id: number;
+  name: string;
+  code?: string;
+  type?: string;
+  is_active?: boolean;
 }
 
 // ============================================================================
@@ -72,21 +78,21 @@ export interface PopLocation {
  * Shipping method options
  */
 export type ShippingMethod =
-    | 'supplier_transport'
-    | 'freight'
-    | 'pickup'
-    | 'other';
+  | 'supplier_transport'
+  | 'freight'
+  | 'pickup'
+  | 'other';
 
 /**
  * Payment term presets
  */
 export type PaymentTermPreset =
-    | 'immediate'
-    | 'net_15'
-    | 'net_30'
-    | 'net_60'
-    | 'net_90'
-    | 'custom';
+  | 'immediate'
+  | 'net_15'
+  | 'net_30'
+  | 'net_60'
+  | 'net_90'
+  | 'custom';
 
 // ============================================================================
 // POP-Specific Interfaces
@@ -96,125 +102,125 @@ export type PaymentTermPreset =
  * Lot/Batch information for purchase order items
  */
 export interface LotInfo {
-    batch_number?: string;
-    manufacturing_date?: Date;
-    expiration_date?: Date;
+  batch_number?: string;
+  manufacturing_date?: Date;
+  expiration_date?: Date;
 }
 
 /**
  * Pre-bulk product data (temporary products not in catalog)
  */
 export interface PreBulkData {
-    name: string;
-    code?: string;
-    description?: string;
-    product_type?: string;
-    track_inventory?: boolean;
-    pricing_type?: string;
-    tax_category_ids?: number[];
-    state?: string;
-    weight?: number;
-    available_for_ecommerce?: boolean;
-    is_featured?: boolean;
-    allow_pos_price_override?: boolean;
-    has_multiple_price_tiers?: boolean;
-    units_per_package?: number;
-    package_consumes_multiple_stock?: boolean;
-    base_price?: number;
-    profit_margin?: number;
-    brand_id?: number | string;
-    category_ids?: number[] | string;
-    is_on_sale?: boolean;
-    sale_price?: number;
+  name: string;
+  code?: string;
+  description?: string;
+  product_type?: string;
+  track_inventory?: boolean;
+  pricing_type?: string;
+  tax_category_ids?: number[];
+  state?: string;
+  weight?: number;
+  available_for_ecommerce?: boolean;
+  is_featured?: boolean;
+  allow_pos_price_override?: boolean;
+  has_multiple_price_tiers?: boolean;
+  units_per_package?: number;
+  package_consumes_multiple_stock?: boolean;
+  base_price?: number;
+  profit_margin?: number;
+  brand_id?: number | string;
+  category_ids?: number[] | string;
+  is_on_sale?: boolean;
+  sale_price?: number;
 }
 
 /**
  * Cart item for purchase order
  */
 export interface PopCartItem {
-    id: string;
-    product: PopProduct;
-    variant?: PopProductVariant | null;
-    quantity: number;
-    unit_cost: number;
-    discount: number;
-    tax_rate: number;
-    subtotal: number;
-    tax_amount: number;
-    total: number;
-    // Optional lot information
-    lot_info?: LotInfo;
-    notes?: string;
-    // Pre-bulk flag (temporary product not in catalog)
-    is_prebulk?: boolean;
-    prebulk_data?: PreBulkData;
-    addedAt: Date;
+  id: string;
+  product: PopProduct;
+  variant?: PopProductVariant | null;
+  quantity: number;
+  unit_cost: number;
+  discount: number;
+  tax_rate: number;
+  subtotal: number;
+  tax_amount: number;
+  total: number;
+  // Optional lot information
+  lot_info?: LotInfo;
+  notes?: string;
+  // Pre-bulk flag (temporary product not in catalog)
+  is_prebulk?: boolean;
+  prebulk_data?: PreBulkData;
+  addedAt: Date;
 }
 
 /**
  * Financial summary for purchase order cart
  */
 export interface PopCartSummary {
-    subtotal: number;
-    tax_amount: number;
-    shipping_cost: number;
-    total: number;
-    itemCount: number;
-    totalItems: number;
+  subtotal: number;
+  tax_amount: number;
+  shipping_cost: number;
+  total: number;
+  itemCount: number;
+  totalItems: number;
 }
 
 /**
  * Complete cart state
  */
 export interface PopCartState {
-    orderId?: number; // ID of the order being edited
-    items: PopCartItem[];
-    summary: PopCartSummary;
-    supplierId: number | null;
-    locationId: number | null;
-    orderDate: Date;
-    expectedDate?: Date;
-    shippingMethod?: string;
-    shippingCost: number;
-    paymentTerms?: string;
-    notes?: string;
-    internalNotes?: string;
-    status: 'draft' | 'submitted' | 'approved';
-    createdAt: Date;
-    updatedAt: Date;
+  orderId?: number; // ID of the order being edited
+  items: PopCartItem[];
+  summary: PopCartSummary;
+  supplierId: number | null;
+  locationId: number | null;
+  orderDate: Date;
+  expectedDate?: Date;
+  shippingMethod?: string;
+  shippingCost: number;
+  paymentTerms?: string;
+  notes?: string;
+  internalNotes?: string;
+  status: 'draft' | 'submitted' | 'approved';
+  createdAt: Date;
+  updatedAt: Date;
 }
 
 /**
  * Request to add item to cart
  */
 export interface AddToPopCartRequest {
-    product: PopProduct;
-    variant?: PopProductVariant | null;
-    quantity: number;
-    unit_cost: number;
-    lot_info?: LotInfo;
-    notes?: string;
-    is_prebulk?: boolean;
-    prebulk_data?: PreBulkData;
+  product: PopProduct;
+  variant?: PopProductVariant | null;
+  quantity: number;
+  unit_cost: number;
+  lot_info?: LotInfo;
+  notes?: string;
+  is_prebulk?: boolean;
+  prebulk_data?: PreBulkData;
 }
 
 /**
  * Request to update cart item
  */
 export interface UpdatePopCartItemRequest {
-    itemId: string;
-    quantity?: number;
-    unit_cost?: number;
-    lot_info?: LotInfo;
-    notes?: string;
-    variant?: PopProductVariant | null;
-    pricing_type?: 'unit' | 'weight';
+  itemId: string;
+  quantity?: number;
+  unit_cost?: number;
+  lot_info?: LotInfo;
+  notes?: string;
+  variant?: PopProductVariant | null;
+  pricing_type?: 'unit' | 'weight';
 }
 
 /**
  * Cart validation error
  */
 export interface PopCartValidationError {
-    field: string;
-    message: string;
+  field: string;
+  message: string;
 }

--- a/apps/frontend/src/app/private/modules/store/marketing/promotions/components/promotion-form-modal/promotion-form-modal.component.ts
+++ b/apps/frontend/src/app/private/modules/store/marketing/promotions/components/promotion-form-modal/promotion-form-modal.component.ts
@@ -111,25 +111,38 @@ import { CategoriesService } from '../../../../products/services/categories.serv
         <!-- Product Selector (when scope is product) -->
         @if (form.get('scope')?.value === 'product') {
           <app-multi-selector
-            label="Productos"
+            label="Productos elegibles"
             [options]="productOptions()"
             formControlName="product_ids"
             placeholder="Buscar productos..."
             [required]="true"
-            [errorText]="form.get('product_ids')?.touched && form.get('product_ids')?.invalid ? 'Selecciona al menos un producto' : ''"
+            [errorText]="form.get('product_ids')?.touched && form.get('product_ids')?.invalid ? 'Selecciona al menos un producto para esta promocion' : ''"
           ></app-multi-selector>
+          <p class="text-xs text-gray-500 -mt-1">
+            La promocion solo aplicara cuando los productos seleccionados esten en el carrito.
+          </p>
         }
 
         <!-- Category Selector (when scope is category) -->
         @if (form.get('scope')?.value === 'category') {
           <app-multi-selector
-            label="Categorias"
+            label="Categorias elegibles"
             [options]="categoryOptions()"
             formControlName="category_ids"
             placeholder="Buscar categorias..."
             [required]="true"
-            [errorText]="form.get('category_ids')?.touched && form.get('category_ids')?.invalid ? 'Selecciona al menos una categoria' : ''"
+            [errorText]="form.get('category_ids')?.touched && form.get('category_ids')?.invalid ? 'Selecciona al menos una categoria para esta promocion' : ''"
           ></app-multi-selector>
+          <p class="text-xs text-gray-500 -mt-1">
+            La promocion aplicara a todos los productos que pertenezcan a las categorias seleccionadas.
+          </p>
+        }
+
+        <!-- Helper note for order scope -->
+        @if (form.get('scope')?.value === 'order') {
+          <p class="text-xs text-gray-500">
+            La promocion aplicara al total de la compra cuando se cumpla la compra minima configurada.
+          </p>
         }
 
         <!-- Dates + Min purchase -->
@@ -270,7 +283,17 @@ export class PromotionFormModalComponent {
 
     this.form.get('scope')?.valueChanges
       .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((scope) => this.configureScopeValidators(scope));
+      .subscribe((scope) => {
+        this.configureScopeValidators(scope);
+        // Clear fields that no longer apply for the new scope so they
+        // are not submitted as dirty data.
+        if (scope !== 'product') {
+          this.form.patchValue({ product_ids: [] }, { emitEvent: false });
+        }
+        if (scope !== 'category') {
+          this.form.patchValue({ category_ids: [] }, { emitEvent: false });
+        }
+      });
 
     // Load product and category options for multi-selectors
     this.productsService.getProducts({ limit: 500 })
@@ -355,6 +378,10 @@ export class PromotionFormModalComponent {
   }
 
   onSubmit(): void {
+    // Re-run scope validators in case the user changed scope and never blurred
+    // the dependent selector. This prevents stale validity state.
+    this.configureScopeValidators(this.form.get('scope')?.value);
+
     if (this.form.invalid) {
       this.form.markAllAsTouched();
       return;
@@ -373,13 +400,28 @@ export class PromotionFormModalComponent {
     if (dto.per_customer_limit === null || dto.per_customer_limit === '') delete dto.per_customer_limit;
     if (dto.type !== 'percentage') delete dto.max_discount_amount;
 
-    // Clean up scope-specific IDs
+    // Normalize scope-specific IDs:
+    // - Product scope: send product_ids, strip category_ids.
+    // - Category scope: send category_ids, strip product_ids.
+    // - Order scope: strip both — they must not be persisted as dirty data.
     if (dto.scope === 'product') {
       dto.product_ids = this.toNumberArray(dto.product_ids);
       delete dto.category_ids;
+      if (!dto.product_ids.length) {
+        // Defensive guard: should be unreachable because of form validators,
+        // but we never want to send an inconsistent payload.
+        this.form.get('product_ids')?.setErrors({ required: true });
+        this.form.markAllAsTouched();
+        return;
+      }
     } else if (dto.scope === 'category') {
       dto.category_ids = this.toNumberArray(dto.category_ids);
       delete dto.product_ids;
+      if (!dto.category_ids.length) {
+        this.form.get('category_ids')?.setErrors({ required: true });
+        this.form.markAllAsTouched();
+        return;
+      }
     } else {
       delete dto.product_ids;
       delete dto.category_ids;

--- a/apps/frontend/src/app/private/modules/store/orders/interfaces/order.interface.ts
+++ b/apps/frontend/src/app/private/modules/store/orders/interfaces/order.interface.ts
@@ -79,6 +79,40 @@ export interface Order {
     phone?: string;
     avatar_url?: string;
   };
+  // Persisted discount snapshots — read-only from backend, never recalculated.
+  order_promotions?: OrderPromotionSnapshot[];
+  coupon_uses?: CouponUseSnapshot[];
+}
+
+export interface OrderPromotionSnapshot {
+  id: number;
+  promotion_id: number;
+  customer_id?: number | null;
+  discount_amount: number | string;
+  created_at?: string | null;
+  promotions?: {
+    id: number;
+    name: string;
+    code?: string | null;
+    type?: 'percentage' | 'fixed_amount' | string | null;
+    scope?: 'order' | 'product' | 'category' | string | null;
+    value?: number | string | null;
+  } | null;
+}
+
+export interface CouponUseSnapshot {
+  id: number;
+  coupon_id: number;
+  customer_id?: number | null;
+  discount_applied: number | string;
+  used_at?: string | null;
+  coupon?: {
+    id: number;
+    code: string;
+    name?: string | null;
+    discount_type?: string | null;
+    discount_value?: number | string | null;
+  } | null;
 }
 
 export interface OrderItem {

--- a/apps/frontend/src/app/private/modules/store/orders/pages/order-details/order-details-page.component.html
+++ b/apps/frontend/src/app/private/modules/store/orders/pages/order-details/order-details-page.component.html
@@ -1303,9 +1303,74 @@
                   orderData.subtotal_amount || 0 | currency
                 }}</span>
               </div>
+
+              <!-- Applied promotions (persisted snapshot) -->
+              @if (appliedPromotions().length > 0) {
+                <div class="pt-1 space-y-1.5">
+                  @for (promo of appliedPromotions(); track promo.id) {
+                    <div
+                      class="flex justify-between items-start text-xs sm:text-sm gap-2"
+                    >
+                      <div class="flex items-start gap-1.5 min-w-0">
+                        <app-icon
+                          name="tag"
+                          size="14"
+                          class="text-green-600 mt-0.5 flex-shrink-0"
+                        ></app-icon>
+                        <span class="text-text-secondary truncate">
+                          {{ promo.name }}
+                          @if (promo.code) {
+                            <span class="text-text-secondary/70">
+                              ({{ promo.code }})</span
+                            >
+                          }
+                        </span>
+                      </div>
+                      <span class="font-semibold text-green-600 whitespace-nowrap"
+                        >-{{ promo.discount_amount | currency }}</span
+                      >
+                    </div>
+                  }
+                </div>
+              }
+
+              <!-- Applied coupons (persisted snapshot) -->
+              @if (appliedCoupons().length > 0) {
+                <div class="pt-1 space-y-1.5">
+                  @for (cp of appliedCoupons(); track cp.id) {
+                    <div
+                      class="flex justify-between items-start text-xs sm:text-sm gap-2"
+                    >
+                      <div class="flex items-start gap-1.5 min-w-0">
+                        <app-icon
+                          name="ticket"
+                          size="14"
+                          class="text-green-600 mt-0.5 flex-shrink-0"
+                        ></app-icon>
+                        <span class="text-text-secondary truncate">
+                          Cupón
+                          <span class="font-semibold text-gray-900">{{
+                            cp.code
+                          }}</span>
+                          @if (cp.name) {
+                            <span class="text-text-secondary/70">
+                              — {{ cp.name }}</span
+                            >
+                          }
+                        </span>
+                      </div>
+                      <span class="font-semibold text-green-600 whitespace-nowrap"
+                        >-{{ cp.discount_applied | currency }}</span
+                      >
+                    </div>
+                  }
+                </div>
+              }
+
+              <!-- Total discount (always shown when > 0; aggregates snapshot or legacy discount_amount) -->
               @if (orderData.discount_amount && orderData.discount_amount > 0) {
                 <div class="flex justify-between items-center text-sm">
-                  <span class="text-text-secondary">Descuento</span>
+                  <span class="text-text-secondary">Descuento total</span>
                   <span class="font-semibold text-green-600"
                     >-{{ orderData.discount_amount || 0 | currency }}</span
                   >

--- a/apps/frontend/src/app/private/modules/store/orders/pages/order-details/order-details-page.component.ts
+++ b/apps/frontend/src/app/private/modules/store/orders/pages/order-details/order-details-page.component.ts
@@ -99,6 +99,33 @@ export class OrderDetailsPageComponent {
     }
     return Array.from(groups.values());
   });
+
+  // ── Discount snapshots (read-only from order; never recalculated) ──
+  readonly appliedPromotions = computed(() =>
+    (this.order()?.order_promotions ?? []).map((op) => ({
+      id: op.id,
+      promotion_id: op.promotion_id,
+      name: op.promotions?.name ?? `Promoción #${op.promotion_id}`,
+      code: op.promotions?.code ?? null,
+      type: op.promotions?.type ?? null,
+      scope: op.promotions?.scope ?? null,
+      discount_amount: Number(op.discount_amount || 0),
+    })),
+  );
+
+  readonly appliedCoupons = computed(() =>
+    (this.order()?.coupon_uses ?? []).map((cu) => ({
+      id: cu.id,
+      coupon_id: cu.coupon_id,
+      code: cu.coupon?.code ?? `CUP-${cu.coupon_id}`,
+      name: cu.coupon?.name ?? null,
+      discount_applied: Number(cu.discount_applied || 0),
+    })),
+  );
+
+  readonly hasDiscountSnapshot = computed(
+    () => this.appliedPromotions().length > 0 || this.appliedCoupons().length > 0,
+  );
   orderRefunds = signal<RefundRecord[]>([]);
   private rawTimeline = signal<any[]>([]);
   isLoading = signal(false);
@@ -864,6 +891,18 @@ export class OrderDetailsPageComponent {
                 item.stock_units_consumed != null
                   ? Number(item.stock_units_consumed)
                   : null,
+            })),
+            // Persisted discount snapshots — numeric coercion only,
+            // never recalculated against current promotions/coupons.
+            order_promotions: (orderData.order_promotions || []).map(
+              (op: any) => ({
+                ...op,
+                discount_amount: Number(op.discount_amount || 0),
+              }),
+            ),
+            coupon_uses: (orderData.coupon_uses || []).map((cu: any) => ({
+              ...cu,
+              discount_applied: Number(cu.discount_applied || 0),
             })),
           });
 

--- a/apps/frontend/src/app/private/modules/store/orders/purchase-orders/purchase-orders.component.ts
+++ b/apps/frontend/src/app/private/modules/store/orders/purchase-orders/purchase-orders.component.ts
@@ -89,5 +89,17 @@ export class PurchaseOrdersComponent {
     if (this.purchaseOrderList) {
       this.purchaseOrderList.loadOrders();
     }
+
+    const currentOrder = this.selectedOrder();
+    if (this.isDetailModalOpen() && currentOrder) {
+      this.purchaseOrdersService
+        .getPurchaseOrderById(currentOrder.id)
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe({
+          next: (response: any) => {
+            this.selectedOrder.set(response.data || response);
+          },
+        });
+    }
   }
 }

--- a/apps/frontend/src/app/private/modules/store/pos/cart/pos-cart.component.ts
+++ b/apps/frontend/src/app/private/modules/store/pos/cart/pos-cart.component.ts
@@ -195,6 +195,23 @@ import {
                 {{ formatCurrency(summary()?.total || 0) }}
               </span>
             </div>
+
+            <!--
+              Local estimate disclaimer.
+              Backend (PromotionEngineService + CouponsService) is the source
+              of truth for the final discount and grand total. The values
+              shown above are computed locally for UX feedback only and are
+              recalculated server-side when the sale is processed.
+            -->
+            @if (getPromotionDiscounts().length > 0 || getAppliedCoupon()) {
+              <div
+                class="flex items-center gap-1 text-[10px] text-text-secondary/80 italic mt-1"
+                title="Los totales finales se confirman al procesar el pago"
+              >
+                <app-icon name="info" [size]="10"></app-icon>
+                <span>Estimación. El total final se confirma al cobrar.</span>
+              </div>
+            }
           </div>
 
           <!-- Checkout Actions -->

--- a/apps/frontend/src/app/private/modules/store/pos/components/pos-cash-movement-modal.component.ts
+++ b/apps/frontend/src/app/private/modules/store/pos/components/pos-cash-movement-modal.component.ts
@@ -24,6 +24,7 @@ import {
 } from '../../../../../shared/components';
 import { PosCashRegisterService } from '../services/pos-cash-register.service';
 import { ToastService } from '../../../../../shared/components/toast/toast.service';
+import { extractApiErrorMessage } from '../../../../../core/utils/api-error-handler';
 
 @Component({
   selector: 'app-pos-cash-movement-modal',
@@ -221,9 +222,7 @@ export class PosCashMovementModalComponent {
         },
         error: (err) => {
           this.submitting.set(false);
-          this.toastService.error(
-            err.error?.message || 'Error al registrar movimiento',
-          );
+          this.toastService.error(extractApiErrorMessage(err));
         },
       });
   }

--- a/apps/frontend/src/app/private/modules/store/pos/components/pos-customer-modal.component.ts
+++ b/apps/frontend/src/app/private/modules/store/pos/components/pos-customer-modal.component.ts
@@ -5,8 +5,9 @@ import {
   inject,
   effect,
   DestroyRef,
-  signal } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+  signal,
+  computed } from '@angular/core';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import {
   FormsModule,
   FormBuilder,
@@ -24,6 +25,11 @@ import {
   IconComponent,
   InputsearchComponent,
   DialogService } from '../../../../../shared/components';
+import {
+  DOCUMENT_TYPES,
+  findDocumentType,
+  DocumentTypeOption,
+} from '../../../../../shared/constants/document-types';
 import { PosCustomerService } from '../services/pos-customer.service';
 import { PosQueueService, QueueEntry } from '../services/pos-queue.service';
 import {
@@ -391,7 +397,7 @@ import { StoreContextService } from '../../../../../core/services/store-context.
                 <app-input
                   formControlName="documentNumber"
                   label="Número *"
-                  placeholder="12345678"
+                  [placeholder]="documentNumberPlaceholder()"
                   type="text"
                   [size]="'md'"
                   [error]="getFieldError('documentNumber')"
@@ -544,13 +550,20 @@ export class PosCustomerModalComponent {
   readonly queueLoading = signal(false);
   readonly queueQrData = signal<{ qr_data_url: string; url: string } | null>(null);
 
-  documentTypeOptions = [
-    { value: 'CC', label: 'Cédula de Ciudadanía' },
-    { value: 'NIT', label: 'NIT' },
-    { value: 'CE', label: 'Cédula de Extranjería' },
-    { value: 'PP', label: 'Pasaporte' },
-    { value: 'TI', label: 'Tarjeta de Identidad' },
-  ];
+  /** Opciones del selector derivadas del catálogo compartido (single source of truth). */
+  readonly documentTypeOptions = DOCUMENT_TYPES.map((opt) => ({
+    value: opt.code,
+    label: opt.label,
+  }));
+
+  /** Tipo de documento seleccionado (reactivo a cambios del FormControl). */
+  readonly selectedDocumentType = signal<DocumentTypeOption | undefined>(undefined);
+
+  /** Placeholder dinámico para el input de número de documento. */
+  readonly documentNumberPlaceholder = computed(() => {
+    const type = this.selectedDocumentType();
+    return type?.placeholder ?? '12345678';
+  });
 
   // Document lookup
   documentLookupQuery = '';
@@ -566,8 +579,35 @@ private searchSubject$ = new Subject<string>(); // LEGÍTIMO — debounceTime+di
 
   constructor() {
     this.customerForm = this.createCustomerForm();
-this.setupFormListeners();
     this.setupSearchSubscription();
+
+    // Bridge document_type valueChanges -> signal (Zoneless-safe reactive read).
+    const documentTypeControl = this.customerForm.controls['documentType'];
+    const documentTypeValue = toSignal(documentTypeControl.valueChanges, {
+      initialValue: documentTypeControl.value as string | null,
+    });
+
+    // Mantener `selectedDocumentType` sincronizado con el FormControl.
+    effect(() => {
+      const code = documentTypeValue();
+      this.selectedDocumentType.set(findDocumentType(code));
+    });
+
+    // Validadores dinámicos del número de documento según el tipo elegido.
+    effect(() => {
+      const ctrl = this.customerForm.controls['documentNumber'];
+      const type = this.selectedDocumentType();
+      if (type) {
+        ctrl.setValidators([
+          Validators.required,
+          Validators.pattern(type.regex),
+          Validators.maxLength(type.maxLength),
+        ]);
+      } else {
+        ctrl.setValidators([Validators.required]);
+      }
+      ctrl.updateValueAndValidity({ emitEvent: false });
+    });
 
     // If customer is provided, populate form for editing
     effect(() => {
@@ -592,23 +632,6 @@ this.setupFormListeners();
       phone: [''],
       documentType: [''],
       documentNumber: ['', [Validators.required]] });
-  }
-
-  private setupFormListeners(): void {
-    // Auto-validate document number when document type changes
-    this.customerForm
-      .get('documentType')
-      ?.valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((documentType) => {
-        const documentNumberControl = this.customerForm.get('documentNumber');
-        if (documentType && documentNumberControl) {
-          documentNumberControl.setValidators([
-            Validators.required,
-            Validators.minLength(5),
-          ]);
-          documentNumberControl.updateValueAndValidity();
-        }
-      });
   }
 
   private setupSearchSubscription(): void {

--- a/apps/frontend/src/app/private/modules/store/pos/components/pos-header-dropdown.component.ts
+++ b/apps/frontend/src/app/private/modules/store/pos/components/pos-header-dropdown.component.ts
@@ -40,7 +40,7 @@ import { PosCustomer } from '../models/customer.model';
         }
 
         <!-- Cash register dot -->
-        @if (cashSession()) {
+        @if (cashSession()?.status === 'open') {
           <span class="relative flex h-2 w-2 flex-shrink-0">
             <span
               class="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"
@@ -145,7 +145,7 @@ import { PosCustomer } from '../models/customer.model';
           }
 
           <!-- Cash register section -->
-          @if (cashSession()) {
+          @if (cashSession()?.status === 'open') {
             <div class="p-3 space-y-2">
               <div class="flex items-center gap-2">
                 <span class="relative flex h-2.5 w-2.5 flex-shrink-0">

--- a/apps/frontend/src/app/private/modules/store/pos/components/pos-order-confirmation.component.ts
+++ b/apps/frontend/src/app/private/modules/store/pos/components/pos-order-confirmation.component.ts
@@ -130,9 +130,30 @@ import { InvoicingNotConfiguredComponent } from '../../invoicing/components/invo
               <span>Subtotal:</span>
               <span>{{ formatCurrency(orderSubtotal) }}</span>
             </div>
+            @for (promo of appliedPromotions; track promo.id) {
+              <div class="flex justify-between text-xs text-success">
+                <span class="truncate">
+                  <app-icon name="tag" [size]="12" class="inline mr-1"></app-icon>
+                  {{ promo.name }}
+                  @if (promo.code) {
+                    <span class="opacity-70">({{ promo.code }})</span>
+                  }
+                </span>
+                <span class="font-medium whitespace-nowrap">-{{ formatCurrency(promo.discount_amount) }}</span>
+              </div>
+            }
+            @for (cp of appliedCoupons; track cp.id) {
+              <div class="flex justify-between text-xs text-success">
+                <span class="truncate">
+                  <app-icon name="ticket" [size]="12" class="inline mr-1"></app-icon>
+                  Cupón <strong>{{ cp.code }}</strong>
+                </span>
+                <span class="font-medium whitespace-nowrap">-{{ formatCurrency(cp.discount_applied) }}</span>
+              </div>
+            }
             @if (hasDiscount()) {
               <div class="flex justify-between text-sm text-destructive font-medium">
-                <span>Descuento:</span>
+                <span>Descuento total:</span>
                 <span>-{{ formatCurrency(orderDiscount) }}</span>
               </div>
             }
@@ -310,6 +331,22 @@ export class PosOrderConfirmationComponent {
   orderDiscount = 0;
   orderTax = 0;
   orderTotal = 0;
+  // Persisted discount snapshots — populated only when the POS payment
+  // response includes them; never recalculated client-side.
+  appliedPromotions: Array<{
+    id?: number;
+    promotion_id?: number;
+    name: string;
+    code?: string | null;
+    discount_amount: number;
+  }> = [];
+  appliedCoupons: Array<{
+    id?: number;
+    coupon_id?: number;
+    code: string;
+    name?: string | null;
+    discount_applied: number;
+  }> = [];
   paymentInfo: any = null;
 private authFacade = inject(AuthFacade);
   private toastService = inject(ToastService);
@@ -390,10 +427,41 @@ effect(() => {
 	        unitsPerPackage };
 	    });
 
+    // Totals come directly from the backend response (source of truth).
+    // The backend recalculates promotions and coupons server-side and
+    // returns the final `discount_amount` and `total_amount` (mapped from
+    // `orders.grand_total`). This component MUST NOT recalculate them
+    // from items — that would diverge from what was actually persisted
+    // and charged. See `PaymentsService.processPosPayment` /
+    // `calculatePosPromotionQuote` / `calculatePosCouponDiscount`.
     this.orderSubtotal = Number(data.subtotal || 0);
     this.orderDiscount = Number(data.discount_amount || data.discount || 0);
     this.orderTax = Number(data.tax_amount || data.tax || 0);
     this.orderTotal = Number(data.total_amount || data.total || 0);
+
+    // Optional persisted discount snapshots from POS response. Fall back to
+    // empty arrays — the order detail page still shows the full breakdown.
+    const promoSnapshots: any[] =
+      data.applied_promotions || data.order_promotions || [];
+    this.appliedPromotions = promoSnapshots.map((op: any) => ({
+      id: op.id,
+      promotion_id: op.promotion_id,
+      name:
+        op.name ??
+        op.promotions?.name ??
+        `Promoción #${op.promotion_id ?? ''}`,
+      code: op.code ?? op.promotions?.code ?? null,
+      discount_amount: Number(op.discount_amount || 0),
+    }));
+    const couponSnapshots: any[] =
+      data.applied_coupons || data.coupon_uses || [];
+    this.appliedCoupons = couponSnapshots.map((cu: any) => ({
+      id: cu.id,
+      coupon_id: cu.coupon_id,
+      code: cu.code ?? cu.coupon?.code ?? `CUP-${cu.coupon_id ?? ''}`,
+      name: cu.name ?? cu.coupon?.name ?? null,
+      discount_applied: Number(cu.discount_applied || 0),
+    }));
 
     if (data.payment) {
       this.paymentInfo = {

--- a/apps/frontend/src/app/private/modules/store/pos/components/pos-product-selection.component.ts
+++ b/apps/frontend/src/app/private/modules/store/pos/components/pos-product-selection.component.ts
@@ -229,7 +229,9 @@ import {
                     </div>
                   }
                   <!-- Stock Badge -->
-                  @if (product.track_inventory !== false && !product.has_variants) {
+                  @if (
+                    product.track_inventory !== false && !product.has_variants
+                  ) {
                     @if (product.is_available === false) {
                       <app-badge
                         variant="error"
@@ -239,7 +241,7 @@ import {
                       >
                         AGOTADO
                       </app-badge>
-                    } @else if (product.stock <= 5) {
+                    } @else if (isProductLowStock(product)) {
                       <app-badge
                         variant="warning"
                         size="xs"
@@ -257,6 +259,17 @@ import {
                       class="absolute top-2 right-2 z-[1]"
                     >
                       Disponible
+                    </app-badge>
+                  }
+                  <!-- Promotion Badge — backend-resolved auto promotion. -->
+                  @if (product.active_promotion) {
+                    <app-badge
+                      variant="success"
+                      size="xs"
+                      badgeStyle="outline"
+                      class="absolute bottom-2 right-2 z-[1]"
+                    >
+                      {{ product.active_promotion.badge_label }}
                     </app-badge>
                   }
                   <!-- Variant Indicator -->
@@ -310,17 +323,38 @@ import {
                   <div class="flex items-center justify-between">
                     <!-- Price -->
                     <div class="flex flex-col">
-                      <span
-                        class="text-text-primary font-bold text-xs sm:text-sm lg:text-base xl:text-lg leading-tight truncate"
-                      >
-                        {{ product.final_price | currency }}
-                        @if (product.pricing_type === 'weight') {
+                      @if (hasActivePromoOrSale(product)) {
+                        <div class="flex items-baseline gap-1 flex-wrap">
                           <span
-                            class="text-[10px] font-normal text-text-secondary"
-                            >/{{ defaultWeightUnit() }}</span
+                            class="text-success font-bold text-xs sm:text-sm lg:text-base xl:text-lg leading-tight truncate"
                           >
-                        }
-                      </span>
+                            {{ promotionalPrice(product) | currency }}
+                            @if (product.pricing_type === 'weight') {
+                              <span
+                                class="text-[10px] font-normal text-text-secondary"
+                                >/{{ defaultWeightUnit() }}</span
+                              >
+                            }
+                          </span>
+                          <span
+                            class="text-[10px] sm:text-xs text-text-muted line-through"
+                          >
+                            {{ product.final_price | currency }}
+                          </span>
+                        </div>
+                      } @else {
+                        <span
+                          class="text-text-primary font-bold text-xs sm:text-sm lg:text-base xl:text-lg leading-tight truncate"
+                        >
+                          {{ product.final_price | currency }}
+                          @if (product.pricing_type === 'weight') {
+                            <span
+                              class="text-[10px] font-normal text-text-secondary"
+                              >/{{ defaultWeightUnit() }}</span
+                            >
+                          }
+                        </span>
+                      }
                       <!-- Stock indicator for non-variant products -->
                       @if (product.track_inventory !== false) {
                         @if (!product.has_variants) {
@@ -329,7 +363,7 @@ import {
                             [class]="
                               product.is_available === false
                                 ? 'text-error font-semibold'
-                                : product.stock <= 5
+                                : isProductLowStock(product)
                                   ? 'text-warning font-medium'
                                   : 'text-text-muted'
                             "
@@ -519,6 +553,7 @@ export class PosProductSelectionComponent {
   readonly scaleEnabled = signal(false);
   readonly defaultWeightUnit = signal<'kg' | 'g' | 'lb'>('kg');
   readonly allowManualWeightEntry = signal(true);
+  readonly lowStockThreshold = signal(10);
 
   // Filter configuration for the options dropdown
   filterConfigs: FilterConfig[] = [
@@ -1032,9 +1067,8 @@ export class PosProductSelectionComponent {
             return;
           }
           const variantLabel =
-            variant?.attributes
-              ?.map((a) => a.attribute_value)
-              .join(' / ') || '';
+            variant?.attributes?.map((a) => a.attribute_value).join(' / ') ||
+            '';
           this.sourcingResponse.set(response);
           this.sourcingProductName.set(product?.name ?? '');
           this.sourcingVariantLabel.set(variantLabel);
@@ -1057,7 +1091,7 @@ export class PosProductSelectionComponent {
 
   private async addToCartNormal(product: any): Promise<void> {
     if (product.track_inventory !== false) {
-      if (product.stock > 0 && product.stock <= 5) {
+      if (product.stock > 0 && this.isProductLowStock(product)) {
         this.toastService.warning(
           `Producto con existencias bajo (${product.stock} unidades restantes)`,
         );
@@ -1262,11 +1296,72 @@ export class PosProductSelectionComponent {
     return this.currencyService.format(amount);
   }
 
+  /**
+   * Cards render the promotional price when the product has either a
+   * backend-resolved auto promotion (`active_promotion`) or an active
+   * `sale_price < base_price`. Both paths are visually consistent —
+   * struck-through original next to the discounted price + a badge.
+   */
+  hasActivePromoOrSale(product: any): boolean {
+    const promo = product?.active_promotion;
+    if (promo && Number(promo.promotional_price) < Number(product.final_price)) {
+      return true;
+    }
+    const salePrice = Number(product?.sale_price);
+    const basePrice = Number(product?.price ?? product?.base_price);
+    return (
+      Number.isFinite(salePrice) &&
+      salePrice > 0 &&
+      Number.isFinite(basePrice) &&
+      salePrice < basePrice &&
+      product?.is_on_sale === true
+    );
+  }
+
+  /**
+   * Resolve the promotional unit price for a card. Prefer the
+   * backend-resolved `active_promotion.promotional_price`; fall back to
+   * `sale_price` when the product is on sale and the promotion is absent.
+   */
+  promotionalPrice(product: any): number {
+    const promo = product?.active_promotion;
+    if (promo && Number.isFinite(Number(promo.promotional_price))) {
+      return Number(promo.promotional_price);
+    }
+    const salePrice = Number(product?.sale_price);
+    if (Number.isFinite(salePrice) && salePrice > 0) {
+      return salePrice;
+    }
+    return Number(product?.final_price ?? 0);
+  }
+
+  isProductLowStock(product: any): boolean {
+    const stock = Number(product?.stock ?? product?.stock_quantity ?? 0);
+    return stock > 0 && stock <= this.getProductLowStockThreshold(product);
+  }
+
+  private getProductLowStockThreshold(product: any): number {
+    const productThreshold = Number(product?.minStock);
+    if (Number.isFinite(productThreshold) && productThreshold >= 0) {
+      return productThreshold;
+    }
+
+    const configuredThreshold = Number(this.lowStockThreshold());
+    return Number.isFinite(configuredThreshold) && configuredThreshold >= 0
+      ? configuredThreshold
+      : 10;
+  }
+
   private loadScaleSettings(): void {
     this.store
       .select(selectStoreSettings)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((storeSettings: any) => {
+        const threshold = Number(storeSettings?.inventory?.low_stock_threshold);
+        this.lowStockThreshold.set(
+          Number.isFinite(threshold) && threshold >= 0 ? threshold : 10,
+        );
+
         if (storeSettings?.pos?.scale) {
           this.scaleEnabled.set(storeSettings.pos.scale.enabled ?? false);
           this.defaultWeightUnit.set(

--- a/apps/frontend/src/app/private/modules/store/pos/components/pos-session-close-modal.component.ts
+++ b/apps/frontend/src/app/private/modules/store/pos/components/pos-session-close-modal.component.ts
@@ -20,6 +20,7 @@ import {
   CashRegisterMovement,
 } from '../services/pos-cash-register.service';
 import { ToastService } from '../../../../../shared/components/toast/toast.service';
+import { extractApiErrorMessage } from '../../../../../core/utils/api-error-handler';
 
 @Component({
   selector: 'app-pos-session-close-modal',
@@ -429,9 +430,7 @@ export class PosSessionCloseModalComponent {
         },
         error: (err) => {
           this.submitting.set(false);
-          this.toastService.error(
-            err.error?.message || 'Error al cerrar la caja',
-          );
+          this.toastService.error(extractApiErrorMessage(err));
         },
       });
   }

--- a/apps/frontend/src/app/private/modules/store/pos/components/pos-session-open-modal.component.ts
+++ b/apps/frontend/src/app/private/modules/store/pos/components/pos-session-open-modal.component.ts
@@ -18,6 +18,7 @@ import {
   CashRegister,
 } from '../services/pos-cash-register.service';
 import { ToastService } from '../../../../../shared/components/toast/toast.service';
+import { extractApiErrorMessage } from '../../../../../core/utils/api-error-handler';
 
 @Component({
   selector: 'app-pos-session-open-modal',
@@ -234,9 +235,7 @@ export class PosSessionOpenModalComponent {
         },
         error: (err) => {
           this.submitting.set(false);
-          this.toastService.error(
-            err.error?.message || 'Error al abrir la caja',
-          );
+          this.toastService.error(extractApiErrorMessage(err));
         },
       });
   }

--- a/apps/frontend/src/app/private/modules/store/pos/components/pos-session-status-bar.component.ts
+++ b/apps/frontend/src/app/private/modules/store/pos/components/pos-session-status-bar.component.ts
@@ -12,7 +12,7 @@ import { CashRegisterSession } from '../services/pos-cash-register.service';
   standalone: true,
   imports: [DatePipe, IconComponent],
   template: `
-    @if (session()) {
+    @if (session()?.status === 'open') {
       <div class="flex items-center gap-1.5 sm:gap-2 px-2.5 sm:px-3 py-2 bg-green-50 border border-green-200 rounded-xl text-green-700 min-h-[40px]">
         <!-- Pulsing alive indicator -->
         <span class="relative flex h-2.5 w-2.5 flex-shrink-0" aria-hidden="true">

--- a/apps/frontend/src/app/private/modules/store/pos/components/pos-variant-selector/pos-variant-selector.component.ts
+++ b/apps/frontend/src/app/private/modules/store/pos/components/pos-variant-selector/pos-variant-selector.component.ts
@@ -1,22 +1,18 @@
-import {
-  Component,
-  input,
-  output,
-  inject,
-} from '@angular/core';
+import { Component, input, output, inject } from '@angular/core';
 import { IconComponent } from '../../../../../../shared/components';
 import { CurrencyPipe } from '../../../../../../shared/pipes/currency';
-import {
-  Product,
-  PosProductVariant,
-} from '../../services/pos-product.service';
+import { Product, PosProductVariant } from '../../services/pos-product.service';
 import { PriceResolverService } from '../../../../../../shared/services/pricing';
 import { PosProductMissingVariantsBannerComponent } from '../pos-product-missing-variants-banner/pos-product-missing-variants-banner.component';
 
 @Component({
   selector: 'app-pos-variant-selector',
   standalone: true,
-  imports: [IconComponent, CurrencyPipe, PosProductMissingVariantsBannerComponent],
+  imports: [
+    IconComponent,
+    CurrencyPipe,
+    PosProductMissingVariantsBannerComponent,
+  ],
   template: `
     <!-- Backdrop -->
     <div
@@ -31,18 +27,26 @@ import { PosProductMissingVariantsBannerComponent } from '../pos-product-missing
         (click)="$event.stopPropagation()"
       >
         <!-- Header -->
-        <div class="px-5 py-4 border-b border-border flex items-center justify-between">
+        <div
+          class="px-5 py-4 border-b border-border flex items-center justify-between"
+        >
           <div>
             <h3 class="text-lg font-semibold text-text-primary">
               Seleccionar variante
             </h3>
-            <p class="text-sm text-text-secondary mt-0.5">{{ product().name }}</p>
+            <p class="text-sm text-text-secondary mt-0.5">
+              {{ product().name }}
+            </p>
           </div>
           <button
             (click)="onClose()"
             class="w-8 h-8 rounded-full bg-muted hover:bg-muted/80 flex items-center justify-center transition-colors"
           >
-            <app-icon name="x" [size]="18" class="text-text-secondary"></app-icon>
+            <app-icon
+              name="x"
+              [size]="18"
+              class="text-text-secondary"
+            ></app-icon>
           </button>
         </div>
 
@@ -59,21 +63,27 @@ import { PosProductMissingVariantsBannerComponent } from '../pos-product-missing
             @for (variant of variants(); track variant.id) {
               <button
                 class="w-full flex items-center gap-3 p-3 rounded-xl border transition-all text-left relative"
-                [class]="isVariantAvailable(variant)
-                  ? 'border-border hover:border-primary hover:bg-primary/5 cursor-pointer active:scale-[0.98]'
-                  : 'border-border/50 opacity-50 cursor-not-allowed'"
+                [class]="
+                  isVariantAvailable(variant)
+                    ? 'border-border hover:border-primary hover:bg-primary/5 cursor-pointer active:scale-[0.98]'
+                    : 'border-border/50 opacity-50 cursor-not-allowed'
+                "
                 [disabled]="!isVariantAvailable(variant)"
                 (click)="onSelectVariant(variant)"
               >
                 <!-- Sale Badge -->
                 @if (isVariantOnSale(variant)) {
-                  <span class="absolute top-2 right-2 px-1.5 py-0.5 bg-error text-white text-[10px] font-bold rounded">
+                  <span
+                    class="absolute top-2 right-2 px-1.5 py-0.5 bg-error text-white text-[10px] font-bold rounded"
+                  >
                     OFERTA
                   </span>
                 }
 
                 <!-- Variant Image or Icon -->
-                <div class="w-14 h-14 rounded-lg bg-muted/50 flex-shrink-0 overflow-hidden">
+                <div
+                  class="w-14 h-14 rounded-lg bg-muted/50 flex-shrink-0 overflow-hidden"
+                >
                   @if (variant.image_url) {
                     <img
                       [src]="variant.image_url"
@@ -82,7 +92,11 @@ import { PosProductMissingVariantsBannerComponent } from '../pos-product-missing
                     />
                   } @else {
                     <div class="w-full h-full flex items-center justify-center">
-                      <app-icon name="package" [size]="20" class="text-text-muted"></app-icon>
+                      <app-icon
+                        name="package"
+                        [size]="20"
+                        class="text-text-muted"
+                      ></app-icon>
                     </div>
                   }
                 </div>
@@ -103,25 +117,41 @@ import { PosProductMissingVariantsBannerComponent } from '../pos-product-missing
                 <div class="flex flex-col items-end flex-shrink-0">
                   @if (getVariantPriceResolution(variant); as resolution) {
                     <div class="flex items-center gap-2">
-                      <span class="font-bold text-sm" [class]="resolution.isOnSale ? 'text-error' : 'text-text-primary'">
+                      <span
+                        class="font-bold text-sm"
+                        [class]="
+                          resolution.isOnSale
+                            ? 'text-error'
+                            : 'text-text-primary'
+                        "
+                      >
                         {{ resolution.unitPrice | currency }}
                       </span>
                     </div>
                     @if (resolution.isOnSale && resolution.compareAtPrice) {
-                      <span class="text-[10px] text-text-muted line-through mt-0.5">
+                      <span
+                        class="text-[10px] text-text-muted line-through mt-0.5"
+                      >
                         {{ resolution.compareAtPrice | currency }}
                       </span>
                     }
                   }
                   @if (doesVariantTrackInventory(variant)) {
                     @if (isVariantAvailable(variant)) {
-                      <span class="text-xs mt-0.5"
-                        [class]="variant.stock <= 5 ? 'text-warning' : 'text-text-muted'"
+                      <span
+                        class="text-xs mt-0.5"
+                        [class]="
+                          isVariantLowStock(variant)
+                            ? 'text-warning'
+                            : 'text-text-muted'
+                        "
                       >
                         {{ variant.stock }} disp.
                       </span>
                     } @else {
-                      <span class="text-xs text-error font-medium mt-0.5">Agotado</span>
+                      <span class="text-xs text-error font-medium mt-0.5"
+                        >Agotado</span
+                      >
                     }
                   } @else {
                     <span class="text-xs text-info mt-0.5">Disponible</span>
@@ -134,11 +164,13 @@ import { PosProductMissingVariantsBannerComponent } from '../pos-product-missing
       </div>
     </div>
   `,
-  styles: [`
-    :host {
-      display: contents;
-    }
-  `],
+  styles: [
+    `
+      :host {
+        display: contents;
+      }
+    `,
+  ],
 })
 export class PosVariantSelectorComponent {
   private priceResolver = inject(PriceResolverService);
@@ -154,7 +186,8 @@ export class PosVariantSelectorComponent {
     if (!this.variants()?.length) return [];
     // Only group if there are multiple attribute types
     const firstVariant = this.variants()[0];
-    if (!firstVariant?.attributes || firstVariant.attributes.length <= 1) return [];
+    if (!firstVariant?.attributes || firstVariant.attributes.length <= 1)
+      return [];
     const groups: Record<string, PosProductVariant[]> = {};
     for (const v of this.variants()) {
       const groupKey = v.attributes?.[0]?.attribute_value || 'Otros';
@@ -162,10 +195,12 @@ export class PosVariantSelectorComponent {
       groups[groupKey].push(v);
     }
     const groupName = firstVariant.attributes[0]?.attribute_name || 'Tipo';
-    return Object.entries(groups).map(([name, variants]: [string, PosProductVariant[]]) => ({
-      name: `${groupName}: ${name}`,
-      variants,
-    }));
+    return Object.entries(groups).map(
+      ([name, variants]: [string, PosProductVariant[]]) => ({
+        name: `${groupName}: ${name}`,
+        variants,
+      }),
+    );
   }
 
   /** Check if a variant is available considering track_inventory */
@@ -181,7 +216,20 @@ export class PosVariantSelectorComponent {
     if (typeof variant.effective_track_inventory === 'boolean') {
       return variant.effective_track_inventory;
     }
-    return variant.track_inventory_override ?? this.product().track_inventory ?? true;
+    return (
+      variant.track_inventory_override ?? this.product().track_inventory ?? true
+    );
+  }
+
+  isVariantLowStock(variant: PosProductVariant): boolean {
+    return (
+      variant.stock > 0 && variant.stock <= this.getProductLowStockThreshold()
+    );
+  }
+
+  private getProductLowStockThreshold(): number {
+    const threshold = Number(this.product().minStock);
+    return Number.isFinite(threshold) && threshold >= 0 ? threshold : 10;
   }
 
   /** Check if a specific variant is on sale */
@@ -201,7 +249,7 @@ export class PosVariantSelectorComponent {
 
   getVariantLabel(variant: PosProductVariant): string {
     if (variant.attributes && variant.attributes.length > 0) {
-      return variant.attributes.map(a => a.attribute_value).join(' / ');
+      return variant.attributes.map((a) => a.attribute_value).join(' / ');
     }
     return variant.sku || `Variante #${variant.id}`;
   }

--- a/apps/frontend/src/app/private/modules/store/pos/pos.component.ts
+++ b/apps/frontend/src/app/private/modules/store/pos/pos.component.ts
@@ -976,9 +976,7 @@ export class PosComponent {
 
     effect(() => {
       const serviceSession = this.cashRegisterService.activeSession();
-      if (serviceSession !== null) {
-        this.activeSession.set(serviceSession);
-      }
+      this.activeSession.set(serviceSession);
     });
   }
 
@@ -2094,6 +2092,8 @@ export class PosComponent {
       this.initCashRegisterSession();
     } else if (!crEnabled) {
       this.cashRegisterSessionInitialized = false;
+      this.cashRegisterService.clearSession();
+      this.activeSession.set(null);
     }
 
     const customerQueueSettings = posSettings.customer_queue;

--- a/apps/frontend/src/app/private/modules/store/pos/services/pos-cash-register.service.ts
+++ b/apps/frontend/src/app/private/modules/store/pos/services/pos-cash-register.service.ts
@@ -107,7 +107,7 @@ export class PosCashRegisterService {
   getRegisterId(): string | null {
     if (this.featureEnabled) {
       const session = this.activeSession();
-      return session?.register?.code || null;
+      return session?.status === 'open' ? session.register?.code || null : null;
     }
     return localStorage.getItem('pos_register_id');
   }
@@ -115,7 +115,7 @@ export class PosCashRegisterService {
   /** Check if the user has an active session (for sales validation) */
   hasActiveSession(): boolean {
     if (!this.featureEnabled) return true; // No validation when disabled
-    return this.activeSession() !== null;
+    return this.activeSession()?.status === 'open';
   }
 
   // --- API calls ---
@@ -133,12 +133,11 @@ export class PosCashRegisterService {
       .get<any>(`${this.baseUrl}/sessions/active`)
       .pipe(
         map((res) => res.data || null),
-        tap((session) => {
-          if (session) {
-            this.activeSession.set(session);
-          }
+        tap((session) => this.activeSession.set(session)),
+        catchError(() => {
+          this.activeSession.set(null);
+          return of(null);
         }),
-        catchError(() => of(null)),
       );
   }
 

--- a/apps/frontend/src/app/private/modules/store/pos/services/pos-payment.service.ts
+++ b/apps/frontend/src/app/private/modules/store/pos/services/pos-payment.service.ts
@@ -377,7 +377,16 @@ export class PosPaymentService {
       );
     }
 
-    // Build sale data with conditional customer fields
+    // Build sale data with conditional customer fields.
+    //
+    // IMPORTANT — Promotions and coupons:
+    //   The backend is the source of truth for `discount_amount` and the
+    //   final `grand_total`. We send `promotion_ids` (manual promotions
+    //   selected by the cashier) and `coupon_code`; the backend recalculates
+    //   the actual discount via `PromotionEngineService.quoteDiscounts` and
+    //   `CouponsService.validate`. Any locally computed `discount_amount` is
+    //   intentionally omitted so the frontend cannot override the server
+    //   calculation.
     const sale_data: any = {
       store_id: this.getStoreId(),
       items: this.mapCartItemsForPos(cartState),
@@ -386,9 +395,6 @@ export class PosPaymentService {
       ),
       tax_amount: Number(
         parseFloat(cartState.summary.taxAmount.toString()).toFixed(2),
-      ),
-      discount_amount: Number(
-        parseFloat(cartState.summary.discountAmount.toString()).toFixed(2),
       ),
       promotion_ids: this.getAppliedPromotionIds(cartState),
       total_amount: Number(
@@ -503,6 +509,9 @@ export class PosPaymentService {
       ).toFixed(2),
     );
 
+    // See `processSaleWithPayment` for the rationale on not sending
+    // `discount_amount`: the backend recalculates it from `promotion_ids` +
+    // `coupon_code` and is the source of truth for the final `grand_total`.
     const sale_data: Record<string, any> = {
       customer_id: cartState.customer.id,
       customer_name:
@@ -516,9 +525,6 @@ export class PosPaymentService {
       ),
       tax_amount: Number(
         parseFloat(cartState.summary.taxAmount.toString()).toFixed(2),
-      ),
-      discount_amount: Number(
-        parseFloat(cartState.summary.discountAmount.toString()).toFixed(2),
       ),
       promotion_ids: this.getAppliedPromotionIds(cartState),
       total_amount: totalWithShipping,
@@ -619,6 +625,8 @@ export class PosPaymentService {
       return throwError(() => new Error('Debe seleccionar un cliente.'));
     }
 
+    // Backend recalculates discounts from `promotion_ids` + `coupon_code`.
+    // See `processSaleWithPayment` comment for full rationale.
     const credit_data = {
       customer_id: cartState.customer.id,
       customer_name: `${cartState.customer.first_name} ${cartState.customer.last_name}`,
@@ -631,9 +639,6 @@ export class PosPaymentService {
       ),
       tax_amount: Number(
         parseFloat(cartState.summary.taxAmount.toString()).toFixed(2),
-      ),
-      discount_amount: Number(
-        parseFloat(cartState.summary.discountAmount.toString()).toFixed(2),
       ),
       promotion_ids: this.getAppliedPromotionIds(cartState),
       total_amount: Number(
@@ -699,6 +704,8 @@ export class PosPaymentService {
       return throwError(() => new Error('Debe seleccionar un cliente para ventas a crédito.'));
     }
 
+    // Backend recalculates discounts from `promotion_ids` + `coupon_code`.
+    // See `processSaleWithPayment` comment for full rationale.
     const credit_data: any = {
       customer_id: cartState.customer.id,
       customer_name: `${cartState.customer.first_name} ${cartState.customer.last_name}`,
@@ -711,9 +718,6 @@ export class PosPaymentService {
       ),
       tax_amount: Number(
         parseFloat(cartState.summary.taxAmount.toString()).toFixed(2),
-      ),
-      discount_amount: Number(
-        parseFloat(cartState.summary.discountAmount.toString()).toFixed(2),
       ),
       promotion_ids: this.getAppliedPromotionIds(cartState),
       total_amount: Number(
@@ -778,6 +782,8 @@ export class PosPaymentService {
       );
     }
 
+    // Drafts: backend still recalculates discounts when saved.
+    // See `processSaleWithPayment` comment for the rationale.
     const draft_data = {
       customer_id: cartState.customer.id,
       customer_name: `${cartState.customer.first_name} ${cartState.customer.last_name}`,
@@ -787,7 +793,6 @@ export class PosPaymentService {
       items: this.mapCartItemsForPos(cartState),
       subtotal: Number(cartState.summary.subtotal.toFixed(2)),
       tax_amount: Number(cartState.summary.taxAmount.toFixed(2)),
-      discount_amount: Number(cartState.summary.discountAmount.toFixed(2)),
       promotion_ids: this.getAppliedPromotionIds(cartState),
       total_amount: Number(cartState.summary.total.toFixed(2)),
       is_draft: true,

--- a/apps/frontend/src/app/private/modules/store/pos/services/pos-product.service.ts
+++ b/apps/frontend/src/app/private/modules/store/pos/services/pos-product.service.ts
@@ -16,6 +16,25 @@ import {
   StockSourcingSuggestionResponse,
 } from '../models/sourcing.model';
 
+/**
+ * Promotional descriptor surfaced on POS product cards. Mirrors the backend
+ * `ActiveProductPromotion` shape returned by the products listing endpoint.
+ * The card uses `promotional_price` + `badge_label` to render the visual
+ * discount, but the authoritative discount is always re-computed in backend
+ * at checkout via the promotion engine.
+ */
+export interface ActiveProductPromotion {
+  id: number;
+  name: string;
+  type: 'percentage' | 'fixed_amount';
+  scope: 'product' | 'category';
+  discount_percentage?: number;
+  discount_amount?: number;
+  promotional_price: number;
+  badge_label: string;
+  priority: number;
+}
+
 export interface Product {
   id: string;
   name: string;
@@ -25,6 +44,7 @@ export interface Product {
   cost?: number;
   is_on_sale?: boolean;
   sale_price?: number | null;
+  active_promotion?: ActiveProductPromotion | null;
   allow_pos_price_override?: boolean;
   category: string;
   category_id?: number | null;
@@ -36,6 +56,9 @@ export interface Product {
   effective_track_inventory?: boolean;
   track_inventory?: boolean;
   minStock: number;
+  min_stock_level?: number | null;
+  reorder_point?: number | null;
+  low_stock_threshold?: number | null;
   image?: string;
   image_url?: string;
   description?: string;
@@ -169,6 +192,14 @@ export class PosProductService {
       | InventorySettings
       | undefined;
     return inventory?.pos_stock_scope ?? 'all_locations';
+  }
+
+  getLowStockThreshold(): number {
+    const inventory = this.storeSettingsFacade.settings()?.inventory as
+      | InventorySettings
+      | undefined;
+    const threshold = Number(inventory?.low_stock_threshold);
+    return Number.isFinite(threshold) && threshold >= 0 ? threshold : 10;
   }
 
   /**
@@ -390,15 +421,15 @@ export class PosProductService {
           v.stock_quantity ??
           (Array.isArray(v.stock_levels) && v.stock_levels.length > 0
             ? v.stock_levels.reduce(
-                (sum: number, sl: any) =>
-                  sum + (sl?.quantity_available ?? 0),
+                (sum: number, sl: any) => sum + (sl?.quantity_available ?? 0),
                 0,
               )
             : (v.stock ?? 0));
 
         const variantEffectiveTracking =
           v.effective_track_inventory ??
-          (v.track_inventory_override ?? product.track_inventory);
+          v.track_inventory_override ??
+          product.track_inventory;
 
         const variantIsAvailable =
           typeof v.is_available === 'boolean'
@@ -438,10 +469,16 @@ export class PosProductService {
 
       const categories = Array.isArray(product.categories)
         ? product.categories
-        : product.product_categories?.map((pc: any) => pc.categories || pc.category || pc) || [];
+        : product.product_categories?.map(
+            (pc: any) => pc.categories || pc.category || pc,
+          ) || [];
       const categoryIds = categories
         .map((category: any) => Number(category?.id))
         .filter((id: number) => Number.isFinite(id));
+
+      const activePromotion = this.parseActivePromotion(
+        product.active_promotion,
+      );
 
       const transformed = {
         id: product.id?.toString() || '',
@@ -451,9 +488,11 @@ export class PosProductService {
         final_price: parseFloat(
           product.final_price || product.base_price || product.price || 0,
         ),
+        active_promotion: activePromotion,
         allow_pos_price_override: product.allow_pos_price_override === true,
         cost: product.cost_price ? parseFloat(product.cost_price) : undefined,
-        category: categories[0]?.name || product.category?.name || 'Sin categoría',
+        category:
+          categories[0]?.name || product.category?.name || 'Sin categoría',
         category_id: categoryIds[0] ?? null,
         category_ids: categoryIds,
         brand: product.brands?.name || '',
@@ -465,7 +504,10 @@ export class PosProductService {
         is_available: productIsAvailable,
         effective_track_inventory: effectiveTrackInventory ?? true,
         track_inventory: product.track_inventory,
-        minStock: product.min_stock_level || 5,
+        minStock: this.resolveLowStockThreshold(product),
+        min_stock_level: product.min_stock_level ?? null,
+        reorder_point: product.reorder_point ?? null,
+        low_stock_threshold: product.low_stock_threshold ?? null,
         image: imageUrl,
         image_url: imageUrl,
         description: product.description || '',
@@ -691,5 +733,59 @@ export class PosProductService {
   updateStock(productId: string, quantity: number): Observable<Product | null> {
     // This would normally call an endpoint, for now return null
     return of(null).pipe(delay(100));
+  }
+
+  /**
+   * Defensive parser for the `active_promotion` payload that the backend
+   * attaches to listing rows. Returns `null` when the field is missing,
+   * malformed, or numerically invalid so the card can fall back to the
+   * regular price without throwing on legacy/cached responses.
+   */
+  private parseActivePromotion(raw: any): ActiveProductPromotion | null {
+    if (!raw || typeof raw !== 'object') return null;
+    const id = Number(raw.id);
+    const promotionalPrice = Number(raw.promotional_price);
+    if (!Number.isFinite(id) || !Number.isFinite(promotionalPrice)) {
+      return null;
+    }
+    const type = raw.type === 'fixed_amount' ? 'fixed_amount' : 'percentage';
+    const scope = raw.scope === 'category' ? 'category' : 'product';
+    const badgeLabel =
+      typeof raw.badge_label === 'string' && raw.badge_label.length > 0
+        ? raw.badge_label
+        : 'OFERTA';
+
+    return {
+      id,
+      name: typeof raw.name === 'string' ? raw.name : 'Promoción',
+      type,
+      scope,
+      discount_percentage:
+        raw.discount_percentage != null
+          ? Number(raw.discount_percentage)
+          : undefined,
+      discount_amount:
+        raw.discount_amount != null ? Number(raw.discount_amount) : undefined,
+      promotional_price: promotionalPrice,
+      badge_label: badgeLabel,
+      priority: Number.isFinite(Number(raw.priority)) ? Number(raw.priority) : 0,
+    };
+  }
+
+  private resolveLowStockThreshold(product: any): number {
+    const productThreshold = [product.reorder_point, product.min_stock_level]
+      .map((value) => Number(value))
+      .find((value) => Number.isFinite(value) && value > 0);
+
+    if (productThreshold !== undefined) {
+      return productThreshold;
+    }
+
+    const apiThreshold = Number(product.low_stock_threshold);
+    if (Number.isFinite(apiThreshold) && apiThreshold >= 0) {
+      return apiThreshold;
+    }
+
+    return this.getLowStockThreshold();
   }
 }

--- a/apps/frontend/src/app/private/modules/store/products/components/product-image-source-modal.component.ts
+++ b/apps/frontend/src/app/private/modules/store/products/components/product-image-source-modal.component.ts
@@ -66,7 +66,7 @@ const ASPECT_RATIOS: {
   { value: '9:16', label: '9:16', ratio: 9 / 16 },
 ];
 
-const DEFAULT_ASPECT: AspectRatio = '1:1';
+const DEFAULT_ASPECT: AspectRatio = 'free';
 
 @Component({
   selector: 'app-product-image-source-modal',

--- a/apps/frontend/src/app/private/modules/store/products/components/product-image-source-modal.component.ts
+++ b/apps/frontend/src/app/private/modules/store/products/components/product-image-source-modal.component.ts
@@ -66,6 +66,8 @@ const ASPECT_RATIOS: {
   { value: '9:16', label: '9:16', ratio: 9 / 16 },
 ];
 
+const DEFAULT_ASPECT: AspectRatio = '1:1';
+
 @Component({
   selector: 'app-product-image-source-modal',
   standalone: true,
@@ -590,7 +592,7 @@ export class ProductImageSourceModalComponent {
   readonly stage = signal<Stage>('select');
   readonly queue = signal<PendingImage[]>([]);
   readonly queueCursor = signal(0);
-  readonly aspect = signal<AspectRatio>('free');
+  readonly aspect = signal<AspectRatio>(DEFAULT_ASPECT);
 
   urlInput = '';
   readonly urlError = signal<string | null>(null);
@@ -678,7 +680,7 @@ export class ProductImageSourceModalComponent {
     this.stage.set('select');
     this.queue.set([]);
     this.queueCursor.set(0);
-    this.aspect.set('free');
+    this.aspect.set(DEFAULT_ASPECT);
     this.rotation.set(0);
     this.flipH.set(false);
     this.flipV.set(false);
@@ -788,7 +790,7 @@ export class ProductImageSourceModalComponent {
     if (items.length === 0) return;
     this.queue.set(items);
     this.queueCursor.set(0);
-    this.aspect.set('free');
+    this.aspect.set(DEFAULT_ASPECT);
     this.rotation.set(0);
     this.flipH.set(false);
     this.flipV.set(false);
@@ -803,7 +805,7 @@ export class ProductImageSourceModalComponent {
     this.stage.set('loading');
     this.queue.set([]);
     this.queueCursor.set(0);
-    this.aspect.set('free');
+    this.aspect.set(DEFAULT_ASPECT);
     this.rotation.set(0);
     this.flipH.set(false);
     this.flipV.set(false);
@@ -919,15 +921,15 @@ export class ProductImageSourceModalComponent {
     let w: number;
     let h: number;
     if (ratio === null) {
-      w = c.w * 0.8;
-      h = c.h * 0.8;
+      w = c.w;
+      h = c.h;
     } else {
       const canvasRatio = c.w / c.h;
       if (canvasRatio > ratio) {
-        h = c.h * 0.9;
+        h = c.h;
         w = h * ratio;
       } else {
-        w = c.w * 0.9;
+        w = c.w;
         h = w / ratio;
       }
     }
@@ -1267,7 +1269,7 @@ export class ProductImageSourceModalComponent {
       return;
     }
     this.queueCursor.set(next);
-    this.aspect.set('free');
+    this.aspect.set(DEFAULT_ASPECT);
     this.rotation.set(0);
     this.flipH.set(false);
     this.flipV.set(false);

--- a/apps/frontend/src/app/private/modules/store/products/interfaces/product.interface.ts
+++ b/apps/frontend/src/app/private/modules/store/products/interfaces/product.interface.ts
@@ -45,6 +45,9 @@ export interface Product {
   allow_pos_price_override?: boolean;
   sku?: string;
   stock_quantity?: number;
+  min_stock_level?: number | null;
+  reorder_point?: number | null;
+  low_stock_threshold?: number | null;
   track_inventory?: boolean;
   weight?: number;
   dimensions?: {

--- a/apps/frontend/src/app/private/modules/store/products/pages/brands-page/components/brand-form-modal.component.ts
+++ b/apps/frontend/src/app/private/modules/store/products/pages/brands-page/components/brand-form-modal.component.ts
@@ -8,6 +8,7 @@ import {
   signal,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { firstValueFrom } from 'rxjs';
 
 import {
   FormBuilder,
@@ -19,19 +20,18 @@ import {
 // Shared Components
 import {
   ButtonComponent,
+  IconComponent,
   InputComponent,
   ModalComponent,
   SettingToggleComponent,
   TextareaComponent,
+  ToastService,
 } from '../../../../../../../shared/components/index';
 
 // Interfaces
-import {
-  Brand,
-  CreateBrandDto,
-  UpdateBrandDto,
-} from '../../../interfaces';
+import { Brand, CreateBrandDto, UpdateBrandDto } from '../../../interfaces';
 import { BrandsService } from '../../../services/brands.service';
+import { ProductImageSourceModalComponent } from '../../../components/product-image-source-modal.component';
 
 @Component({
   selector: 'app-brand-form-modal',
@@ -40,9 +40,11 @@ import { BrandsService } from '../../../services/brands.service';
     ReactiveFormsModule,
     ModalComponent,
     ButtonComponent,
+    IconComponent,
     InputComponent,
     TextareaComponent,
     SettingToggleComponent,
+    ProductImageSourceModalComponent,
   ],
   template: `
     <app-modal
@@ -63,20 +65,12 @@ import { BrandsService } from '../../../services/brands.service';
             [error]="getError('name')"
           ></app-input>
 
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
-            <app-input
-              label="Slug"
-              formControlName="slug"
-              placeholder="nike"
-              [error]="getError('slug')"
-            ></app-input>
-            <app-input
-              label="URL del Logo"
-              formControlName="logo_url"
-              placeholder="https://..."
-              [error]="getError('logo_url')"
-            ></app-input>
-          </div>
+          <app-input
+            label="Slug"
+            formControlName="slug"
+            placeholder="nike"
+            [error]="getError('slug')"
+          ></app-input>
 
           <div class="rounded-lg border border-gray-100 bg-gray-50 p-3">
             <div class="flex items-center gap-3">
@@ -105,22 +99,16 @@ import { BrandsService } from '../../../services/brands.service';
                   Se usará en el inicio y en filtros visuales de marcas.
                 </p>
               </div>
-              <input
-                #brandLogoInput
-                type="file"
-                accept="image/*"
-                class="hidden"
-                (change)="onLogoSelected($event)"
-              />
               <app-button
                 variant="outline"
                 type="button"
                 size="sm"
                 [loading]="isUploadingLogo()"
                 [disabled]="isUploadingLogo()"
-                (clicked)="brandLogoInput.click()"
+                (clicked)="openLogoSourceModal()"
               >
-                Subir
+                <app-icon slot="icon" name="image" size="16"></app-icon>
+                {{ logoPreviewUrl() ? 'Cambiar' : 'Agregar' }}
               </app-button>
               @if (logoPreviewUrl()) {
                 <app-button
@@ -171,7 +159,7 @@ import { BrandsService } from '../../../services/brands.service';
             variant="primary"
             type="button"
             [loading]="isSubmitting()"
-            [disabled]="form.invalid || isSubmitting()"
+            [disabled]="form.invalid || isSubmitting() || isUploadingLogo()"
             (clicked)="onSubmit()"
           >
             {{ brand() ? 'Guardar Cambios' : 'Crear Marca' }}
@@ -179,6 +167,14 @@ import { BrandsService } from '../../../services/brands.service';
         </div>
       </div>
     </app-modal>
+
+    <app-product-image-source-modal
+      [isOpen]="isLogoSourceModalOpen()"
+      (isOpenChange)="isLogoSourceModalOpen.set($event)"
+      [remainingSlots]="1"
+      [allowAiEnhance]="false"
+      (imagesAdded)="onLogoImagesAdded($event)"
+    ></app-product-image-source-modal>
   `,
 })
 export class BrandFormModalComponent {
@@ -192,9 +188,11 @@ export class BrandFormModalComponent {
 
   readonly logoPreviewUrl = signal<string | null>(null);
   readonly isUploadingLogo = signal(false);
+  readonly isLogoSourceModalOpen = signal(false);
 
   form: FormGroup;
   private readonly brandsService = inject(BrandsService);
+  private readonly toastService = inject(ToastService);
   private readonly destroyRef = inject(DestroyRef);
 
   constructor(private fb: FormBuilder) {
@@ -258,6 +256,7 @@ export class BrandFormModalComponent {
   }
 
   onCancel(): void {
+    this.isLogoSourceModalOpen.set(false);
     this.cancel.emit();
   }
 
@@ -282,45 +281,64 @@ export class BrandFormModalComponent {
       description: value.description ? value.description : undefined,
       logo_url: value.logo_url ? value.logo_url : this.brand() ? '' : undefined,
       state: value.state ? 'active' : 'inactive',
-      is_featured: !!value.is_featured,
     };
+
+    const nextFeatured = !!value.is_featured;
+    const currentFeatured = !!this.brand()?.is_featured;
+    if (nextFeatured || (this.brand() && nextFeatured !== currentFeatured)) {
+      payload.is_featured = nextFeatured;
+    }
 
     this.save.emit(payload);
   }
 
-  onLogoSelected(event: Event): void {
-    const inputElement = event.target as HTMLInputElement;
-    const file = inputElement.files?.[0];
-    if (!file) return;
+  openLogoSourceModal(): void {
+    if (this.isUploadingLogo()) return;
+    this.isLogoSourceModalOpen.set(true);
+  }
 
-    if (!file.type.startsWith('image/')) {
-      inputElement.value = '';
-      return;
-    }
+  async onLogoImagesAdded(images: string[]): Promise<void> {
+    const dataUrl = images?.[0];
+    if (!dataUrl) return;
 
     this.isUploadingLogo.set(true);
-    this.brandsService
-      .uploadBrandLogo(file)
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        next: (result) => {
-          this.form.patchValue({ logo_url: result.key });
-          this.logoPreviewUrl.set(result.url);
-          this.form.markAsDirty();
-        },
-        error: () => {
-          this.isUploadingLogo.set(false);
-        },
-        complete: () => {
-          this.isUploadingLogo.set(false);
-          inputElement.value = '';
-        },
-      });
+    try {
+      const file = await this.dataUrlToFile(
+        dataUrl,
+        `brand-logo-${Date.now()}.jpg`,
+      );
+      const result = await firstValueFrom(
+        this.brandsService
+          .uploadBrandLogo(file)
+          .pipe(takeUntilDestroyed(this.destroyRef)),
+      );
+
+      this.form.patchValue({ logo_url: result.key });
+      this.logoPreviewUrl.set(result.url);
+      this.form.markAsDirty();
+      this.toastService.success('Logo cargado correctamente');
+    } catch {
+      this.toastService.error('No pudimos cargar el logo de la marca');
+    } finally {
+      this.isUploadingLogo.set(false);
+    }
   }
 
   removeLogo(): void {
     this.form.patchValue({ logo_url: '' });
     this.logoPreviewUrl.set(null);
     this.form.markAsDirty();
+  }
+
+  private async dataUrlToFile(
+    dataUrl: string,
+    fileName: string,
+  ): Promise<File> {
+    const response = await fetch(dataUrl);
+    if (!response.ok) {
+      throw new Error('No se pudo preparar la imagen');
+    }
+    const blob = await response.blob();
+    return new File([blob], fileName, { type: blob.type || 'image/jpeg' });
   }
 }

--- a/apps/frontend/src/app/private/modules/store/products/pages/brands-page/components/brand-list/brand-list.component.html
+++ b/apps/frontend/src/app/private/modules/store/products/pages/brands-page/components/brand-list/brand-list.component.html
@@ -105,4 +105,13 @@
       </div>
     }
   </app-card>
+
+  <app-image-lightbox
+    [isOpen]="imagePreviewOpen()"
+    [currentImage]="getSelectedImageUrl()"
+    [alt]="getSelectedImageAlt()"
+    [title]="getSelectedImageAlt()"
+    [showInfo]="true"
+    (close)="closeImagePreview()"
+  ></app-image-lightbox>
 </div>

--- a/apps/frontend/src/app/private/modules/store/products/pages/brands-page/components/brand-list/brand-list.component.ts
+++ b/apps/frontend/src/app/private/modules/store/products/pages/brands-page/components/brand-list/brand-list.component.ts
@@ -18,6 +18,7 @@ import {
   PaginationComponent,
   EmptyStateComponent,
   CardComponent,
+  ImageLightboxComponent,
 } from '../../../../../../../../shared/components/index';
 
 // Interfaces
@@ -36,6 +37,7 @@ import { Brand } from '../../../../interfaces';
     PaginationComponent,
     EmptyStateComponent,
     CardComponent,
+    ImageLightboxComponent,
   ],
   templateUrl: './brand-list.component.html',
 })
@@ -68,6 +70,8 @@ export class BrandListComponent {
 
   searchTerm = signal('');
   selectedState = signal('');
+  readonly selectedImageBrand = signal<Brand | null>(null);
+  readonly imagePreviewOpen = signal(false);
 
   // Filter configuration for the options dropdown
   filterConfigs: FilterConfig[] = [
@@ -121,6 +125,8 @@ export class BrandListComponent {
       width: '80px',
       priority: 3,
       defaultValue: '',
+      imageClick: (brand: Brand, event: MouseEvent) =>
+        this.openImagePreview(brand, event),
     },
     { key: 'name', label: 'Nombre', sortable: true, priority: 1 },
     { key: 'slug', label: 'Slug', sortable: true, priority: 3 },
@@ -140,8 +146,8 @@ export class BrandListComponent {
       badgeConfig: {
         type: 'custom',
         colorMap: {
-          'true': '#d97706',
-          'false': '#6b7280',
+          true: '#d97706',
+          false: '#6b7280',
           Destacada: '#d97706',
           Normal: '#6b7280',
         },
@@ -186,8 +192,7 @@ export class BrandListComponent {
         label: (item: Brand) =>
           item.is_featured ? 'Quitar destacado' : 'Destacar',
         icon: 'star',
-        variant: (item: Brand) =>
-          item.is_featured ? 'muted' : 'warning',
+        variant: (item: Brand) => (item.is_featured ? 'muted' : 'warning'),
         tooltip: (item: Brand) =>
           item.is_featured
             ? 'Quitar prioridad en el inicio'
@@ -213,6 +218,8 @@ export class BrandListComponent {
     titleKey: 'name',
     subtitleKey: 'slug',
     avatarKey: 'logo_url',
+    avatarClick: (brand: Brand, event: MouseEvent) =>
+      this.openImagePreview(brand, event),
     avatarFallbackIcon: 'tag',
     avatarShape: 'square',
     badgeKey: 'state',
@@ -265,6 +272,26 @@ export class BrandListComponent {
   onRowClick(brand: Brand): void {
     if (!this.canUpdate()) return;
     this.edit.emit(brand);
+  }
+
+  openImagePreview(brand: Brand, event?: MouseEvent): void {
+    event?.stopPropagation();
+    if (!brand.logo_url) return;
+    this.selectedImageBrand.set(brand);
+    this.imagePreviewOpen.set(true);
+  }
+
+  closeImagePreview(): void {
+    this.imagePreviewOpen.set(false);
+    this.selectedImageBrand.set(null);
+  }
+
+  getSelectedImageUrl(): string {
+    return this.selectedImageBrand()?.logo_url ?? '';
+  }
+
+  getSelectedImageAlt(): string {
+    return this.selectedImageBrand()?.name || 'Logo de marca';
   }
 
   // Helper methods

--- a/apps/frontend/src/app/private/modules/store/products/pages/categories-page/components/category-form-modal.component.ts
+++ b/apps/frontend/src/app/private/modules/store/products/pages/categories-page/components/category-form-modal.component.ts
@@ -8,6 +8,7 @@ import {
   signal,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { firstValueFrom } from 'rxjs';
 
 import {
   FormBuilder,
@@ -20,9 +21,11 @@ import {
 import {
   ModalComponent,
   ButtonComponent,
+  IconComponent,
   InputComponent,
   TextareaComponent,
   SettingToggleComponent,
+  ToastService,
 } from '../../../../../../../shared/components/index';
 
 // Interfaces
@@ -32,6 +35,7 @@ import {
   UpdateCategoryDto,
 } from '../../../interfaces';
 import { CategoriesService } from '../../../services/categories.service';
+import { ProductImageSourceModalComponent } from '../../../components/product-image-source-modal.component';
 
 @Component({
   selector: 'app-category-form-modal',
@@ -40,9 +44,11 @@ import { CategoriesService } from '../../../services/categories.service';
     ReactiveFormsModule,
     ModalComponent,
     ButtonComponent,
+    IconComponent,
     InputComponent,
     TextareaComponent,
     SettingToggleComponent,
+    ProductImageSourceModalComponent,
   ],
   template: `
     <app-modal
@@ -71,14 +77,6 @@ import { CategoriesService } from '../../../services/categories.service';
             ></app-input>
           </div>
 
-          <!-- Image URL -->
-          <app-input
-            label="URL de Imagen"
-            formControlName="image_url"
-            placeholder="https://..."
-            [error]="getError('image_url')"
-          ></app-input>
-
           <div class="rounded-lg border border-gray-100 bg-gray-50 p-3">
             <div class="flex items-center gap-3">
               <div
@@ -106,22 +104,16 @@ import { CategoriesService } from '../../../services/categories.service';
                   Se usará en el inicio y en filtros visuales de categorías.
                 </p>
               </div>
-              <input
-                #categoryImageInput
-                type="file"
-                accept="image/*"
-                class="hidden"
-                (change)="onImageSelected($event)"
-              />
               <app-button
                 variant="outline"
                 type="button"
                 size="sm"
                 [loading]="isUploadingImage()"
                 [disabled]="isUploadingImage()"
-                (clicked)="categoryImageInput.click()"
+                (clicked)="openImageSourceModal()"
               >
-                Subir
+                <app-icon slot="icon" name="image" size="16"></app-icon>
+                {{ imagePreviewUrl() ? 'Cambiar' : 'Agregar' }}
               </app-button>
               @if (imagePreviewUrl()) {
                 <app-button
@@ -172,7 +164,7 @@ import { CategoriesService } from '../../../services/categories.service';
             variant="primary"
             type="button"
             [loading]="isSubmitting()"
-            [disabled]="form.invalid || isSubmitting()"
+            [disabled]="form.invalid || isSubmitting() || isUploadingImage()"
             (clicked)="onSubmit()"
           >
             {{ category() ? 'Guardar Cambios' : 'Crear Categoría' }}
@@ -180,6 +172,14 @@ import { CategoriesService } from '../../../services/categories.service';
         </div>
       </div>
     </app-modal>
+
+    <app-product-image-source-modal
+      [isOpen]="isImageSourceModalOpen()"
+      (isOpenChange)="isImageSourceModalOpen.set($event)"
+      [remainingSlots]="1"
+      [allowAiEnhance]="false"
+      (imagesAdded)="onImagesAdded($event)"
+    ></app-product-image-source-modal>
   `,
 })
 export class CategoryFormModalComponent {
@@ -193,9 +193,11 @@ export class CategoryFormModalComponent {
 
   readonly imagePreviewUrl = signal<string | null>(null);
   readonly isUploadingImage = signal(false);
+  readonly isImageSourceModalOpen = signal(false);
 
   form: FormGroup;
   private readonly categoriesService = inject(CategoriesService);
+  private readonly toastService = inject(ToastService);
   private readonly destroyRef = inject(DestroyRef);
 
   constructor(private fb: FormBuilder) {
@@ -259,6 +261,7 @@ export class CategoryFormModalComponent {
   }
 
   onCancel(): void {
+    this.isImageSourceModalOpen.set(false);
     this.cancel.emit();
   }
 
@@ -283,44 +286,63 @@ export class CategoryFormModalComponent {
     if (imageUrl || this.category()) payload.image_url = imageUrl;
 
     payload.state = raw.state ? 'active' : 'inactive';
-    payload.is_featured = !!raw.is_featured;
+
+    const nextFeatured = !!raw.is_featured;
+    const currentFeatured = !!this.category()?.is_featured;
+    if (nextFeatured || (this.category() && nextFeatured !== currentFeatured)) {
+      payload.is_featured = nextFeatured;
+    }
 
     this.save.emit(payload);
   }
 
-  onImageSelected(event: Event): void {
-    const inputElement = event.target as HTMLInputElement;
-    const file = inputElement.files?.[0];
-    if (!file) return;
+  openImageSourceModal(): void {
+    if (this.isUploadingImage()) return;
+    this.isImageSourceModalOpen.set(true);
+  }
 
-    if (!file.type.startsWith('image/')) {
-      inputElement.value = '';
-      return;
-    }
+  async onImagesAdded(images: string[]): Promise<void> {
+    const dataUrl = images?.[0];
+    if (!dataUrl) return;
 
     this.isUploadingImage.set(true);
-    this.categoriesService
-      .uploadCategoryImage(file)
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        next: (result) => {
-          this.form.patchValue({ image_url: result.key });
-          this.imagePreviewUrl.set(result.url);
-          this.form.markAsDirty();
-        },
-        error: () => {
-          this.isUploadingImage.set(false);
-        },
-        complete: () => {
-          this.isUploadingImage.set(false);
-          inputElement.value = '';
-        },
-      });
+    try {
+      const file = await this.dataUrlToFile(
+        dataUrl,
+        `category-image-${Date.now()}.jpg`,
+      );
+      const result = await firstValueFrom(
+        this.categoriesService
+          .uploadCategoryImage(file)
+          .pipe(takeUntilDestroyed(this.destroyRef)),
+      );
+
+      this.form.patchValue({ image_url: result.key });
+      this.imagePreviewUrl.set(result.url);
+      this.form.markAsDirty();
+      this.toastService.success('Imagen cargada correctamente');
+    } catch {
+      this.toastService.error('No pudimos cargar la imagen de la categoría');
+    } finally {
+      this.isUploadingImage.set(false);
+    }
   }
 
   removeImage(): void {
     this.form.patchValue({ image_url: '' });
     this.imagePreviewUrl.set(null);
     this.form.markAsDirty();
+  }
+
+  private async dataUrlToFile(
+    dataUrl: string,
+    fileName: string,
+  ): Promise<File> {
+    const response = await fetch(dataUrl);
+    if (!response.ok) {
+      throw new Error('No se pudo preparar la imagen');
+    }
+    const blob = await response.blob();
+    return new File([blob], fileName, { type: blob.type || 'image/jpeg' });
   }
 }

--- a/apps/frontend/src/app/private/modules/store/products/pages/categories-page/components/category-list/category-list.component.html
+++ b/apps/frontend/src/app/private/modules/store/products/pages/categories-page/components/category-list/category-list.component.html
@@ -105,4 +105,13 @@
       </div>
     }
   </app-card>
+
+  <app-image-lightbox
+    [isOpen]="imagePreviewOpen()"
+    [currentImage]="getSelectedImageUrl()"
+    [alt]="getSelectedImageAlt()"
+    [title]="getSelectedImageAlt()"
+    [showInfo]="true"
+    (close)="closeImagePreview()"
+  ></app-image-lightbox>
 </div>

--- a/apps/frontend/src/app/private/modules/store/products/pages/categories-page/components/category-list/category-list.component.ts
+++ b/apps/frontend/src/app/private/modules/store/products/pages/categories-page/components/category-list/category-list.component.ts
@@ -18,6 +18,7 @@ import {
   PaginationComponent,
   EmptyStateComponent,
   CardComponent,
+  ImageLightboxComponent,
 } from '../../../../../../../../shared/components/index';
 
 // Interfaces
@@ -36,6 +37,7 @@ import { ProductCategory } from '../../../../interfaces';
     PaginationComponent,
     EmptyStateComponent,
     CardComponent,
+    ImageLightboxComponent,
   ],
   templateUrl: './category-list.component.html',
 })
@@ -66,6 +68,8 @@ export class CategoryListComponent {
 
   searchTerm = signal('');
   selectedStatus = signal('');
+  readonly selectedImageCategory = signal<ProductCategory | null>(null);
+  readonly imagePreviewOpen = signal(false);
 
   filterConfigs: FilterConfig[] = [
     {
@@ -115,6 +119,8 @@ export class CategoryListComponent {
       width: '80px',
       priority: 3,
       defaultValue: '',
+      imageClick: (category: ProductCategory, event: MouseEvent) =>
+        this.openImagePreview(category, event),
     },
     { key: 'name', label: 'Nombre', sortable: true, priority: 1 },
     { key: 'slug', label: 'Slug', sortable: true, priority: 3 },
@@ -134,8 +140,8 @@ export class CategoryListComponent {
       badgeConfig: {
         type: 'custom',
         colorMap: {
-          'true': '#d97706',
-          'false': '#6b7280',
+          true: '#d97706',
+          false: '#6b7280',
           Destacada: '#d97706',
           Normal: '#6b7280',
         },
@@ -204,6 +210,8 @@ export class CategoryListComponent {
     titleKey: 'name',
     subtitleKey: 'slug',
     avatarKey: 'image_url',
+    avatarClick: (category: ProductCategory, event: MouseEvent) =>
+      this.openImagePreview(category, event),
     avatarFallbackIcon: 'layers',
     avatarShape: 'square',
     badgeKey: 'state',
@@ -254,6 +262,26 @@ export class CategoryListComponent {
   onRowClick(category: ProductCategory): void {
     if (!this.canUpdate()) return;
     this.edit.emit(category);
+  }
+
+  openImagePreview(category: ProductCategory, event?: MouseEvent): void {
+    event?.stopPropagation();
+    if (!category.image_url) return;
+    this.selectedImageCategory.set(category);
+    this.imagePreviewOpen.set(true);
+  }
+
+  closeImagePreview(): void {
+    this.imagePreviewOpen.set(false);
+    this.selectedImageCategory.set(null);
+  }
+
+  getSelectedImageUrl(): string {
+    return this.selectedImageCategory()?.image_url ?? '';
+  }
+
+  getSelectedImageAlt(): string {
+    return this.selectedImageCategory()?.name || 'Imagen de categoría';
   }
 
   getEmptyStateTitle(): string {

--- a/apps/frontend/src/app/private/modules/store/products/pages/product-create-page/product-create-page.component.html
+++ b/apps/frontend/src/app/private/modules/store/products/pages/product-create-page/product-create-page.component.html
@@ -25,7 +25,12 @@
 </app-sticky-header>
 
 <div class="space-y-4 md:space-y-6 max-w-[1600px] mx-auto">
-  <form [formGroup]="productForm" class="space-y-4 md:space-y-6">
+  <form
+    [formGroup]="productForm"
+    class="space-y-4 md:space-y-6"
+    (submit)="preventNativeFormSubmit($event)"
+    (keydown.enter)="preventImplicitEnterSubmit($event)"
+  >
     <!-- Tipo de Producto -->
     <section
       class="bg-white rounded-2xl border border-gray-100 p-4 md:p-6 shadow-sm"
@@ -417,8 +422,8 @@
                             >Descuento por defecto:
                             {{ row.tier.discount_percentage }}%</span
                           >
-                          }
-                        </div>
+                        }
+                      </div>
                       <div class="flex items-center gap-2">
                         @if (row.tier.is_default) {
                           <app-badge variant="primary" size="sm"
@@ -2322,6 +2327,7 @@
                       [(ngModel)]="attr.name"
                       [ngModelOptions]="{ standalone: true }"
                       placeholder="Ej. Talla, Color"
+                      (keydown.enter)="confirmAttributeName(i, $event)"
                       (inputBlur)="onAttributeNameBlur(i)"
                       tooltipText="Etiqueta del eje de variación. Ejemplos: 'Color', 'Talla', 'Material', 'Capacidad'. Define la dimensión, no los valores."
                       customWrapperClass="!mt-0"
@@ -2372,6 +2378,7 @@
                     </div>
                   </div>
                   <button
+                    type="button"
                     (click)="removeAttribute(i)"
                     title="Eliminar este atributo"
                     class="self-end md:mt-6 text-destructive hover:text-destructive/80 p-2"
@@ -3037,9 +3044,7 @@
         @for (sl of product?.stock_levels; track sl) {
           <div
             class="p-3 bg-white rounded-lg border border-gray-200"
-            [class.bg-destructive/5]="
-              sl.quantity_available <= (sl.reorder_point || 0)
-            "
+            [class.bg-destructive/5]="isStockLevelLowStock(sl)"
           >
             <div class="flex justify-between items-start mb-2">
               <div>
@@ -3052,18 +3057,10 @@
               </div>
               <span
                 class="px-2 py-1 rounded-md text-xs font-bold"
-                [class.bg-primary-50]="
-                  sl.quantity_available > (sl.reorder_point || 0)
-                "
-                [class.text-primary-700]="
-                  sl.quantity_available > (sl.reorder_point || 0)
-                "
-                [class.bg-destructive/10]="
-                  sl.quantity_available <= (sl.reorder_point || 0)
-                "
-                [class.text-destructive]="
-                  sl.quantity_available <= (sl.reorder_point || 0)
-                "
+                [class.bg-primary-50]="!isStockLevelLowStock(sl)"
+                [class.text-primary-700]="!isStockLevelLowStock(sl)"
+                [class.bg-destructive/10]="isStockLevelLowStock(sl)"
+                [class.text-destructive]="isStockLevelLowStock(sl)"
               >
                 {{ sl.quantity_available }} disp.
               </span>
@@ -3082,7 +3079,7 @@
               <div>
                 <span class="text-text-muted">Reorden:</span>
                 <span class="font-medium ml-1">{{
-                  sl.reorder_point || "-"
+                  getStockLevelLowStockThreshold(sl)
                 }}</span>
               </div>
             </div>
@@ -3126,11 +3123,7 @@
           @if (product?.stock_levels) {
             <tbody class="divide-y divide-border">
               @for (sl of product!.stock_levels; track sl) {
-                <tr
-                  [class.bg-destructive/5]="
-                    sl.quantity_available <= (sl.reorder_point || 0)
-                  "
-                >
+                <tr [class.bg-destructive/5]="isStockLevelLowStock(sl)">
                   <td class="px-4 py-3">
                     <span class="text-sm font-semibold text-text-primary">{{
                       sl.inventory_locations.name
@@ -3153,24 +3146,16 @@
                   <td class="px-4 py-3 text-center">
                     <span
                       class="px-2 py-1 rounded-md text-xs font-bold"
-                      [class.bg-primary-50]="
-                        sl.quantity_available > (sl.reorder_point || 0)
-                      "
-                      [class.text-primary-700]="
-                        sl.quantity_available > (sl.reorder_point || 0)
-                      "
-                      [class.bg-destructive/10]="
-                        sl.quantity_available <= (sl.reorder_point || 0)
-                      "
-                      [class.text-destructive]="
-                        sl.quantity_available <= (sl.reorder_point || 0)
-                      "
+                      [class.bg-primary-50]="!isStockLevelLowStock(sl)"
+                      [class.text-primary-700]="!isStockLevelLowStock(sl)"
+                      [class.bg-destructive/10]="isStockLevelLowStock(sl)"
+                      [class.text-destructive]="isStockLevelLowStock(sl)"
                     >
                       {{ sl.quantity_available }}
                     </span>
                   </td>
                   <td class="px-4 py-3 text-right text-sm text-text-secondary">
-                    {{ sl.reorder_point || "-" }}
+                    {{ getStockLevelLowStockThreshold(sl) }}
                   </td>
                 </tr>
               }

--- a/apps/frontend/src/app/private/modules/store/products/pages/product-create-page/product-create-page.component.ts
+++ b/apps/frontend/src/app/private/modules/store/products/pages/product-create-page/product-create-page.component.ts
@@ -1439,15 +1439,22 @@ export class ProductCreatePageComponent {
     this.reconcileVariants();
   }
 
-  addAttributeValue(attrIndex: number, event: any): void {
-    const value = event.target.value.trim();
-    if (value) {
-      if (!this.variantAttributes[attrIndex].values.includes(value)) {
-        this.variantAttributes[attrIndex].values.push(value);
-        // Auto-generate variants when attributes change
-        this.reconcileVariants();
-      }
-      event.target.value = '';
+  addAttributeValue(attrIndex: number, event: Event): void {
+    const attr = this.variantAttributes[attrIndex];
+    const input = event.target;
+    if (!(input instanceof HTMLInputElement)) return;
+
+    const value = input.value.trim();
+    if (!attr || !value) return;
+
+    input.value = '';
+
+    if (!attr.values.includes(value)) {
+      attr.values.push(value);
+      // Auto-generate only after the attribute has a name. This keeps
+      // existing variants intact while the user is still configuring a row.
+      if (!attr.name.trim()) return;
+      this.reconcileVariants();
     }
   }
 
@@ -1560,9 +1567,16 @@ export class ProductCreatePageComponent {
     }
   }
 
+  confirmAttributeName(attrIndex: number, event: Event): void {
+    event.preventDefault();
+    this.onAttributeNameBlur(attrIndex);
+  }
+
   onAttributeNameBlur(attrIndex: number): void {
     const attr = this.variantAttributes[attrIndex];
     if (!attr || !attr.name.trim()) return;
+
+    attr.name = attr.name.trim();
 
     // Only reconcile if there are values to generate variants with
     if (attr.values.length > 0) {
@@ -1922,6 +1936,36 @@ export class ProductCreatePageComponent {
     return (this.product?.stock_levels || []).length;
   }
 
+  isStockLevelLowStock(stockLevel: any): boolean {
+    return (
+      Number(stockLevel?.quantity_available ?? 0) <=
+      this.getStockLevelLowStockThreshold(stockLevel)
+    );
+  }
+
+  getStockLevelLowStockThreshold(stockLevel: any): number {
+    const stockLevelThreshold = Number(stockLevel?.reorder_point);
+    if (Number.isFinite(stockLevelThreshold) && stockLevelThreshold > 0) {
+      return stockLevelThreshold;
+    }
+
+    const productThreshold = [
+      this.product?.reorder_point,
+      this.product?.min_stock_level,
+    ]
+      .map((value) => Number(value))
+      .find((value) => Number.isFinite(value) && value > 0);
+
+    if (productThreshold !== undefined) {
+      return productThreshold;
+    }
+
+    const configuredThreshold = Number(this.product?.low_stock_threshold);
+    return Number.isFinite(configuredThreshold) && configuredThreshold >= 0
+      ? configuredThreshold
+      : 10;
+  }
+
   isExpired(date: Date | string): boolean {
     if (!date) return false;
     const expiryDate = new Date(date);
@@ -2239,6 +2283,27 @@ export class ProductCreatePageComponent {
   onHeaderAction(actionId: string): void {
     if (actionId === 'cancel') this.onCancel();
     else if (actionId === 'save') this.onSubmit();
+  }
+
+  preventNativeFormSubmit(event: SubmitEvent): void {
+    event.preventDefault();
+  }
+
+  preventImplicitEnterSubmit(event: Event): void {
+    const target = event.target;
+    if (!(target instanceof HTMLInputElement)) return;
+
+    const submitSafeTypes = new Set([
+      'button',
+      'checkbox',
+      'file',
+      'radio',
+      'reset',
+      'submit',
+    ]);
+    if (submitSafeTypes.has(target.type)) return;
+
+    event.preventDefault();
   }
 
   onSubmit(): void {
@@ -3134,10 +3199,10 @@ export class ProductCreatePageComponent {
     if (operations.length === 0) return Promise.resolve();
 
     this.isSyncingOverrides.set(true);
-	    return Promise.all(operations)
-	      .then(() => {
-	        this.priceTierCache.invalidateProductOverrides(productId);
-	        // Update snapshots so subsequent edits diff correctly.
+    return Promise.all(operations)
+      .then(() => {
+        this.priceTierCache.invalidateProductOverrides(productId);
+        // Update snapshots so subsequent edits diff correctly.
         const refreshed = this.priceTierRows().map((row) => ({
           ...row,
           initial_override_price: row.override_price,

--- a/apps/frontend/src/app/private/modules/store/products/utils/format.utils.ts
+++ b/apps/frontend/src/app/private/modules/store/products/utils/format.utils.ts
@@ -52,7 +52,10 @@ export class FormatUtils {
   /**
    * Format stock status
    */
-  static formatStockStatus(quantity: number | undefined): {
+  static formatStockStatus(
+    quantity: number | undefined,
+    threshold = 10,
+  ): {
     text: string;
     color: string;
   } {
@@ -60,7 +63,7 @@ export class FormatUtils {
 
     if (qty === 0) {
       return { text: 'Out of Stock', color: 'red' };
-    } else if (qty <= 5) {
+    } else if (qty <= threshold) {
       return { text: `Low Stock (${qty})`, color: 'yellow' };
     } else {
       return { text: `In Stock (${qty})`, color: 'green' };

--- a/apps/frontend/src/app/private/modules/store/products/utils/product.utils.ts
+++ b/apps/frontend/src/app/private/modules/store/products/utils/product.utils.ts
@@ -17,8 +17,14 @@ export class ProductUtils {
    * Check if a product is low stock
    */
   static isLowStock(product: Product, threshold: number = 10): boolean {
+    const effectiveThreshold =
+      product.low_stock_threshold !== undefined &&
+      product.low_stock_threshold !== null
+        ? product.low_stock_threshold
+        : threshold;
+
     return (
-      (product.stock_quantity || 0) <= threshold &&
+      (product.stock_quantity || 0) <= effectiveThreshold &&
       product.state === ProductState.ACTIVE
     );
   }
@@ -72,10 +78,13 @@ export class ProductUtils {
     return JSON.stringify(
       Object.keys(attributes)
         .sort()
-        .reduce((sorted, key) => {
-          sorted[key] = attributes[key];
-          return sorted;
-        }, {} as Record<string, string>)
+        .reduce(
+          (sorted, key) => {
+            sorted[key] = attributes[key];
+            return sorted;
+          },
+          {} as Record<string, string>,
+        ),
     );
   }
 }

--- a/apps/frontend/src/app/private/modules/store/settings/general/components/notifications-settings-form/notifications-settings-form.component.ts
+++ b/apps/frontend/src/app/private/modules/store/settings/general/components/notifications-settings-form/notifications-settings-form.component.ts
@@ -1,4 +1,13 @@
-import {Component, OnInit, effect, inject, input, output, DestroyRef, computed} from '@angular/core';
+import {
+  Component,
+  OnInit,
+  effect,
+  inject,
+  input,
+  output,
+  DestroyRef,
+  computed,
+} from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 
 import {
@@ -12,10 +21,16 @@ import { InputComponent } from '../../../../../../../shared/components/input/inp
 import { SettingToggleComponent } from '../../../../../../../shared/components/setting-toggle/setting-toggle.component';
 import { IconComponent } from '../../../../../../../shared/components/icon/icon.component';
 import { ButtonComponent } from '../../../../../../../shared/components/button/button.component';
-import { SelectorComponent, SelectorOption } from '../../../../../../../shared/components/selector/selector.component';
+import {
+  SelectorComponent,
+  SelectorOption,
+} from '../../../../../../../shared/components/selector/selector.component';
 import { NotificationsApiService } from '../../../../../../../core/services/notifications.service';
 import { PushSubscriptionService } from '../../../../../../../core/services/push-subscription.service';
-import { NotificationSoundsCatalogService, NotificationSoundCatalogItem } from '../../../../../../../core/services/notification-sounds-catalog.service';
+import {
+  NotificationSoundsCatalogService,
+  NotificationSoundCatalogItem,
+} from '../../../../../../../core/services/notification-sounds-catalog.service';
 
 export interface NotificationsSettings {
   email_enabled: boolean;
@@ -84,6 +99,7 @@ export class NotificationsSettingsForm implements OnInit {
     low_stock: true,
     new_customer: true,
     payment_received: true,
+    new_review: true,
   };
 
   subscriptionLabels: Record<string, string> = {
@@ -92,6 +108,7 @@ export class NotificationsSettingsForm implements OnInit {
     low_stock: 'Stock bajo',
     new_customer: 'Nuevos clientes',
     payment_received: 'Pagos recibidos',
+    new_review: 'Nuevas reseñas',
   };
 
   form: FormGroup = new FormGroup({
@@ -233,19 +250,22 @@ export class NotificationsSettingsForm implements OnInit {
   }
 
   loadSubscriptions() {
-    this.notificationsApi.getSubscriptions().pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
-      next: (response: any) => {
-        const subs = response?.data || [];
-        for (const sub of subs) {
-          if (sub.type in this.subscriptions) {
-            this.subscriptions[sub.type] = sub.in_app;
+    this.notificationsApi
+      .getSubscriptions()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (response: any) => {
+          const subs = response?.data || [];
+          for (const sub of subs) {
+            if (sub.type in this.subscriptions) {
+              this.subscriptions[sub.type] = sub.in_app;
+            }
           }
-        }
-      },
-      error: () => {
-        // Silently fail — subscriptions will use defaults
-      },
-    });
+        },
+        error: () => {
+          // Silently fail — subscriptions will use defaults
+        },
+      });
   }
 
   get devicePushDescription(): string {
@@ -261,7 +281,8 @@ export class NotificationsSettingsForm implements OnInit {
     this.subscriptions[type] = !this.subscriptions[type];
     this.notificationsApi
       .updateSubscription({ type, in_app: this.subscriptions[type] })
-      .pipe(takeUntilDestroyed(this.destroyRef)).subscribe();
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe();
   }
 
   async onDevicePushToggle() {

--- a/apps/frontend/src/app/private/modules/super-admin/help-center/components/categories-tab/categories-tab.component.ts
+++ b/apps/frontend/src/app/private/modules/super-admin/help-center/components/categories-tab/categories-tab.component.ts
@@ -12,6 +12,7 @@ import { ModalComponent } from '../../../../../../shared/components/modal/modal.
 import { ToastService } from '../../../../../../shared/components/toast/toast.service';
 import { IconComponent } from '../../../../../../shared/components/icon/icon.component';
 import { ConfirmationModalComponent } from '../../../../../../shared/components/confirmation-modal/confirmation-modal.component';
+import { parseApiError } from '../../../../../../core/utils/parse-api-error';
 
 @Component({
   selector: 'app-categories-tab',
@@ -202,8 +203,8 @@ export class CategoriesTabComponent implements OnInit {
 
   categoryForm: FormGroup = this.fb.group({
     name: ['', [Validators.required, Validators.maxLength(100)]],
-    description: [''],
-    icon: [''],
+    description: ['', [Validators.maxLength(500)]],
+    icon: ['', [Validators.maxLength(50)]],
     sort_order: [0],
     is_active: [true],
   });
@@ -220,8 +221,9 @@ export class CategoriesTabComponent implements OnInit {
         this.loading.set(false);
       },
       error: (err) => {
-        console.error('Error loading categories', err);
-        this.toast.error('Error al cargar las categorías');
+        const parsed = parseApiError(err);
+        console.error('Error loading categories', parsed.devMessage ?? err);
+        this.toast.error(parsed.errorCode ? parsed.userMessage : 'Error al cargar las categorías');
         this.loading.set(false);
       },
     });
@@ -252,7 +254,11 @@ export class CategoriesTabComponent implements OnInit {
   }
 
   onSaveCategory() {
-    if (this.categoryForm.invalid) return;
+    if (this.categoryForm.invalid) {
+      this.categoryForm.markAllAsTouched();
+      this.toast.error('Revisa los campos marcados.');
+      return;
+    }
 
     this.modalSubmitting.set(true);
     const dto = this.categoryForm.value;
@@ -270,8 +276,9 @@ export class CategoriesTabComponent implements OnInit {
         this.loadCategories();
       },
       error: (err) => {
-        console.error('Error saving category', err);
-        this.toast.error('Error al guardar la categoría');
+        const parsed = parseApiError(err);
+        console.error('Error saving category', parsed.devMessage ?? err);
+        this.toast.error(parsed.errorCode ? parsed.userMessage : 'Error al guardar la categoría');
         this.modalSubmitting.set(false);
       },
     });
@@ -292,8 +299,13 @@ export class CategoriesTabComponent implements OnInit {
         this.loadCategories();
       },
       error: (err) => {
-        console.error('Error deleting category', err);
-        this.toast.error('Error al eliminar la categoría. Verifica que no tenga artículos asociados.');
+        const parsed = parseApiError(err);
+        console.error('Error deleting category', parsed.devMessage ?? err);
+        this.toast.error(
+          parsed.errorCode
+            ? parsed.userMessage
+            : 'Error al eliminar la categoría. Verifica que no tenga artículos asociados.',
+        );
       },
     });
   }

--- a/apps/frontend/src/app/private/modules/super-admin/help-center/help-center-admin.component.ts
+++ b/apps/frontend/src/app/private/modules/super-admin/help-center/help-center-admin.component.ts
@@ -32,6 +32,7 @@ import {
 } from '../../../../shared/components/index';
 import { ConfirmationModalComponent } from '../../../../shared/components/confirmation-modal/confirmation-modal.component';
 import { CardComponent } from '../../../../shared/components';
+import { parseApiError } from '../../../../core/utils/parse-api-error';
 
 @Component({
   selector: 'app-help-center-admin',
@@ -401,8 +402,9 @@ export class HelpCenterAdminComponent implements OnInit {
         this.loading.set(false);
       },
       error: (err) => {
-        console.error('Error loading articles', err);
-        this.toast.error('Error al cargar los artículos');
+        const parsed = parseApiError(err);
+        console.error('Error loading articles', parsed.devMessage ?? err);
+        this.toast.error(parsed.errorCode ? parsed.userMessage : 'Error al cargar los artículos');
         this.loading.set(false);
       },
     });
@@ -442,8 +444,9 @@ export class HelpCenterAdminComponent implements OnInit {
         this.loadStats();
       },
       error: (err) => {
-        this.toast.error('Error al cambiar el estado');
-        console.error(err);
+        const parsed = parseApiError(err);
+        console.error('Error toggling article status', parsed.devMessage ?? err);
+        this.toast.error(parsed.errorCode ? parsed.userMessage : 'Error al cambiar el estado');
       },
     });
   }
@@ -464,8 +467,9 @@ export class HelpCenterAdminComponent implements OnInit {
         this.loadStats();
       },
       error: (err) => {
-        this.toast.error('Error al eliminar el artículo');
-        console.error(err);
+        const parsed = parseApiError(err);
+        console.error('Error deleting article', parsed.devMessage ?? err);
+        this.toast.error(parsed.errorCode ? parsed.userMessage : 'Error al eliminar el artículo');
       },
     });
   }

--- a/apps/frontend/src/app/private/modules/super-admin/help-center/pages/article-form/article-form.component.ts
+++ b/apps/frontend/src/app/private/modules/super-admin/help-center/pages/article-form/article-form.component.ts
@@ -5,6 +5,7 @@ import { Router, ActivatedRoute } from '@angular/router';
 import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
 import { Observable } from 'rxjs';
 import { HelpCenterAdminService } from '../../services/help-center-admin.service';
+import { parseApiError } from '../../../../../../core/utils/parse-api-error';
 import { InputComponent } from '../../../../../../shared/components/input/input.component';
 import { TextareaComponent } from '../../../../../../shared/components/textarea/textarea.component';
 import {
@@ -153,6 +154,11 @@ import { ModalComponent } from '../../../../../../shared/components/modal/modal.
               (contentChange)="onContentChange($event)"
               (uploadError)="toast.error($event)"
             ></app-markdown-editor>
+            @if (contentError()) {
+              <p class="mt-2 text-sm text-[var(--color-destructive)]">
+                {{ contentError() }}
+              </p>
+            }
           </section>
           <!-- Section 5: Extra -->
           <section class="bg-white rounded-2xl border border-gray-100 p-4 md:p-6 shadow-sm">
@@ -244,7 +250,7 @@ export class ArticleFormComponent implements OnInit {
   categorySubmitting = signal(false);
   categoryForm: FormGroup = this.fb.group({
     name: ['', [Validators.required, Validators.maxLength(100)]],
-    description: [''],
+    description: ['', [Validators.maxLength(500)]],
   });
 
   headerActions = computed(() => [
@@ -290,11 +296,13 @@ export class ArticleFormComponent implements OnInit {
     type: ['GUIDE', Validators.required],
     category_id: [null as number | null, Validators.required],
     status: ['DRAFT'],
-    module: [''],
+    module: ['', [Validators.maxLength(50)]],
     tags: [''],
     is_featured: [false],
     sort_order: [0],
   });
+
+  contentError = signal<string | null>(null);
 
   // Bind upload function for markdown editor
   imageUploadFn = (file: File): Observable<{ key: string; url: string }> => {
@@ -354,8 +362,9 @@ export class ArticleFormComponent implements OnInit {
         this.loadingArticle.set(false);
       },
       error: (err) => {
-        console.error('Error loading article', err);
-        this.toast.error('Error al cargar el artículo');
+        const parsed = parseApiError(err);
+        console.error('Error loading article', parsed.devMessage ?? err);
+        this.toast.error(parsed.errorCode ? parsed.userMessage : 'Error al cargar el artículo');
         this.loadingArticle.set(false);
         this.goBack();
       },
@@ -364,6 +373,9 @@ export class ArticleFormComponent implements OnInit {
 
   onContentChange(content: string) {
     this.contentValue.set(content);
+    if (this.contentError() && content && content.trim()) {
+      this.contentError.set(null);
+    }
   }
 
   onCoverImageSelected(file: File) {
@@ -374,8 +386,9 @@ export class ArticleFormComponent implements OnInit {
         this.existingCoverUrl.set(result.url);
       },
       error: (err) => {
-        console.error('Error uploading cover image', err);
-        this.toast.error('Error al subir la imagen de portada');
+        const parsed = parseApiError(err);
+        console.error('Error uploading cover image', parsed.devMessage ?? err);
+        this.toast.error(parsed.errorCode ? parsed.userMessage : 'Error al subir la imagen de portada');
         this.coverFile.set(null);
       },
     });
@@ -387,7 +400,14 @@ export class ArticleFormComponent implements OnInit {
   }
 
   onSubmit() {
-    if (this.form.invalid) return;
+    const contentEmpty = !this.contentValue() || !this.contentValue().trim();
+    this.contentError.set(contentEmpty ? 'El contenido es requerido.' : null);
+
+    if (this.form.invalid || contentEmpty) {
+      this.form.markAllAsTouched();
+      this.toast.error('Revisa los campos marcados.');
+      return;
+    }
 
     this.submitting.set(true);
 
@@ -423,10 +443,12 @@ export class ArticleFormComponent implements OnInit {
         this.goBack();
       },
       error: (err) => {
-        console.error('Error saving article', err);
-        this.toast.error(
-          this.isEditMode() ? 'Error al actualizar el artículo' : 'Error al crear el artículo',
-        );
+        const parsed = parseApiError(err);
+        console.error('Error saving article', parsed.devMessage ?? err);
+        const fallback = this.isEditMode()
+          ? 'Error al actualizar el artículo'
+          : 'Error al crear el artículo';
+        this.toast.error(parsed.errorCode ? parsed.userMessage : fallback);
         this.submitting.set(false);
       },
     });
@@ -437,7 +459,10 @@ export class ArticleFormComponent implements OnInit {
   }
 
   onCategoryCreated() {
-    if (this.categoryForm.invalid) return;
+    if (this.categoryForm.invalid) {
+      this.categoryForm.markAllAsTouched();
+      return;
+    }
 
     this.categorySubmitting.set(true);
     this.service.createCategory(this.categoryForm.value).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
@@ -449,8 +474,9 @@ export class ArticleFormComponent implements OnInit {
         this.loadCategories();
       },
       error: (err) => {
-        console.error('Error creating category', err);
-        this.toast.error('Error al crear la categoría');
+        const parsed = parseApiError(err);
+        console.error('Error creating category', parsed.devMessage ?? err);
+        this.toast.error(parsed.errorCode ? parsed.userMessage : 'Error al crear la categoría');
         this.categorySubmitting.set(false);
       },
     });

--- a/apps/frontend/src/app/shared/components/notifications-dropdown/notifications-dropdown.component.scss
+++ b/apps/frontend/src/app/shared/components/notifications-dropdown/notifications-dropdown.component.scss
@@ -164,6 +164,11 @@
     background: rgba(34, 197, 94, 0.1);
     color: #22c55e;
   }
+
+  &[data-type="new_review"] {
+    background: rgba(234, 179, 8, 0.12);
+    color: #ca8a04;
+  }
 }
 
 .notif-content {

--- a/apps/frontend/src/app/shared/components/notifications-dropdown/notifications-dropdown.component.ts
+++ b/apps/frontend/src/app/shared/components/notifications-dropdown/notifications-dropdown.component.ts
@@ -140,6 +140,9 @@ export class NotificationsDropdownComponent {
 
   private getRouteForNotification(n: AppNotification): string | null {
     const d = n.data;
+    const explicitRoute = this.getSafeRoute(d?.route ?? d?.url);
+    if (explicitRoute) return explicitRoute;
+
     switch (n.type) {
       case 'new_order':
       case 'order_status_change':
@@ -155,6 +158,10 @@ export class NotificationsDropdownComponent {
         return d?.product_id
           ? `/admin/products/edit/${d.product_id}`
           : '/admin/products';
+      case 'new_review':
+        return d?.review_id
+          ? `/admin/customers/reviews?review_id=${d.review_id}`
+          : '/admin/customers/reviews';
       case 'layaway_payment_received':
       case 'layaway_payment_reminder':
       case 'layaway_overdue':
@@ -173,6 +180,12 @@ export class NotificationsDropdownComponent {
     }
   }
 
+  private getSafeRoute(route: unknown): string | null {
+    if (typeof route !== 'string') return null;
+    if (!route.startsWith('/') || route.startsWith('//')) return null;
+    return route;
+  }
+
   getIconForType(type: string): string {
     const map: Record<string, string> = {
       new_order: 'shopping-cart',
@@ -180,6 +193,7 @@ export class NotificationsDropdownComponent {
       low_stock: 'alert-triangle',
       new_customer: 'user-plus',
       payment_received: 'credit-card',
+      new_review: 'star',
       layaway_payment_received: 'credit-card',
       layaway_payment_reminder: 'clock',
       layaway_overdue: 'alert-triangle',

--- a/apps/frontend/src/app/shared/constants/document-types.ts
+++ b/apps/frontend/src/app/shared/constants/document-types.ts
@@ -1,0 +1,127 @@
+export const DOCUMENT_TYPE_CODES = [
+  'CC',
+  'CE',
+  'NIT',
+  'TI',
+  'RC',
+  'PA',
+  'PEP',
+  'PPT',
+  'DIE',
+  'NUIP',
+] as const;
+
+export type DocumentTypeCode = (typeof DOCUMENT_TYPE_CODES)[number];
+
+export interface DocumentTypeOption {
+  code: DocumentTypeCode;
+  label: string;
+  shortLabel: string;
+  placeholder: string;
+  maxLength: number;
+  regex: RegExp;
+}
+
+export const DOCUMENT_TYPES: DocumentTypeOption[] = [
+  {
+    code: 'CC',
+    label: 'Cédula de Ciudadanía',
+    shortLabel: 'CC',
+    placeholder: '1023456789',
+    maxLength: 10,
+    regex: /^\d{6,10}$/,
+  },
+  {
+    code: 'CE',
+    label: 'Cédula de Extranjería',
+    shortLabel: 'CE',
+    placeholder: '1023456789',
+    maxLength: 10,
+    regex: /^\d{6,10}$/,
+  },
+  {
+    code: 'NIT',
+    label: 'NIT',
+    shortLabel: 'NIT',
+    placeholder: '900123456-7',
+    maxLength: 12,
+    regex: /^\d{8,10}-?\d?$/,
+  },
+  {
+    code: 'TI',
+    label: 'Tarjeta de Identidad',
+    shortLabel: 'TI',
+    placeholder: '1012345678',
+    maxLength: 11,
+    regex: /^\d{8,11}$/,
+  },
+  {
+    code: 'RC',
+    label: 'Registro Civil',
+    shortLabel: 'RC',
+    placeholder: '1012345678',
+    maxLength: 11,
+    regex: /^\d{8,11}$/,
+  },
+  {
+    code: 'PA',
+    label: 'Pasaporte',
+    shortLabel: 'PA',
+    placeholder: 'AB123456',
+    maxLength: 16,
+    regex: /^[A-Z0-9]{5,16}$/,
+  },
+  {
+    code: 'PEP',
+    label: 'Permiso Especial de Permanencia',
+    shortLabel: 'PEP',
+    placeholder: '123456789',
+    maxLength: 15,
+    regex: /^\d{9,15}$/,
+  },
+  {
+    code: 'PPT',
+    label: 'Permiso por Protección Temporal',
+    shortLabel: 'PPT',
+    placeholder: '123456789',
+    maxLength: 15,
+    regex: /^\d{9,15}$/,
+  },
+  {
+    code: 'DIE',
+    label: 'Documento de Identificación Extranjero',
+    shortLabel: 'DIE',
+    placeholder: 'AB12345678',
+    maxLength: 20,
+    regex: /^[A-Z0-9]{5,20}$/,
+  },
+  {
+    code: 'NUIP',
+    label: 'Número Único de Identificación Personal',
+    shortLabel: 'NUIP',
+    placeholder: '1012345678',
+    maxLength: 11,
+    regex: /^\d{8,11}$/,
+  },
+];
+
+const DOCUMENT_TYPE_INDEX: Record<string, DocumentTypeOption> = DOCUMENT_TYPES.reduce(
+  (acc, option) => {
+    acc[option.code] = option;
+    return acc;
+  },
+  {} as Record<string, DocumentTypeOption>,
+);
+
+export function findDocumentType(code: string | null | undefined): DocumentTypeOption | undefined {
+  if (!code) return undefined;
+  return DOCUMENT_TYPE_INDEX[code.toUpperCase()];
+}
+
+export function getDocumentTypeLabel(code: string | null | undefined): string {
+  return findDocumentType(code)?.label ?? 'Sin clasificar';
+}
+
+export function isValidDocumentType(value: unknown): value is DocumentTypeCode {
+  return typeof value === 'string' && value in DOCUMENT_TYPE_INDEX;
+}

--- a/apps/mobile/app/(org-admin)/stores.tsx
+++ b/apps/mobile/app/(org-admin)/stores.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useMemo } from 'react';
-import { View, Text, Pressable, FlatList, StyleSheet, RefreshControl } from 'react-native';
+import { View, Text, Pressable, FlatList, StyleSheet, RefreshControl, TextInput } from 'react-native';
 import { useRouter } from 'expo-router';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { OrgStoreService } from '@/features/org/services';
 import { AuthService } from '@/core/auth/auth.service';
 import { useTenantStore } from '@/core/store/tenant.store';
@@ -11,23 +11,42 @@ import { Badge } from '@/shared/components/badge/badge';
 import { Spinner } from '@/shared/components/spinner/spinner';
 import { SearchBar } from '@/shared/components/search-bar/search-bar';
 import { EmptyState } from '@/shared/components/empty-state/empty-state';
+import { Button } from '@/shared/components/button/button';
+import { BottomSheet } from '@/shared/components/bottom-sheet/bottom-sheet';
+import { Modal } from '@/shared/components/modal/modal';
 import { toastSuccess, toastError } from '@/shared/components/toast/toast.store';
+import { formatCurrency } from '@/shared/utils/currency';
 
 const storeTypeLabels: Record<string, string> = {
-  PHYSICAL: 'Física',
-  ONLINE: 'En línea',
-  HYBRID: 'Híbrida',
-  POPUP: 'Pop-up',
-  KIOSKO: 'Kiosko',
+  physical: 'Física',
+  online: 'En línea',
+  hybrid: 'Híbrida',
+  popup: 'Pop-up',
+  kiosko: 'Kiosko',
 };
 
 const storeTypeIcons: Record<string, string> = {
-  PHYSICAL: 'store',
-  ONLINE: 'globe',
-  HYBRID: 'layers',
-  POPUP: 'calendar',
-  KIOSKO: 'shopping-bag',
+  physical: 'store',
+  online: 'globe',
+  hybrid: 'layers',
+  popup: 'calendar',
+  kiosko: 'shopping-bag',
 };
+
+const STORE_TYPE_FILTERS = [
+  { label: 'Todos', value: '' },
+  { label: 'Física', value: 'physical' },
+  { label: 'Online', value: 'online' },
+  { label: 'Híbrida', value: 'hybrid' },
+  { label: 'Temporal', value: 'popup' },
+  { label: 'Kiosko', value: 'kiosko' },
+];
+
+const STATUS_FILTERS = [
+  { label: 'Todos', value: '' },
+  { label: 'Activas', value: 'active' },
+  { label: 'Inactivas', value: 'inactive' },
+];
 
 function getStoreStatusBadge(state: string, isActive: boolean): { label: string; variant: 'success' | 'warning' | 'error' | 'default' } {
   if (!isActive) return { label: 'Inactiva', variant: 'error' };
@@ -39,149 +58,356 @@ function getStoreStatusBadge(state: string, isActive: boolean): { label: string;
 
 export default function StoresScreen() {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const setStoreId = useTenantStore((s) => s.setStoreId);
   const setStoreName = useTenantStore((s) => s.setStoreName);
   const setStoreSlug = useTenantStore((s) => s.setStoreSlug);
   const [search, setSearch] = useState('');
   const [page, setPage] = useState(1);
   const [switchingStore, setSwitchingStore] = useState<number | null>(null);
+  const [typeFilter, setTypeFilter] = useState('');
+  const [statusFilter, setStatusFilter] = useState('');
+  const [selectedStore, setSelectedStore] = useState<any>(null);
+  const [showActionsSheet, setShowActionsSheet] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<any>(null);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [deleteSlug, setDeleteSlug] = useState('');
 
   const { data: statsData, isLoading: statsLoading } = useQuery({
     queryKey: ['org-stores-stats'],
     queryFn: () => OrgStoreService.stats(),
   });
 
-  const { data: storesData, isLoading, isRefetching, refetch } = useQuery({
-    queryKey: ['org-stores', search, page],
-    queryFn: () => OrgStoreService.list({ search: search || undefined, page, limit: 50 }),
+  const {
+    data: storesData,
+    isLoading,
+    isRefetching,
+    refetch,
+  } = useQuery({
+    queryKey: ['org-stores', search, page, typeFilter, statusFilter],
+    queryFn: () =>
+      OrgStoreService.list({
+        search: search || undefined,
+        page,
+        limit: 50,
+        store_type: (typeFilter || undefined) as any,
+        is_active: statusFilter === 'active' ? true : statusFilter === 'inactive' ? false : undefined,
+      }),
   });
 
   const stores = useMemo(() => storesData?.data ?? [], [storesData]);
   const stats = statsData;
 
-  const handleStorePress = useCallback(async (store: { id: number; name: string; slug: string }) => {
-    setSwitchingStore(store.id);
-    try {
-      await AuthService.switchEnvironment('STORE_ADMIN', store.slug);
-      setStoreId(String(store.id));
-      setStoreName(store.name);
-      setStoreSlug(store.slug);
-      toastSuccess(`Cambiando a ${store.name}`);
-      router.replace('/(store-admin)/dashboard' as never);
-    } catch (error: any) {
-      const message = error?.response?.data?.message || error?.message || 'Error al cambiar de tienda';
+  const deleteMutation = useMutation({
+    mutationFn: (id: number) => OrgStoreService.deleteStore(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['org-stores'] });
+      queryClient.invalidateQueries({ queryKey: ['org-stores-stats'] });
+      toastSuccess('Tienda eliminada exitosamente');
+      setShowDeleteModal(false);
+      setDeleteTarget(null);
+      setDeleteSlug('');
+    },
+    onError: (error: any) => {
+      const message = error?.response?.data?.message || error?.message || 'Error al eliminar tienda';
       toastError(message);
-    } finally {
-      setSwitchingStore(null);
-    }
-  }, [setStoreId, setStoreName, setStoreSlug, router]);
+    },
+  });
+
+  const handleStorePress = useCallback(
+    async (store: { id: number; name: string; slug: string }) => {
+      setSwitchingStore(store.id);
+      try {
+        await AuthService.switchEnvironment('STORE_ADMIN', store.slug);
+        setStoreId(String(store.id));
+        setStoreName(store.name);
+        setStoreSlug(store.slug);
+        toastSuccess(`Cambiando a ${store.name}`);
+        router.replace('/(store-admin)/dashboard' as never);
+      } catch (error: any) {
+        const message = error?.response?.data?.message || error?.message || 'Error al cambiar de tienda';
+        toastError(message);
+      } finally {
+        setSwitchingStore(null);
+      }
+    },
+    [setStoreId, setStoreName, setStoreSlug, router],
+  );
 
   const handleSearch = useCallback((value: string) => {
     setSearch(value);
     setPage(1);
   }, []);
 
-  const renderStoreItem = useCallback(({ item }: { item: import('@/features/org/services').OrgStore }) => {
-    const status = getStoreStatusBadge(item.state, item.is_active);
-    const typeLabel = storeTypeLabels[item.store_type] || item.store_type;
-    const typeIcon = storeTypeIcons[item.store_type] || 'store';
+  const handleStoreAction = useCallback((store: any, action: 'edit' | 'settings' | 'delete') => {
+    setShowActionsSheet(false);
+    setSelectedStore(null);
 
-    return (
-      <Pressable
-        onPress={() => handleStorePress(item)}
-        style={({ pressed }) => [
-          styles.storeCard,
-          pressed && { backgroundColor: colorScales.gray[50] },
-        ]}
-      >
-        <View style={styles.storeIcon}>
-          <Icon name={typeIcon} size={20} color={colors.primary} />
-        </View>
+    if (action === 'edit') {
+      router.push({ pathname: '/(org-admin)/stores/edit', params: { id: String(store.id) } } as never);
+    } else if (action === 'settings') {
+      router.push(`/(org-admin)/stores/${store.id}/settings` as never);
+    } else if (action === 'delete') {
+      setDeleteTarget(store);
+      setDeleteSlug('');
+      setShowDeleteModal(true);
+    }
+  }, [router]);
 
-        <View style={styles.storeInfo}>
-          <View style={styles.storeNameRow}>
-            <Text style={styles.storeName} numberOfLines={1}>{item.name}</Text>
-            {!item.is_active && <View style={styles.inactiveDot} />}
+  const handleConfirmDelete = useCallback(() => {
+    if (!deleteTarget || deleteSlug !== deleteTarget.slug) return;
+    deleteMutation.mutate(deleteTarget.id);
+  }, [deleteTarget, deleteSlug, deleteMutation]);
+
+  const renderStoreItem = useCallback(
+    ({ item }: { item: any }) => {
+      const status = getStoreStatusBadge(item.state, item.is_active);
+      const typeLabel = storeTypeLabels[item.store_type] || item.store_type;
+      const typeIcon = storeTypeIcons[item.store_type] || 'store';
+
+      return (
+        <Pressable
+          onPress={() => handleStorePress(item)}
+          style={({ pressed }) => [styles.storeCard, pressed && { backgroundColor: colorScales.gray[50] }]}
+        >
+          <View style={styles.storeIcon}>
+            <Icon name={typeIcon} size={20} color={colors.primary} />
           </View>
-          <Text style={styles.storeCode}>{item.store_code}</Text>
-          {item.primary_address && (
-            <Text style={styles.storeAddress} numberOfLines={1}>
-              <Icon name="map-pin" size={12} color={colorScales.gray[400]} /> {item.primary_address}
-            </Text>
-          )}
-          <View style={styles.storeMeta}>
-            <Badge label={typeLabel} variant="info" size="sm" />
-            <Badge label={status.label} variant={status.variant} size="sm" />
-          </View>
-          {item.orders_count > 0 && (
-            <Text style={styles.ordersCount}>
-              {item.orders_count} {item.orders_count === 1 ? 'orden' : 'órdenes'}
-            </Text>
-          )}
-        </View>
 
-        <Icon name="chevron-right" size={18} color={colorScales.gray[400]} />
-      </Pressable>
-    );
-  }, [handleStorePress]);
+          <View style={styles.storeInfo}>
+            <View style={styles.storeNameRow}>
+              <Text style={styles.storeName} numberOfLines={1}>
+                {item.name}
+              </Text>
+              {!item.is_active && <View style={styles.inactiveDot} />}
+            </View>
+            <Text style={styles.storeCode}>{item.store_code}</Text>
+            {item.primary_address && (
+              <Text style={styles.storeAddress} numberOfLines={1}>
+                <Icon name="map-pin" size={12} color={colorScales.gray[400]} /> {item.primary_address}
+              </Text>
+            )}
+            <View style={styles.storeMeta}>
+              <Badge label={typeLabel} variant="info" size="sm" />
+              <Badge label={status.label} variant={status.variant} size="sm" />
+            </View>
+            {item.orders_count > 0 && (
+              <Text style={styles.ordersCount}>
+                {item.orders_count} {item.orders_count === 1 ? 'orden' : 'órdenes'}
+              </Text>
+            )}
+          </View>
+
+          <Pressable
+            onPress={() => {
+              setSelectedStore(item);
+              setShowActionsSheet(true);
+            }}
+            hitSlop={8}
+            style={styles.moreButton}
+          >
+            <Icon name="more-vertical" size={18} color={colorScales.gray[400]} />
+          </Pressable>
+        </Pressable>
+      );
+    },
+    [handleStorePress],
+  );
+
+  const formatNumber = (num: number): string => {
+    if (num >= 1000000) return (num / 1000000).toFixed(1) + 'M';
+    if (num >= 1000) return (num / 1000).toFixed(1) + 'K';
+    return num.toString();
+  };
 
   return (
     <View style={styles.container}>
-      {/* Stats Summary */}
-      {stats && !statsLoading && (
-        <View style={styles.statsRow}>
-          <View style={[styles.statCard, { backgroundColor: colorScales.blue[50] }]}>
-            <Text style={[styles.statValue, { color: colorScales.blue[700] }]}>
-              {stats.total_stores}
-            </Text>
-            <Text style={[styles.statLabel, { color: colorScales.blue[600] }]}>Totales</Text>
-          </View>
-          <View style={[styles.statCard, { backgroundColor: colorScales.green[50] }]}>
-            <Text style={[styles.statValue, { color: colorScales.green[700] }]}>
-              {stats.active_stores}
-            </Text>
-            <Text style={[styles.statLabel, { color: colorScales.green[600] }]}>Activas</Text>
-          </View>
-          <View style={[styles.statCard, { backgroundColor: colorScales.amber[50] }]}>
-            <Text style={[styles.statValue, { color: colorScales.amber[700] }]}>
-              {stats.total_orders}
-            </Text>
-            <Text style={[styles.statLabel, { color: colorScales.amber[600] }]}>Órdenes</Text>
-          </View>
-        </View>
-      )}
+      <FlatList
+        data={stores}
+        keyExtractor={(item) => item.id.toString()}
+        contentContainerStyle={styles.listContent}
+        refreshControl={<RefreshControl refreshing={isRefetching} onRefresh={refetch} />}
+        ListHeaderComponent={
+          <View>
+            {/* Stats Summary */}
+            {stats && !statsLoading && (
+              <View style={styles.statsRow}>
+                <View style={[styles.statCard, { backgroundColor: colorScales.blue[50] }]}>
+                  <Text style={[styles.statValue, { color: colorScales.blue[700] }]}>{stats.total_stores}</Text>
+                  <Text style={[styles.statLabel, { color: colorScales.blue[600] }]}>Totales</Text>
+                </View>
+                <View style={[styles.statCard, { backgroundColor: colorScales.green[50] }]}>
+                  <Text style={[styles.statValue, { color: colorScales.green[700] }]}>{stats.active_stores}</Text>
+                  <Text style={[styles.statLabel, { color: colorScales.green[600] }]}>Activas</Text>
+                </View>
+                <View style={[styles.statCard, { backgroundColor: colorScales.amber[50] }]}>
+                  <Text style={[styles.statValue, { color: colorScales.amber[700] }]}>{formatNumber(stats.total_orders)}</Text>
+                  <Text style={[styles.statLabel, { color: colorScales.amber[600] }]}>Órdenes</Text>
+                </View>
+                <View style={[styles.statCard, { backgroundColor: colorScales.blue[50] }]}>
+                  <Text style={[styles.statValue, { color: colorScales.blue[700], fontSize: 14 }]} numberOfLines={1} adjustsFontSizeToFit>
+                    {formatCurrency(stats.total_revenue || 0)}
+                  </Text>
+                  <Text style={[styles.statLabel, { color: colorScales.blue[600] }]}>Ganancias</Text>
+                </View>
+              </View>
+            )}
 
-      {/* Search */}
-      <View style={styles.searchContainer}>
-        <SearchBar
-          placeholder="Buscar tiendas..."
-          value={search}
-          onChangeText={handleSearch}
-        />
-      </View>
+            {/* Search */}
+            <View style={styles.searchContainer}>
+              <SearchBar placeholder="Buscar tiendas..." value={search} onChangeText={handleSearch} />
+            </View>
 
-      {/* Store List */}
-      {isLoading ? (
-        <View style={styles.centerContent}>
-          <Spinner />
+            {/* Filter: Store Type */}
+            <View style={styles.filterRow}>
+              <Text style={styles.filterLabel}>Tipo:</Text>
+              <FlatList
+                horizontal
+                showsHorizontalScrollIndicator={false}
+                data={STORE_TYPE_FILTERS}
+                keyExtractor={(f) => f.value}
+                contentContainerStyle={styles.chipList}
+                renderItem={({ item: f }) => (
+                  <Pressable
+                    onPress={() => {
+                      setTypeFilter(f.value);
+                      setPage(1);
+                    }}
+                    style={[styles.filterChip, typeFilter === f.value && styles.filterChipActive]}
+                  >
+                    <Text style={[styles.filterChipText, typeFilter === f.value && styles.filterChipTextActive]}>
+                      {f.label}
+                    </Text>
+                  </Pressable>
+                )}
+              />
+            </View>
+
+            {/* Filter: Status */}
+            <View style={styles.filterRow}>
+              <Text style={styles.filterLabel}>Estado:</Text>
+              <FlatList
+                horizontal
+                showsHorizontalScrollIndicator={false}
+                data={STATUS_FILTERS}
+                keyExtractor={(f) => f.value}
+                contentContainerStyle={styles.chipList}
+                renderItem={({ item: f }) => (
+                  <Pressable
+                    onPress={() => {
+                      setStatusFilter(f.value);
+                      setPage(1);
+                    }}
+                    style={[styles.filterChip, statusFilter === f.value && styles.filterChipActive]}
+                  >
+                    <Text style={[styles.filterChipText, statusFilter === f.value && styles.filterChipTextActive]}>
+                      {f.label}
+                    </Text>
+                  </Pressable>
+                )}
+              />
+            </View>
+
+            {/* Divider */}
+            <View style={styles.divider} />
+          </View>
+        }
+        ListEmptyComponent={
+          isLoading ? (
+            <View style={styles.centerContent}>
+              <Spinner />
+            </View>
+          ) : (
+            <EmptyState
+              title="Sin tiendas"
+              description={search || typeFilter || statusFilter ? 'No se encontraron tiendas con esos filtros' : 'No hay tiendas disponibles'}
+              icon="store"
+            />
+          )
+        }
+        renderItem={renderStoreItem}
+      />
+
+      {/* FAB: Create Store */}
+      <Pressable onPress={() => router.push('/(org-admin)/stores/create' as never)} style={styles.fab}>
+        <Icon name="plus" size={24} color={colors.background} />
+      </Pressable>
+
+      {/* Actions Bottom Sheet */}
+      <BottomSheet visible={showActionsSheet} onClose={() => setShowActionsSheet(false)}>
+        <View style={styles.sheetContent}>
+          {selectedStore && (
+            <>
+              <Text style={styles.sheetTitle}>{selectedStore.name}</Text>
+              <Pressable style={styles.sheetAction} onPress={() => handleStoreAction(selectedStore, 'edit')}>
+                <Icon name="edit" size={20} color={colorScales.gray[700]} />
+                <Text style={styles.sheetActionText}>Editar Tienda</Text>
+              </Pressable>
+              <Pressable style={styles.sheetAction} onPress={() => handleStoreAction(selectedStore, 'settings')}>
+                <Icon name="settings" size={20} color={colorScales.gray[700]} />
+                <Text style={styles.sheetActionText}>Configuración</Text>
+              </Pressable>
+              <View style={styles.sheetDivider} />
+              <Pressable style={styles.sheetAction} onPress={() => handleStoreAction(selectedStore, 'delete')}>
+                <Icon name="trash-2" size={20} color={colors.error} />
+                <Text style={[styles.sheetActionText, { color: colors.error }]}>Eliminar Tienda</Text>
+              </Pressable>
+            </>
+          )}
         </View>
-      ) : stores.length === 0 ? (
-        <EmptyState
-          title="Sin tiendas"
-          description={search ? 'No se encontraron tiendas' : 'No hay tiendas disponibles'}
-          icon="store"
-        />
-      ) : (
-        <FlatList
-          data={stores}
-          keyExtractor={(item) => item.id.toString()}
-          contentContainerStyle={styles.listContent}
-          refreshControl={
-            <RefreshControl refreshing={isRefetching} onRefresh={refetch} />
-          }
-          renderItem={renderStoreItem}
-        />
-      )}
+      </BottomSheet>
+
+      {/* Delete Confirmation Modal */}
+      <Modal visible={showDeleteModal} onClose={() => setShowDeleteModal(false)} title="Eliminar Tienda">
+        <View style={styles.deleteContent}>
+          {deleteTarget && (
+            <>
+              <View style={styles.deleteWarning}>
+                <Icon name="alert-triangle" size={24} color={colors.error} />
+                <Text style={styles.deleteWarningText}>
+                  Estás a punto de eliminar la tienda <Text style={styles.deleteStoreName}>{deleteTarget.name}</Text>.
+                  Esta acción no se puede deshacer.
+                </Text>
+              </View>
+
+              <Text style={styles.deleteInstruction}>
+                Escribe <Text style={styles.deleteSlugText}>{deleteTarget.slug}</Text> para confirmar:
+              </Text>
+
+              <TextInput
+                style={styles.deleteInput}
+                value={deleteSlug}
+                onChangeText={setDeleteSlug}
+                placeholder={deleteTarget.slug}
+                autoCapitalize="none"
+                autoCorrect={false}
+              />
+
+              <View style={styles.deleteActions}>
+                <Pressable
+                  style={styles.deleteCancelBtn}
+                  onPress={() => {
+                    setShowDeleteModal(false);
+                    setDeleteTarget(null);
+                    setDeleteSlug('');
+                  }}
+                >
+                  <Text style={styles.deleteCancelText}>Cancelar</Text>
+                </Pressable>
+                <Pressable
+                  style={[styles.deleteConfirmBtn, deleteSlug !== deleteTarget.slug && styles.deleteConfirmBtnDisabled]}
+                  onPress={handleConfirmDelete}
+                  disabled={deleteSlug !== deleteTarget.slug || deleteMutation.isPending}
+                >
+                  <Text style={styles.deleteConfirmText}>
+                    {deleteMutation.isPending ? 'Eliminando...' : 'Eliminar Tienda'}
+                  </Text>
+                </Pressable>
+              </View>
+            </>
+          )}
+        </View>
+      </Modal>
     </View>
   );
 }
@@ -193,7 +419,7 @@ const styles = StyleSheet.create({
   },
   statsRow: {
     flexDirection: 'row',
-    gap: spacing[3],
+    gap: spacing[2],
     paddingHorizontal: spacing[4],
     paddingTop: spacing[3],
     paddingBottom: spacing[2],
@@ -201,8 +427,9 @@ const styles = StyleSheet.create({
   statCard: {
     flex: 1,
     borderRadius: borderRadius.xl,
-    padding: spacing[3],
+    padding: spacing[2],
     alignItems: 'center',
+    minWidth: 0,
   },
   statValue: {
     fontSize: typography.fontSize['2xl'],
@@ -219,14 +446,57 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing[4],
     paddingVertical: spacing[2],
   },
+  filterRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[1],
+  },
+  filterLabel: {
+    fontSize: typography.fontSize.xs,
+    fontWeight: typography.fontWeight.semibold as any,
+    fontFamily: typography.fontFamily,
+    color: colorScales.gray[500],
+    marginRight: spacing[2],
+  },
+  chipList: {
+    gap: spacing[2],
+  },
+  filterChip: {
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[1.5],
+    borderRadius: borderRadius.full,
+    borderWidth: 1,
+    borderColor: colorScales.gray[200],
+    backgroundColor: colors.background,
+  },
+  filterChipActive: {
+    backgroundColor: colors.primary,
+    borderColor: colors.primary,
+  },
+  filterChipText: {
+    fontSize: typography.fontSize.xs,
+    fontWeight: typography.fontWeight.medium as any,
+    fontFamily: typography.fontFamily,
+    color: colorScales.gray[700],
+  },
+  filterChipTextActive: {
+    color: colors.background,
+  },
+  divider: {
+    height: 1,
+    backgroundColor: colorScales.gray[200],
+    marginHorizontal: spacing[4],
+    marginVertical: spacing[2],
+  },
   centerContent: {
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
+    paddingVertical: spacing[16],
   },
   listContent: {
-    paddingHorizontal: spacing[4],
-    paddingBottom: spacing[4],
+    paddingBottom: spacing[20],
   },
   storeCard: {
     flexDirection: 'row',
@@ -234,6 +504,7 @@ const styles = StyleSheet.create({
     backgroundColor: '#FFFFFF',
     borderRadius: borderRadius.xl,
     padding: spacing[4],
+    marginHorizontal: spacing[4],
     marginBottom: spacing[2],
     borderWidth: 1,
     borderColor: colorScales.gray[100],
@@ -290,5 +561,131 @@ const styles = StyleSheet.create({
     fontFamily: typography.fontFamily,
     color: colorScales.gray[500],
     marginTop: spacing[1],
+  },
+  moreButton: {
+    width: 32,
+    height: 32,
+    borderRadius: borderRadius.full,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  fab: {
+    position: 'absolute',
+    bottom: spacing[6],
+    right: spacing[6],
+    width: 56,
+    height: 56,
+    borderRadius: borderRadius.full,
+    backgroundColor: colors.primary,
+    alignItems: 'center',
+    justifyContent: 'center',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.2,
+    shadowRadius: 8,
+    elevation: 6,
+  },
+  sheetContent: {
+    padding: spacing[4],
+    paddingBottom: spacing[8],
+  },
+  sheetTitle: {
+    fontSize: typography.fontSize.lg,
+    fontWeight: typography.fontWeight.bold as any,
+    fontFamily: typography.fontFamily,
+    color: colorScales.gray[900],
+    marginBottom: spacing[4],
+  },
+  sheetAction: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: spacing[3],
+    gap: spacing[3],
+  },
+  sheetActionText: {
+    fontSize: typography.fontSize.base,
+    fontFamily: typography.fontFamily,
+    color: colorScales.gray[700],
+  },
+  sheetDivider: {
+    height: 1,
+    backgroundColor: colorScales.gray[200],
+    marginVertical: spacing[1],
+  },
+  deleteContent: {
+    padding: spacing[4],
+  },
+  deleteWarning: {
+    flexDirection: 'row',
+    gap: spacing[3],
+    backgroundColor: colorScales.red[50],
+    borderRadius: borderRadius.lg,
+    padding: spacing[4],
+    marginBottom: spacing[4],
+  },
+  deleteWarningText: {
+    flex: 1,
+    fontSize: typography.fontSize.sm,
+    fontFamily: typography.fontFamily,
+    color: colorScales.red[700],
+    lineHeight: 20,
+  },
+  deleteStoreName: {
+    fontWeight: typography.fontWeight.bold as any,
+  },
+  deleteInstruction: {
+    fontSize: typography.fontSize.sm,
+    fontFamily: typography.fontFamily,
+    color: colorScales.gray[700],
+    marginBottom: spacing[3],
+  },
+  deleteSlugText: {
+    fontWeight: typography.fontWeight.bold as any,
+    fontFamily: typography.fontFamily,
+    color: colorScales.gray[900],
+  },
+  deleteInput: {
+    borderWidth: 1,
+    borderColor: colorScales.gray[300],
+    borderRadius: borderRadius.lg,
+    padding: spacing[3],
+    fontSize: typography.fontSize.base,
+    fontFamily: typography.fontFamily,
+    backgroundColor: colors.background,
+    marginBottom: spacing[4],
+  },
+  deleteActions: {
+    flexDirection: 'row',
+    gap: spacing[3],
+  },
+  deleteCancelBtn: {
+    flex: 1,
+    paddingVertical: spacing[3],
+    borderRadius: borderRadius.lg,
+    borderWidth: 1,
+    borderColor: colorScales.gray[200],
+    alignItems: 'center',
+  },
+  deleteCancelText: {
+    fontSize: typography.fontSize.sm,
+    fontWeight: typography.fontWeight.semibold as any,
+    fontFamily: typography.fontFamily,
+    color: colorScales.gray[700],
+  },
+  deleteConfirmBtn: {
+    flex: 1,
+    paddingVertical: spacing[3],
+    borderRadius: borderRadius.lg,
+    backgroundColor: colors.error,
+    alignItems: 'center',
+  },
+  deleteConfirmBtnDisabled: {
+    opacity: 0.4,
+  },
+  deleteConfirmText: {
+    fontSize: typography.fontSize.sm,
+    fontWeight: typography.fontWeight.semibold as any,
+    fontFamily: typography.fontFamily,
+    color: '#FFFFFF',
   },
 });

--- a/apps/mobile/app/(org-admin)/stores/[id]/settings.tsx
+++ b/apps/mobile/app/(org-admin)/stores/[id]/settings.tsx
@@ -1,0 +1,205 @@
+import { useState } from 'react';
+import { View, Text, ScrollView, StyleSheet, KeyboardAvoidingView, Platform } from 'react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { OrgStoreService } from '@/features/org/services';
+import { Button } from '@/shared/components/button/button';
+import { Card } from '@/shared/components/card/card';
+import { Input } from '@/shared/components/input/input';
+import { Spinner } from '@/shared/components/spinner/spinner';
+import { toastError, toastSuccess } from '@/shared/components/toast/toast.store';
+import { borderRadius, colorScales, colors, spacing, typography } from '@/shared/theme';
+
+const TIMEZONE_OPTIONS = [
+  { value: 'America/Bogota', label: 'Bogotá (UTC-5)' },
+  { value: 'America/Medellin', label: 'Medellín (UTC-5)' },
+  { value: 'America/Cali', label: 'Cali (UTC-5)' },
+  { value: 'America/New_York', label: 'Nueva York (UTC-5)' },
+  { value: 'America/Mexico_City', label: 'Ciudad de México (UTC-6)' },
+  { value: 'Europe/Madrid', label: 'Madrid (UTC+1)' },
+];
+
+export default function StoreSettingsScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const router = useRouter();
+  const storeId = Number(id);
+
+  const { data: settings, isLoading } = useQuery({
+    queryKey: ['org-store-settings', storeId],
+    queryFn: () => OrgStoreService.getSettings(storeId),
+    enabled: !!storeId,
+  });
+
+  const [timezone, setTimezone] = useState('America/Bogota');
+  const [currency, setCurrency] = useState('COP');
+  const [lowStockThreshold, setLowStockThreshold] = useState('10');
+
+  useState(() => {
+    if (settings) {
+      setTimezone(settings.timezone || 'America/Bogota');
+      setCurrency(settings.currency || 'COP');
+      setLowStockThreshold(String(settings.low_stock_threshold ?? 10));
+    }
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: (data: any) => OrgStoreService.updateSettings(storeId, { settings: data }),
+    onSuccess: () => {
+      toastSuccess('Configuración guardada exitosamente');
+      router.back();
+    },
+    onError: (error: any) => {
+      const message = error?.response?.data?.message || error?.message || 'Error al guardar configuración';
+      toastError(message);
+    },
+  });
+
+  const handleSave = () => {
+    updateMutation.mutate({
+      timezone,
+      currency,
+      low_stock_threshold: Number(lowStockThreshold) || 10,
+    });
+  };
+
+  if (isLoading) {
+    return (
+      <View style={styles.center}>
+        <Spinner />
+      </View>
+    );
+  }
+
+  return (
+    <KeyboardAvoidingView
+      style={styles.flex}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      keyboardVerticalOffset={Platform.OS === 'ios' ? 100 : 0}
+    >
+      <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollContent} keyboardShouldPersistTaps="handled">
+        {/* General Settings */}
+        <Card>
+          <Card.Header title="General" />
+          <Card.Body>
+            <Text style={styles.label}>Zona Horaria</Text>
+            <View style={styles.chipRow}>
+              {TIMEZONE_OPTIONS.map((opt) => (
+                <View
+                  key={opt.value}
+                  style={[styles.chip, timezone === opt.value && styles.chipActive]}
+                >
+                  <Text
+                    style={[styles.chipText, timezone === opt.value && styles.chipTextActive]}
+                    onPress={() => setTimezone(opt.value)}
+                  >
+                    {opt.label}
+                  </Text>
+                </View>
+              ))}
+            </View>
+
+            <View style={{ height: spacing[4] }} />
+
+            <Input
+              label="Moneda"
+              value={currency}
+              onChangeText={setCurrency}
+              placeholder="COP"
+              helperText="Código de moneda (ej. COP, USD, EUR)"
+            />
+          </Card.Body>
+        </Card>
+
+        {/* Inventory Settings */}
+        <Card>
+          <Card.Header title="Inventario" />
+          <Card.Body>
+            <Input
+              label="Umbral de Stock Bajo"
+              value={lowStockThreshold}
+              onChangeText={setLowStockThreshold}
+              placeholder="10"
+              keyboardType="number-pad"
+              helperText="Notificar cuando el stock baje de esta cantidad"
+            />
+          </Card.Body>
+        </Card>
+
+        {/* Spacer */}
+        <View style={{ height: spacing[20] }} />
+      </ScrollView>
+
+      {/* Fixed bottom save button */}
+      <View style={styles.footer}>
+        <Button
+          title="Guardar Configuración"
+          onPress={handleSave}
+          loading={updateMutation.isPending}
+          disabled={updateMutation.isPending}
+          fullWidth
+        />
+      </View>
+    </KeyboardAvoidingView>
+  );
+}
+
+const styles = StyleSheet.create({
+  flex: {
+    flex: 1,
+  },
+  scrollView: {
+    flex: 1,
+  },
+  scrollContent: {
+    padding: spacing[4],
+    paddingBottom: spacing[4],
+  },
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colorScales.gray[50],
+  },
+  label: {
+    fontSize: typography.fontSize.xs,
+    fontWeight: typography.fontWeight.semibold,
+    fontFamily: typography.fontFamily,
+    color: colors.text.secondary,
+    marginBottom: spacing[1.5],
+    letterSpacing: 1.5,
+    textTransform: 'uppercase',
+  },
+  chipRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing[2],
+    marginBottom: spacing[4],
+  },
+  chip: {
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[2],
+    borderRadius: borderRadius.full,
+    borderWidth: 1,
+    borderColor: colorScales.gray[200],
+    backgroundColor: colors.background,
+  },
+  chipActive: {
+    backgroundColor: colors.primary,
+    borderColor: colors.primary,
+  },
+  chipText: {
+    fontSize: typography.fontSize.sm,
+    fontWeight: typography.fontWeight.medium,
+    color: colorScales.gray[700],
+  },
+  chipTextActive: {
+    color: colors.background,
+  },
+  footer: {
+    padding: spacing[4],
+    paddingBottom: spacing[6],
+    borderTopWidth: 1,
+    borderTopColor: colorScales.gray[200],
+    backgroundColor: colors.background,
+  },
+});

--- a/apps/mobile/app/(org-admin)/stores/create.tsx
+++ b/apps/mobile/app/(org-admin)/stores/create.tsx
@@ -1,0 +1,5 @@
+import { StoreUpsertForm } from '@/features/org/components/store-upsert-form';
+
+export default function CreateStoreScreen() {
+  return <StoreUpsertForm mode="create" />;
+}

--- a/apps/mobile/app/(org-admin)/stores/edit.tsx
+++ b/apps/mobile/app/(org-admin)/stores/edit.tsx
@@ -1,0 +1,31 @@
+import { useLocalSearchParams } from 'expo-router';
+import { View, Text, StyleSheet } from 'react-native';
+import { StoreUpsertForm } from '@/features/org/components/store-upsert-form';
+import { colorScales } from '@/shared/theme';
+
+export default function EditStoreScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+
+  if (!id) {
+    return (
+      <View style={styles.center}>
+        <Text style={styles.error}>ID de tienda no encontrado</Text>
+      </View>
+    );
+  }
+
+  return <StoreUpsertForm mode="edit" storeId={Number(id)} />;
+}
+
+const styles = StyleSheet.create({
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colorScales.gray[50],
+  },
+  error: {
+    color: colorScales.red[600],
+    fontSize: 16,
+  },
+});

--- a/apps/mobile/src/core/api/endpoints.ts
+++ b/apps/mobile/src/core/api/endpoints.ts
@@ -210,10 +210,15 @@ export const Endpoints = {
   ORGANIZATION: {
     STORES: {
       LIST: '/organization/stores',
+      CREATE: '/organization/stores',
       GET: '/organization/stores/:id',
+      UPDATE: '/organization/stores/:id',
+      DELETE: '/organization/stores/:id',
       STATS: '/organization/stores/stats',
       SETTINGS: '/organization/stores/:id/settings',
+      SETTINGS_RESET: '/organization/stores/:id/settings/reset',
       DASHBOARD: '/organization/stores/:id/stats',
+      CHECK_CODE: '/organization/stores/check-code',
     },
   },
 } as const;

--- a/apps/mobile/src/features/org/components/store-upsert-form.tsx
+++ b/apps/mobile/src/features/org/components/store-upsert-form.tsx
@@ -1,0 +1,504 @@
+import { useEffect, useMemo, useState } from 'react';
+import { View, Text, ScrollView, Pressable, StyleSheet, KeyboardAvoidingView, Platform } from 'react-native';
+import { useRouter } from 'expo-router';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { OrgStoreService } from '@/features/org/services';
+import type { CreateStoreDto, UpdateStoreDto, Store } from '@/features/org/types/store.types';
+import { StoreType } from '@/features/org/types/store.types';
+import { Button } from '@/shared/components/button/button';
+import { Card } from '@/shared/components/card/card';
+import { Input } from '@/shared/components/input/input';
+import { Spinner } from '@/shared/components/spinner/spinner';
+import { toastError, toastSuccess } from '@/shared/components/toast/toast.store';
+import { borderRadius, colorScales, colors, shadows, spacing, typography } from '@/shared/theme';
+
+type StoreMode = 'create' | 'edit';
+
+interface StoreFormState {
+  name: string;
+  store_code: string;
+  slug: string;
+  store_type: string;
+  timezone: string;
+  is_active: boolean;
+  address_line1: string;
+  address_line2: string;
+  city: string;
+  state_province: string;
+  postal_code: string;
+  country_code: string;
+  phone_number: string;
+  logo_url: string;
+}
+
+const initialForm: StoreFormState = {
+  name: '',
+  store_code: '',
+  slug: '',
+  store_type: StoreType.PHYSICAL,
+  timezone: 'America/Bogota',
+  is_active: true,
+  address_line1: '',
+  address_line2: '',
+  city: '',
+  state_province: '',
+  postal_code: '',
+  country_code: 'CO',
+  phone_number: '',
+  logo_url: '',
+};
+
+const STORE_TYPE_OPTIONS = [
+  { value: 'physical', label: 'Física' },
+  { value: 'online', label: 'Online' },
+  { value: 'hybrid', label: 'Híbrida' },
+  { value: 'popup', label: 'Temporal' },
+  { value: 'kiosko', label: 'Kiosko' },
+];
+
+const TIMEZONE_OPTIONS = [
+  { value: 'America/Bogota', label: 'Bogotá (UTC-5)' },
+  { value: 'America/Medellin', label: 'Medellín (UTC-5)' },
+  { value: 'America/Cali', label: 'Cali (UTC-5)' },
+  { value: 'America/New_York', label: 'Nueva York (UTC-5)' },
+  { value: 'America/Mexico_City', label: 'Ciudad de México (UTC-6)' },
+  { value: 'Europe/Madrid', label: 'Madrid (UTC+1)' },
+];
+
+function generateSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+interface StoreUpsertFormProps {
+  mode: StoreMode;
+  storeId?: number;
+}
+
+export function StoreUpsertForm({ mode, storeId }: StoreUpsertFormProps) {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const [form, setForm] = useState<StoreFormState>(initialForm);
+  const [errors, setErrors] = useState<Partial<Record<keyof StoreFormState, string>>>({});
+  const [slugEdited, setSlugEdited] = useState(false);
+
+  const isEdit = mode === 'edit';
+
+  const { data: existingStore, isLoading: loadingStore } = useQuery({
+    queryKey: ['org-store', storeId],
+    queryFn: () => OrgStoreService.getById(storeId!),
+    enabled: isEdit && !!storeId,
+  });
+
+  useEffect(() => {
+    if (existingStore) {
+      const address = existingStore.primary_address || '';
+      setForm({
+        name: existingStore.name || '',
+        store_code: existingStore.store_code || '',
+        slug: existingStore.slug || '',
+        store_type: existingStore.store_type || StoreType.PHYSICAL,
+        timezone: 'America/Bogota',
+        is_active: existingStore.is_active !== false,
+        address_line1: address,
+        address_line2: '',
+        city: '',
+        state_province: '',
+        postal_code: '',
+        country_code: 'CO',
+        phone_number: '',
+        logo_url: existingStore.logo_url || '',
+      });
+    }
+  }, [existingStore]);
+
+  useEffect(() => {
+    if (!slugEdited && form.name && !isEdit) {
+      setForm((prev) => ({ ...prev, slug: generateSlug(form.name) }));
+    }
+  }, [form.name, slugEdited, isEdit]);
+
+  const updateField = <K extends keyof StoreFormState>(key: K, value: StoreFormState[K]) => {
+    setForm((prev) => ({ ...prev, [key]: value }));
+    if (errors[key]) {
+      setErrors((prev) => ({ ...prev, [key]: undefined }));
+    }
+  };
+
+  const validate = (): boolean => {
+    const newErrors: Partial<Record<keyof StoreFormState, string>> = {};
+
+    if (!form.name.trim()) {
+      newErrors.name = 'El nombre es requerido';
+    } else if (form.name.trim().length < 2) {
+      newErrors.name = 'Mínimo 2 caracteres';
+    }
+
+    if (form.store_code && form.store_code.length > 20) {
+      newErrors.store_code = 'Máximo 20 caracteres';
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const createMutation = useMutation({
+    mutationFn: (data: CreateStoreDto) => OrgStoreService.create(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['org-stores'] });
+      queryClient.invalidateQueries({ queryKey: ['org-stores-stats'] });
+      toastSuccess('Tienda creada exitosamente');
+      router.back();
+    },
+    onError: (error: any) => {
+      const message = error?.response?.data?.message || error?.message || 'Error al crear tienda';
+      toastError(message);
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: (data: UpdateStoreDto) => OrgStoreService.update(storeId!, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['org-stores'] });
+      queryClient.invalidateQueries({ queryKey: ['org-stores-stats'] });
+      toastSuccess('Tienda actualizada exitosamente');
+      router.back();
+    },
+    onError: (error: any) => {
+      const message = error?.response?.data?.message || error?.message || 'Error al actualizar tienda';
+      toastError(message);
+    },
+  });
+
+  const isSubmitting = createMutation.isPending || updateMutation.isPending;
+
+  const handleSubmit = () => {
+    if (!validate()) return;
+
+    const commonData = {
+      name: form.name.trim(),
+      slug: form.slug || undefined,
+      store_code: form.store_code || undefined,
+      store_type: form.store_type as StoreType,
+      timezone: form.timezone || undefined,
+      is_active: form.is_active,
+      logo_url: form.logo_url || undefined,
+    };
+
+    if (isEdit) {
+      updateMutation.mutate(commonData);
+    } else {
+      const createData: CreateStoreDto = {
+        ...commonData,
+        address: form.address_line1
+          ? {
+              address_line1: form.address_line1,
+              address_line2: form.address_line2 || undefined,
+              city: form.city,
+              state_province: form.state_province || undefined,
+              postal_code: form.postal_code || undefined,
+              country_code: form.country_code || 'CO',
+              phone_number: form.phone_number || undefined,
+            }
+          : undefined,
+      };
+      createMutation.mutate(createData);
+    }
+  };
+
+  if (isEdit && loadingStore) {
+    return (
+      <View style={styles.centerContent}>
+        <Spinner />
+      </View>
+    );
+  }
+
+  return (
+    <KeyboardAvoidingView
+      style={styles.flex}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      keyboardVerticalOffset={Platform.OS === 'ios' ? 100 : 0}
+    >
+      <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollContent} keyboardShouldPersistTaps="handled">
+        {/* Basic Information */}
+        <Card>
+          <Card.Header title="Información Básica" />
+          <Card.Body>
+            <View style={styles.formRow}>
+              <Input
+                label="Nombre de la Tienda"
+                value={form.name}
+                onChangeText={(v) => updateField('name', v)}
+                placeholder="Tienda Central"
+                error={errors.name}
+              />
+            </View>
+
+            <View style={styles.formRow}>
+              <Input
+                label="Código"
+                value={form.store_code}
+                onChangeText={(v) => updateField('store_code', v)}
+                placeholder="TC001"
+                error={errors.store_code}
+                helperText="Código único para la tienda"
+              />
+            </View>
+
+            <View style={styles.formRow}>
+              <Input
+                label="Slug (URL)"
+                value={form.slug}
+                onChangeText={(v) => {
+                  updateField('slug', v);
+                  setSlugEdited(true);
+                }}
+                placeholder="tienda-central"
+                helperText="Generado automáticamente desde el nombre"
+              />
+            </View>
+
+            <View style={styles.formRow}>
+              <Text style={styles.label}>Tipo de Tienda</Text>
+              <View style={styles.chipRow}>
+                {STORE_TYPE_OPTIONS.map((opt) => (
+                  <Pressable
+                    key={opt.value}
+                    onPress={() => updateField('store_type', opt.value)}
+                    style={[styles.chip, form.store_type === opt.value && styles.chipActive]}
+                  >
+                    <Text style={[styles.chipText, form.store_type === opt.value && styles.chipTextActive]}>
+                      {opt.label}
+                    </Text>
+                  </Pressable>
+                ))}
+              </View>
+            </View>
+
+            <View style={styles.formRow}>
+              <Text style={styles.label}>Zona Horaria</Text>
+              <View style={styles.chipRow}>
+                {TIMEZONE_OPTIONS.map((opt) => (
+                  <Pressable
+                    key={opt.value}
+                    onPress={() => updateField('timezone', opt.value)}
+                    style={[styles.chip, form.timezone === opt.value && styles.chipActive]}
+                  >
+                    <Text style={[styles.chipText, form.timezone === opt.value && styles.chipTextActive]}>
+                      {opt.label}
+                    </Text>
+                  </Pressable>
+                ))}
+              </View>
+            </View>
+
+            <View style={styles.toggleRow}>
+              <Pressable
+                onPress={() => updateField('is_active', !form.is_active)}
+                style={[styles.toggle, form.is_active && styles.toggleActive]}
+              >
+                <View style={[styles.toggleDot, form.is_active && styles.toggleDotActive]} />
+              </Pressable>
+              <Text style={styles.toggleLabel}>Tienda activa</Text>
+            </View>
+          </Card.Body>
+        </Card>
+
+        {/* Address */}
+        <Card>
+          <Card.Header title="Dirección" />
+          <Card.Body>
+            <View style={styles.formRow}>
+              <Input
+                label="Dirección"
+                value={form.address_line1}
+                onChangeText={(v) => updateField('address_line1', v)}
+                placeholder="Carrera 7 # 72-01"
+              />
+            </View>
+
+            <View style={styles.formRow}>
+              <Input
+                label="Complemento (opcional)"
+                value={form.address_line2}
+                onChangeText={(v) => updateField('address_line2', v)}
+                placeholder="Oficina 301, Torre A"
+              />
+            </View>
+
+            <View style={styles.formRow}>
+              <Input
+                label="Ciudad"
+                value={form.city}
+                onChangeText={(v) => updateField('city', v)}
+                placeholder="Bogotá"
+              />
+            </View>
+
+            <View style={styles.formRow}>
+              <Input
+                label="Departamento / Estado"
+                value={form.state_province}
+                onChangeText={(v) => updateField('state_province', v)}
+                placeholder="Cundinamarca"
+              />
+            </View>
+
+            <View style={styles.formRow}>
+              <Input
+                label="Código Postal"
+                value={form.postal_code}
+                onChangeText={(v) => updateField('postal_code', v)}
+                placeholder="110231"
+              />
+            </View>
+
+            <View style={styles.formRow}>
+              <Input
+                label="País"
+                value={form.country_code}
+                onChangeText={(v) => updateField('country_code', v)}
+                placeholder="CO"
+              />
+            </View>
+
+            <View style={styles.formRow}>
+              <Input
+                label="Teléfono"
+                value={form.phone_number}
+                onChangeText={(v) => updateField('phone_number', v)}
+                placeholder="+57 300 123 4567"
+              />
+            </View>
+          </Card.Body>
+        </Card>
+
+        {/* Branding */}
+        <Card>
+          <Card.Header title="Branding" />
+          <Card.Body>
+            <View style={styles.formRow}>
+              <Input
+                label="URL del Logo"
+                value={form.logo_url}
+                onChangeText={(v) => updateField('logo_url', v)}
+                placeholder="https://ejemplo.com/logo.png"
+              />
+            </View>
+          </Card.Body>
+        </Card>
+
+        {/* Spacer for button */}
+        <View style={{ height: spacing[20] }} />
+      </ScrollView>
+
+      {/* Fixed bottom submit button */}
+      <View style={styles.footer}>
+        <Button
+          title={isEdit ? 'Actualizar Tienda' : 'Crear Tienda'}
+          onPress={handleSubmit}
+          loading={isSubmitting}
+          disabled={isSubmitting}
+          fullWidth
+        />
+      </View>
+    </KeyboardAvoidingView>
+  );
+}
+
+const styles = StyleSheet.create({
+  flex: {
+    flex: 1,
+  },
+  scrollView: {
+    flex: 1,
+  },
+  scrollContent: {
+    padding: spacing[4],
+    paddingBottom: spacing[4],
+  },
+  centerContent: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colorScales.gray[50],
+  },
+  formRow: {
+    marginBottom: spacing[4],
+  },
+  label: {
+    fontSize: typography.fontSize.xs,
+    fontWeight: typography.fontWeight.semibold,
+    fontFamily: typography.fontFamily,
+    color: colors.text.secondary,
+    marginBottom: spacing[1.5],
+    letterSpacing: 1.5,
+    textTransform: 'uppercase',
+  },
+  chipRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing[2],
+  },
+  chip: {
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[2],
+    borderRadius: borderRadius.full,
+    borderWidth: 1,
+    borderColor: colorScales.gray[200],
+    backgroundColor: colors.background,
+  },
+  chipActive: {
+    backgroundColor: colors.primary,
+    borderColor: colors.primary,
+  },
+  chipText: {
+    fontSize: typography.fontSize.sm,
+    fontWeight: typography.fontWeight.medium,
+    color: colorScales.gray[700],
+  },
+  chipTextActive: {
+    color: colors.background,
+  },
+  toggleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+  },
+  toggle: {
+    width: 48,
+    height: 28,
+    borderRadius: 14,
+    backgroundColor: colorScales.gray[300],
+    justifyContent: 'center',
+    paddingHorizontal: 2,
+  },
+  toggleActive: {
+    backgroundColor: colors.primary,
+  },
+  toggleDot: {
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    backgroundColor: '#fff',
+  },
+  toggleDotActive: {
+    alignSelf: 'flex-end',
+  },
+  toggleLabel: {
+    fontSize: typography.fontSize.sm,
+    color: colorScales.gray[800],
+  },
+  footer: {
+    padding: spacing[4],
+    paddingBottom: spacing[6],
+    borderTopWidth: 1,
+    borderTopColor: colorScales.gray[200],
+    backgroundColor: colors.background,
+  },
+});

--- a/apps/mobile/src/features/org/services/org-store.service.ts
+++ b/apps/mobile/src/features/org/services/org-store.service.ts
@@ -1,6 +1,17 @@
 import { apiClient, Endpoints } from '@/core/api';
 import { unwrapPaginated } from '@/core/api/pagination';
 import type { ApiResponse, PaginatedResponse } from '@/features/store/types';
+import type {
+  Store,
+  StoreListItem,
+  CreateStoreDto,
+  UpdateStoreDto,
+  StoreStats,
+  StoreDashboardResponse,
+  StoreSettings,
+  StoreSettingsUpdateDto,
+  StoreQueryDto,
+} from '../types/store.types';
 
 function unwrap<T>(response: { data: T | ApiResponse<T> }): T {
   const d = response.data as ApiResponse<T>;
@@ -46,7 +57,7 @@ export interface OrgStoreStats {
 }
 
 export const OrgStoreService = {
-  async list(query?: { page?: number; limit?: number; search?: string; store_type?: string; is_active?: boolean }): Promise<PaginatedResponse<OrgStore>> {
+  async list(query?: StoreQueryDto): Promise<PaginatedResponse<OrgStore>> {
     const params: Record<string, unknown> = {
       page: query?.page ?? 1,
       limit: query?.limit ?? 50,
@@ -67,5 +78,80 @@ export const OrgStoreService = {
   async stats(): Promise<OrgStoreStats> {
     const res = await apiClient.get(Endpoints.ORGANIZATION.STORES.STATS);
     return unwrap<OrgStoreStats>(res);
+  },
+
+  async create(data: CreateStoreDto): Promise<Store> {
+    const res = await apiClient.post(Endpoints.ORGANIZATION.STORES.CREATE, data);
+    return unwrap<Store>(res);
+  },
+
+  async update(id: number, data: UpdateStoreDto): Promise<Store> {
+    const endpoint = Endpoints.ORGANIZATION.STORES.UPDATE.replace(':id', String(id));
+    const res = await apiClient.patch(endpoint, data);
+    return unwrap<Store>(res);
+  },
+
+  async deleteStore(id: number): Promise<void> {
+    const endpoint = Endpoints.ORGANIZATION.STORES.DELETE.replace(':id', String(id));
+    await apiClient.delete(endpoint);
+  },
+
+  async activate(id: number): Promise<Store> {
+    return OrgStoreService.update(id, { is_active: true });
+  },
+
+  async deactivate(id: number): Promise<Store> {
+    return OrgStoreService.update(id, { is_active: false });
+  },
+
+  async getSettings(id: number): Promise<StoreSettings> {
+    const endpoint = Endpoints.ORGANIZATION.STORES.SETTINGS.replace(':id', String(id));
+    const res = await apiClient.get(endpoint);
+    return unwrap<StoreSettings>(res);
+  },
+
+  async updateSettings(id: number, data: StoreSettingsUpdateDto): Promise<any> {
+    const endpoint = Endpoints.ORGANIZATION.STORES.SETTINGS.replace(':id', String(id));
+    const res = await apiClient.patch(endpoint, data);
+    return unwrap<any>(res);
+  },
+
+  async resetSettings(id: number): Promise<StoreSettings> {
+    const endpoint = Endpoints.ORGANIZATION.STORES.SETTINGS_RESET.replace(':id', String(id));
+    const res = await apiClient.post(endpoint);
+    return unwrap<StoreSettings>(res);
+  },
+
+  async getDashboard(id: number): Promise<StoreDashboardResponse> {
+    const endpoint = Endpoints.ORGANIZATION.STORES.DASHBOARD.replace(':id', String(id));
+    const res = await apiClient.get(endpoint);
+    return unwrap<StoreDashboardResponse>(res);
+  },
+
+  async checkCode(code: string): Promise<boolean> {
+    const res = await apiClient.get(`${Endpoints.ORGANIZATION.STORES.CHECK_CODE}?code=${encodeURIComponent(code)}`);
+    const data = unwrap<{ available: boolean }>(res);
+    return data.available !== false;
+  },
+
+  getStoreTypeOptions(): Array<{ value: string; label: string }> {
+    return [
+      { value: 'physical', label: 'Tienda Física' },
+      { value: 'online', label: 'Tienda Online' },
+      { value: 'hybrid', label: 'Tienda Híbrida' },
+      { value: 'popup', label: 'Tienda Temporal' },
+      { value: 'kiosko', label: 'Kiosko' },
+    ];
+  },
+
+  getTimezoneOptions(): Array<{ value: string; label: string }> {
+    return [
+      { value: 'America/Bogota', label: 'Bogotá (UTC-5)' },
+      { value: 'America/Medellin', label: 'Medellín (UTC-5)' },
+      { value: 'America/Cali', label: 'Cali (UTC-5)' },
+      { value: 'America/New_York', label: 'Nueva York (UTC-5)' },
+      { value: 'America/Mexico_City', label: 'Ciudad de México (UTC-6)' },
+      { value: 'Europe/Madrid', label: 'Madrid (UTC+1)' },
+    ];
   },
 };

--- a/apps/mobile/src/features/org/types/index.ts
+++ b/apps/mobile/src/features/org/types/index.ts
@@ -1,0 +1,15 @@
+export type {
+  Store,
+  StoreListItem,
+  CreateStoreDto,
+  UpdateStoreDto,
+  StoreStats,
+  StoreDashboardResponse,
+  StoreSettings,
+  StoreSettingsUpdateDto,
+  StoreQueryDto,
+  StoreAddress,
+  OperatingHours,
+} from './store.types';
+
+export { StoreType, StoreState } from './store.types';

--- a/apps/mobile/src/features/org/types/store.types.ts
+++ b/apps/mobile/src/features/org/types/store.types.ts
@@ -1,0 +1,236 @@
+export enum StoreType {
+  PHYSICAL = 'physical',
+  ONLINE = 'online',
+  HYBRID = 'hybrid',
+  POPUP = 'popup',
+  KIOSKO = 'kiosko',
+}
+
+export enum StoreState {
+  ACTIVE = 'active',
+  INACTIVE = 'inactive',
+  DRAFT = 'draft',
+  SUSPENDED = 'suspended',
+  ARCHIVED = 'archived',
+}
+
+export interface OperatingHours {
+  monday?: { open: string; close: string };
+  tuesday?: { open: string; close: string };
+  wednesday?: { open: string; close: string };
+  thursday?: { open: string; close: string };
+  friday?: { open: string; close: string };
+  saturday?: { open: string; close: string };
+  sunday?: { open: string; close: string };
+}
+
+export interface StoreSettings {
+  theme?: string;
+  notifications?: boolean;
+  language?: string;
+  currency_format?: string;
+  email_notifications?: boolean;
+  sms_notifications?: boolean;
+  inventory_alerts?: boolean;
+  low_stock_threshold?: number;
+  allow_guest_checkout?: boolean;
+  require_email_verification?: boolean;
+  enable_inventory_tracking?: boolean;
+  enable_tax_calculation?: boolean;
+  tax_rate?: number;
+  enable_shipping?: boolean;
+  free_shipping_threshold?: number;
+  currency?: string;
+  timezone?: string;
+  color_primary?: string;
+  color_secondary?: string;
+  logo_url?: string;
+}
+
+export interface StoreAddress {
+  id?: number;
+  address_line1: string;
+  address_line2?: string | null;
+  city: string;
+  state_province?: string | null;
+  postal_code?: string | null;
+  country_code: string;
+  phone_number?: string | null;
+  is_primary?: boolean;
+}
+
+export interface Store {
+  id: number;
+  name: string;
+  slug: string;
+  store_code: string | null;
+  created_at: string;
+  updated_at: string;
+  is_active: boolean;
+  manager_user_id: number | null;
+  organization_id: number;
+  store_type: StoreType;
+  timezone: string;
+  onboarding: boolean;
+  logo_url?: string | null;
+  primary_address?: string | null;
+  description?: string;
+  email?: string;
+  phone?: string;
+  website?: string;
+  domain?: string;
+  currency_code?: string;
+  color_primary?: string;
+  color_secondary?: string;
+  operating_hours?: OperatingHours;
+  status?: StoreState | 'active' | 'inactive' | 'maintenance';
+  settings?: StoreSettings;
+  addresses?: StoreAddress[];
+  organizations?: {
+    id: number;
+    name: string;
+    slug: string;
+  };
+  _count?: {
+    products: number;
+    orders: number;
+    store_users: number;
+  };
+  products_count?: number;
+  orders_count?: number;
+  users_count?: number;
+}
+
+export interface StoreListItem {
+  id: number;
+  name: string;
+  slug: string;
+  store_code: string | null;
+  created_at: string;
+  updated_at: string;
+  is_active: boolean;
+  manager_user_id: number | null;
+  organization_id: number;
+  store_type: StoreType;
+  timezone: string;
+  onboarding: boolean;
+  logo_url?: string | null;
+  primary_address?: string | null;
+  products_count: number;
+  orders_count: number;
+  users_count: number;
+  organizations?: {
+    id: number;
+    name: string;
+    slug: string;
+  };
+  addresses?: StoreAddress[];
+  _count?: {
+    products: number;
+    orders: number;
+    store_users: number;
+  };
+}
+
+export interface CreateStoreDto {
+  organization_id?: number;
+  name: string;
+  slug?: string;
+  store_code?: string;
+  logo_url?: string;
+  domain?: string;
+  timezone?: string;
+  currency_code?: string;
+  operating_hours?: OperatingHours;
+  store_type: StoreType;
+  is_active?: boolean;
+  manager_user_id?: number;
+  description?: string;
+  email?: string;
+  phone?: string;
+  website?: string;
+  address?: {
+    address_line1: string;
+    address_line2?: string;
+    city: string;
+    state_province?: string;
+    postal_code?: string;
+    country_code: string;
+    phone_number?: string;
+  };
+  settings?: {
+    currency_code?: string;
+    color_primary?: string;
+    color_secondary?: string;
+  };
+}
+
+export interface UpdateStoreDto {
+  name?: string;
+  slug?: string;
+  store_code?: string;
+  store_type?: StoreType;
+  is_active?: boolean;
+  status?: StoreState | 'active' | 'inactive' | 'maintenance';
+  manager_user_id?: number | null;
+  description?: string;
+  email?: string;
+  phone?: string;
+  website?: string;
+  domain?: string;
+  logo_url?: string;
+  banner_url?: string;
+  color_primary?: string;
+  color_secondary?: string;
+  timezone?: string;
+  currency_code?: string;
+  operating_hours?: OperatingHours;
+  address?: {
+    address_line1: string;
+    address_line2?: string;
+    city: string;
+    state_province?: string;
+    postal_code?: string;
+    country_code: string;
+    phone_number?: string;
+  };
+  settings?: Partial<StoreSettings>;
+}
+
+export interface StoreStats {
+  total_stores: number;
+  active_stores: number;
+  inactive_stores?: number;
+  total_orders: number;
+  total_revenue: number;
+  total_products?: number;
+}
+
+export interface StoreDashboardResponse {
+  store_id: number;
+  metrics: {
+    total_orders: number;
+    total_revenue: number;
+    low_stock_products: number;
+    active_customers: number;
+    revenue_today: number;
+    revenue_this_week: number;
+    average_order_value: number;
+  };
+  recent_orders?: any[];
+  top_products?: any[];
+  sales_chart?: any[];
+}
+
+export interface StoreQueryDto {
+  page?: number;
+  limit?: number;
+  search?: string;
+  store_type?: StoreType;
+  is_active?: boolean;
+  status?: StoreState | 'active' | 'inactive';
+}
+
+export interface StoreSettingsUpdateDto {
+  settings: Partial<StoreSettings>;
+}

--- a/bruno/Vendix/Store/Customers/Create Customer CC.bru
+++ b/bruno/Vendix/Store/Customers/Create Customer CC.bru
@@ -1,0 +1,48 @@
+meta {
+  name: Create Customer CC
+  type: http
+  seq: 2
+}
+
+post {
+  url: http://{{url}}/store/customers
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "email": "rafael.test.cc@vendix.example",
+    "first_name": "Rafael",
+    "last_name": "Martínez",
+    "phone": "+57 300 000 0001",
+    "document_type": "CC",
+    "document_number": "1023456001"
+  }
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}
+
+tests {
+  test("Customer with CC created successfully", function() {
+    expect(res.status).to.be.oneOf([200, 201]);
+    expect(res.body).to.have.property('success', true);
+    expect(res.body.data).to.have.property('id');
+    expect(res.body.data).to.have.property('document_type', 'CC');
+    expect(res.body.data).to.have.property('document_number', '1023456001');
+  });
+
+  test("Persisted document_number is normalized (uppercase, no spaces/hyphens)", function() {
+    const doc = res.body.data.document_number;
+    expect(doc).to.match(/^[A-Z0-9]+$/);
+  });
+}
+
+post_response {
+  if (res.status === 200 || res.status === 201) {
+    bru.setVar("createdCustomerIdCC", res.body.data.id);
+  }
+}

--- a/bruno/Vendix/Store/Customers/Create Customer Duplicate.bru
+++ b/bruno/Vendix/Store/Customers/Create Customer Duplicate.bru
@@ -1,0 +1,45 @@
+meta {
+  name: Create Customer Duplicate
+  type: http
+  seq: 5
+}
+
+post {
+  url: http://{{url}}/store/customers
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "email": "duplicate.test@vendix.example",
+    "first_name": "Duplicate",
+    "last_name": "Document",
+    "document_type": "CC",
+    "document_number": "1023456001"
+  }
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}
+
+tests {
+  test("Duplicate document returns 409 Conflict", function() {
+    expect(res.status).to.equal(409);
+  });
+
+  test("Error response uses Spanish copy", function() {
+    const message = JSON.stringify(res.body).toLowerCase();
+    expect(message).to.match(/ya existe|este documento|conflict/);
+  });
+
+  test("Error code is SYS_CONFLICT_001", function() {
+    const code = res.body?.error_code
+      ?? res.body?.error?.error_code
+      ?? res.body?.error?.code
+      ?? res.body?.code;
+    expect(code).to.equal('SYS_CONFLICT_001');
+  });
+}

--- a/bruno/Vendix/Store/Customers/Create Customer Invalid Type.bru
+++ b/bruno/Vendix/Store/Customers/Create Customer Invalid Type.bru
@@ -1,0 +1,41 @@
+meta {
+  name: Create Customer Invalid Type
+  type: http
+  seq: 4
+}
+
+post {
+  url: http://{{url}}/store/customers
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "email": "invalid.type@vendix.example",
+    "first_name": "Test",
+    "last_name": "Invalid",
+    "document_type": "DNI",
+    "document_number": "12345678"
+  }
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}
+
+tests {
+  test("Invalid document_type is rejected with 400", function() {
+    expect(res.status).to.equal(400);
+  });
+
+  test("Error response mentions document_type", function() {
+    const message = JSON.stringify(res.body);
+    expect(message.toLowerCase()).to.match(/document_type|tipo de documento/);
+  });
+
+  test("No customer is persisted on rejection", function() {
+    expect(res.body).to.not.have.property('data');
+  });
+}

--- a/bruno/Vendix/Store/Customers/Create Customer NIT.bru
+++ b/bruno/Vendix/Store/Customers/Create Customer NIT.bru
@@ -1,0 +1,45 @@
+meta {
+  name: Create Customer NIT
+  type: http
+  seq: 3
+}
+
+post {
+  url: http://{{url}}/store/customers
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "email": "empresa.test.nit@vendix.example",
+    "first_name": "Comercializadora",
+    "last_name": "Andina SAS",
+    "phone": "+57 601 555 0001",
+    "document_type": "NIT",
+    "document_number": "900123456-7"
+  }
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}
+
+tests {
+  test("Customer with NIT created successfully", function() {
+    expect(res.status).to.be.oneOf([200, 201]);
+    expect(res.body).to.have.property('success', true);
+    expect(res.body.data).to.have.property('document_type', 'NIT');
+  });
+
+  test("NIT verification digit hyphen is stripped on persist", function() {
+    expect(res.body.data.document_number).to.equal('9001234567');
+  });
+}
+
+post_response {
+  if (res.status === 200 || res.status === 201) {
+    bru.setVar("createdCustomerIdNIT", res.body.data.id);
+  }
+}

--- a/planning/promotions-sales-flow-fix-plan.md
+++ b/planning/promotions-sales-flow-fix-plan.md
@@ -1,0 +1,150 @@
+## Context
+El sistema de promociones ya tiene entidades, configuracion basica, motor de elegibilidad y soporte parcial en POS, pero los flujos de catalogo, carrito, checkout, orden y pago no comparten una fuente de verdad para calcular descuentos. Hoy e-commerce no aplica promociones/cupones al crear orden, POS envia descuentos calculados por frontend y el backend no reconstruye el total de forma autoritativa, y las cards de POS/e-commerce solo muestran ofertas por `sale_price`, no promociones por producto o categoria. El cambio debe completar promociones por producto, categoria y compra general, mantener los cupones donde aplican, y no afectar ventas sin promociones ni configuraciones existentes de POS/e-commerce.
+
+## General Objective
+Garantizar que promociones y cupones se configuren, visualicen, calculen, persistan y paguen correctamente de punta a punta en POS y e-commerce sin romper los flujos de venta existentes.
+
+## Specific Objectives
+1. Validar que la configuracion de promociones por producto, categoria y compra general sea consistente en backend y frontend.
+2. Exponer descuentos activos de promociones por producto/categoria en las cards de POS y e-commerce, incluyendo productos que califican por categoria.
+3. Recalcular promociones y cupones en backend como fuente de verdad al vender por POS, checkout normal y checkout WhatsApp.
+4. Persistir en la orden el total correcto, `discount_amount`, detalles de promociones y uso de cupones con importes separados.
+5. Crear pagos por el `grand_total` final de la orden despues de descuentos, incluyendo Wompi y metodos manuales.
+6. Mostrar en detalle de orden, confirmaciones y resumen de checkout los descuentos aplicados sin recalcular ordenes historicas.
+7. Cubrir regresiones de venta sin promociones, venta con solo cupon, venta con promocion por producto, categoria y compra general.
+
+## Approach Chosen
+Centralizar el calculo promocional en backend reutilizando `PromotionEngineService`, `CouponsService` y `PriceResolverService`, y exponer una respuesta de cotizacion/descuento que consuman catalogo, POS, checkout y ordenes. Este enfoque mantiene el backend como fuente de verdad economica, permite que frontend solo muestre estimaciones o snapshots devueltos por API, y evita duplicar reglas de elegibilidad en cada pantalla.
+
+## Alternatives Considered
+- Mantener el calculo principal en frontend y solo guardar IDs en backend: se rechaza porque permite diferencias entre UI, orden y pago, y ya es la raiz del bug actual en POS.
+- Aplicar promociones directamente sobre `final_price` de productos en base de datos: se rechaza porque mezclaria snapshots temporales con precio base/sale price, romperia ordenes historicas y afectaria flujos sin promociones.
+- Crear un segundo motor de promociones exclusivo para e-commerce: se rechaza porque duplicaria reglas existentes y haria que POS y e-commerce diverjan.
+
+## Critical Files
+- `apps/backend/src/domains/store/promotions/promotion-engine/promotion-engine.service.ts` - motor base para elegibilidad, calculo y persistencia de promociones.
+- `apps/backend/src/domains/store/promotions/promotions.service.ts` - configuracion, validacion y consulta de promociones activas.
+- `apps/backend/src/domains/store/promotions/promotions.module.ts` - exporta el motor para otros dominios.
+- `apps/backend/src/domains/store/promotions/dto/create-promotion.dto.ts` - contrato de creacion/edicion de promociones.
+- `apps/backend/src/domains/store/coupons/coupons.service.ts` - validacion y registro de cupones.
+- `apps/backend/src/domains/store/coupons/coupons.module.ts` - exporta cupones para checkout/pagos.
+- `apps/backend/src/domains/store/products/products.service.ts` - listado POS y datos de productos con promociones activas.
+- `apps/backend/src/domains/store/products/products.module.ts` - composicion de dependencias de productos.
+- `apps/backend/src/domains/store/products/services/price-resolver.service.ts` - calculo base/sale/tax actual de productos y variantes.
+- `apps/backend/src/domains/ecommerce/catalog/catalog.service.ts` - catalogo publico y `has_discount`.
+- `apps/backend/src/domains/ecommerce/catalog/catalog.module.ts` - dependencias de catalogo.
+- `apps/backend/src/domains/ecommerce/catalog/dto/catalog-query.dto.ts` - filtros de catalogo con descuentos.
+- `apps/backend/src/domains/ecommerce/cart/cart.service.ts` - precios y resumen de carrito autenticado.
+- `apps/backend/src/domains/ecommerce/cart/cart.module.ts` - dependencias de carrito.
+- `apps/backend/src/domains/ecommerce/checkout/checkout.service.ts` - creacion de orden, pago y Wompi desde e-commerce.
+- `apps/backend/src/domains/ecommerce/checkout/checkout.module.ts` - dependencias de checkout.
+- `apps/backend/src/domains/ecommerce/checkout/dto/checkout.dto.ts` - payload normal de checkout.
+- `apps/backend/src/domains/ecommerce/checkout/dto/whatsapp-checkout.dto.ts` - payload checkout WhatsApp.
+- `apps/backend/src/domains/ecommerce/account/account.service.ts` - detalle de orden e-commerce.
+- `apps/backend/src/domains/store/payments/payments.service.ts` - venta POS, persistencia de orden y pago.
+- `apps/backend/src/domains/store/payments/dto/create-pos-payment.dto.ts` - payload de pagos POS con promociones/cupones.
+- `apps/backend/src/domains/store/orders/orders.service.ts` - lectura y detalle de ordenes store.
+- `apps/backend/src/domains/store/orders/dto/create-order.dto.ts` - contrato de ordenes store.
+- `apps/frontend/src/app/private/modules/store/marketing/promotions/components/promotion-form-modal/promotion-form-modal.component.ts` - formulario de promociones.
+- `apps/frontend/src/app/private/modules/store/marketing/promotions/interfaces/promotion.interface.ts` - tipos frontend de promociones.
+- `apps/frontend/src/app/private/modules/store/marketing/promotions/services/promotions.service.ts` - llamadas frontend de promociones.
+- `apps/frontend/src/app/private/modules/store/pos/services/pos-product.service.ts` - tipos y mapeo de productos POS.
+- `apps/frontend/src/app/private/modules/store/pos/components/pos-product-selection.component.ts` - cards de productos POS.
+- `apps/frontend/src/app/private/modules/store/pos/services/pos-cart.service.ts` - descuentos, promociones y cupones en carrito POS.
+- `apps/frontend/src/app/private/modules/store/pos/cart/pos-cart.component.ts` - resumen POS y cupones.
+- `apps/frontend/src/app/private/modules/store/pos/services/pos-payment.service.ts` - payloads de venta POS.
+- `apps/frontend/src/app/private/modules/store/pos/components/pos-order-confirmation.component.ts` - confirmacion de venta POS.
+- `apps/frontend/src/app/private/modules/store/orders/pages/order-details/order-details-page.component.ts` - detalle de orden store.
+- `apps/frontend/src/app/private/modules/store/orders/pages/order-details/order-details-page.component.html` - visualizacion de descuentos store.
+- `apps/frontend/src/app/private/modules/ecommerce/services/catalog.service.ts` - tipos y filtros de catalogo e-commerce.
+- `apps/frontend/src/app/private/modules/ecommerce/components/product-card/product-card.component.ts` - card de producto e-commerce.
+- `apps/frontend/src/app/private/modules/ecommerce/services/cart.service.ts` - carrito e-commerce autenticado/invitado.
+- `apps/frontend/src/app/private/modules/ecommerce/pages/cart/cart.component.ts` - resumen visual de carrito e-commerce.
+- `apps/frontend/src/app/private/modules/ecommerce/services/checkout.service.ts` - contrato frontend de checkout.
+- `apps/frontend/src/app/private/modules/ecommerce/pages/checkout/checkout.component.ts` - flujo de checkout, Wompi y resumen.
+- `apps/frontend/src/app/private/modules/ecommerce/pages/checkout/checkout.component.html` - visualizacion de totales checkout.
+- `apps/frontend/src/app/private/modules/ecommerce/pages/account/order-detail/order-detail.component.ts` - detalle de orden e-commerce.
+- `apps/frontend/src/app/private/modules/ecommerce/pages/account/order-detail/order-detail.component.html` - visualizacion de descuentos e-commerce.
+- `apps/backend/src/domains/store/promotions/promotion-engine/promotion-engine.service.spec.ts` - pruebas nuevas del motor/cotizacion promocional.
+- `apps/backend/src/domains/store/payments/payments.service.spec.ts` - regresiones POS.
+- `apps/backend/src/domains/ecommerce/checkout/checkout.service.spec.ts` - pruebas nuevas de checkout con descuentos.
+- `apps/backend/src/domains/ecommerce/catalog/catalog.service.spec.ts` - regresiones de catalogo e-commerce.
+- `apps/backend/src/domains/store/products/products.service.spec.ts` - regresiones de listado POS.
+
+## Reusable Assets
+- `apps/backend/src/domains/store/promotions/promotion-engine/promotion-engine.service.ts` - ya valida fechas, uso, scope y calcula descuentos por orden/producto/categoria.
+- `apps/backend/src/domains/store/promotions/promotions.service.ts` - ya valida seleccion de productos/categorias y devuelve promociones activas.
+- `apps/backend/src/domains/store/coupons/coupons.service.ts` - ya valida cupones por producto/categoria/compra total y calcula `discount_amount`.
+- `apps/backend/src/domains/store/products/services/price-resolver.service.ts` - resuelve precio base, sale price, impuestos y variantes sin mezclar promociones temporales.
+- `apps/frontend/src/app/shared/services/pricing/price-resolver.service.ts` - patron frontend existente para resolver precios de productos/variantes.
+- `apps/frontend/src/app/private/modules/store/pos/services/pos-cart.service.ts` - ya tiene aplicacion local de promociones/cupones para UX POS.
+- `apps/frontend/src/app/private/modules/store/pos/services/pos-api.service.ts` - ya consulta promociones activas y valida cupones.
+- `apps/frontend/src/app/shared/pipes/currency/currency.pipe.ts` - formato de moneda centralizado.
+- `apps/frontend/src/app/shared/components/modal/modal.component.ts` - modal estandar para configuracion sin crear UI paralela.
+- `apps/backend/src/common/responses/response.service.ts` - respuestas API consistentes.
+- `apps/backend/src/prisma/services/store-prisma.service.ts` - scoping multi-tenant de `order_promotions` y entidades store.
+
+## Steps
+1. Formalizar la cotizacion promocional backend
+   Skills: vendix-business-analysis, vendix-product-pricing, vendix-calculated-pricing, vendix-backend, vendix-prisma-scopes, vendix-validation, vendix-naming-conventions
+   Resources: `npm run test -w apps/backend -- --runInBand src/domains/store/promotions/promotion-engine/promotion-engine.service.spec.ts`
+   Business decision: El backend es la fuente de verdad; promociones `is_auto_apply` aplican automaticamente, promociones manuales solo aplican si llegan por ID, cupones siguen siendo separados, y los descuentos se calculan sobre totales de productos antes de shipping.
+   Why: Va primero porque POS, catalogo, checkout, orden y pago deben consumir el mismo resultado economico para no divergir.
+   Output: `PromotionEngineService` con metodo de cotizacion reusable que devuelve descuentos por promocion, descuento total, precio promocional por item/producto y metadata para persistir `order_promotions`.
+   Verification: `npm run test -w apps/backend -- --runInBand src/domains/store/promotions/promotion-engine/promotion-engine.service.spec.ts` cubre promocion por producto, categoria, orden, cap maximo, min purchase, no elegible y stacking existente.
+2. Endurecer configuracion de promociones
+   Skills: vendix-backend-api, vendix-validation, vendix-frontend, vendix-angular-forms, vendix-zoneless-signals, vendix-frontend-modal, vendix-ui-ux
+   Resources: `npm run zoneless:audit`
+   Business decision: Promocion por producto requiere productos, promocion por categoria requiere categorias, promocion de compra general no requiere seleccion, y una promocion invalida no debe quedar guardada ni parecer activa en venta.
+   Why: Debe corregirse antes de confiar en promociones activas, porque el motor depende de datos de configuracion coherentes.
+   Output: Validaciones backend/frontend alineadas, mensajes claros en el modal de promocion y payloads normalizados para productos/categorias/compra general.
+   Verification: `npm run zoneless:audit` valida patrones Angular; prueba manual en `http://localhost:4200/store/marketing/promotions` crea/edita una promocion por producto, una por categoria y una general sin errores visuales ni de validacion.
+3. Mostrar promociones activas en cards POS y e-commerce
+   Skills: vendix-backend, vendix-backend-api, vendix-product-pricing, vendix-calculated-pricing, vendix-frontend, vendix-frontend-component, vendix-frontend-icons, vendix-currency-formatting, vendix-ui-ux, vendix-zoneless-signals
+   Resources: `npm run test -w apps/backend -- --runInBand src/domains/ecommerce/catalog/catalog.service.spec.ts src/domains/store/products/products.service.spec.ts`
+   Business decision: Las cards muestran precio promocional y badge solo para promociones activas por producto/categoria; `base_price`, `sale_price` y `final_price` historicos no se sobrescriben, y `has_discount=true` incluye sale price o promocion activa.
+   Why: Va despues de la cotizacion porque la UI no debe duplicar reglas ni inventar descuentos distintos a los del backend.
+   Output: Catalogo e-commerce y listado POS devuelven campos de promocion activa, y las cards muestran precio original, precio con promo y etiqueta de descuento sin cambiar disponibilidad ni stock.
+   Verification: `npm run test -w apps/backend -- --runInBand src/domains/ecommerce/catalog/catalog.service.spec.ts src/domains/store/products/products.service.spec.ts` valida producto directo, categoria y filtro `has_discount`.
+4. Corregir calculo de venta POS y registro de pagos
+   Skills: vendix-backend, vendix-backend-api, vendix-payment-processors, vendix-prisma-scopes, vendix-validation, vendix-currency-formatting, vendix-frontend, vendix-zoneless-signals
+   Resources: `npm run test -w apps/backend -- --runInBand src/domains/store/payments/payments.service.spec.ts`
+   Business decision: POS puede mostrar una estimacion local, pero `processPosPayment` recalcula promociones/cupones en backend, actualiza `orders.discount_amount` y `orders.grand_total`, registra `order_promotions` y `coupon_uses` con importes separados, y crea el pago por el `grand_total` final de la orden.
+   Why: Corrige el flujo de venta inmediato y evita que descuentos manipulados en frontend creen pagos u ordenes inconsistentes.
+   Output: Venta POS con promociones/cupones genera orden, detalles de descuentos y pago con totales correctos; venta POS sin descuentos conserva el comportamiento actual.
+   Verification: `npm run test -w apps/backend -- --runInBand src/domains/store/payments/payments.service.spec.ts` cubre venta sin promo, con promo producto, con promo categoria, con promo general, con cupon y con promo+cupon.
+5. Corregir checkout e-commerce normal y WhatsApp
+   Skills: vendix-ecommerce-checkout, vendix-customer-auth, vendix-payment-processors, vendix-backend, vendix-backend-api, vendix-multi-tenant-context, vendix-prisma-scopes, vendix-product-pricing, vendix-calculated-pricing, vendix-validation
+   Resources: `npm run test -w apps/backend -- --runInBand src/domains/ecommerce/checkout/checkout.service.spec.ts`
+   Business decision: Checkout aplica promociones automaticas activas sobre items elegibles, aplica cupon solo cuando el payload lo provee y lo valida, excluye shipping de la base de descuento, y Wompi/metodos manuales usan siempre el `order.grand_total` persistido.
+   Why: Va despues de POS porque reutiliza la misma cotizacion y cierra el mayor hueco actual del e-commerce.
+   Output: Checkout normal y WhatsApp crean orden con `discount_amount`, detalles de promociones/cupon y pago por total final; frontend envia/recibe campos de descuento y muestra resumen consistente.
+   Verification: `npm run test -w apps/backend -- --runInBand src/domains/ecommerce/checkout/checkout.service.spec.ts` cubre checkout invitado/autenticado, WhatsApp, Wompi, promocion por categoria y cupon invalido.
+6. Mostrar detalles de descuentos en ordenes y confirmaciones
+   Skills: vendix-backend-api, vendix-frontend, vendix-frontend-data-display, vendix-currency-formatting, vendix-zoneless-signals, vendix-ui-ux
+   Resources: `npm run test -w apps/backend -- --runInBand src/domains/store/orders/orders.service.spec.ts`
+   Business decision: Las ordenes muestran snapshots persistidos de descuentos aplicados, no recalculan contra promociones activas actuales, para preservar historico fiscal/comercial.
+   Why: Va despues de persistir descuentos, porque las pantallas deben leer datos reales de orden y no estados temporales del carrito.
+   Output: Detalle store, detalle e-commerce, confirmacion POS y resumen de checkout muestran subtotal, promociones, cupones, descuento total, shipping y total final con nombres/importes.
+   Verification: `npm run test -w apps/backend -- --runInBand src/domains/store/orders/orders.service.spec.ts` valida que el detalle incluya promociones/cupones; `npm run zoneless:audit` valida cambios frontend.
+7. Verificacion integral y regresion de flujos sin promocion
+   Skills: buildcheck-dev, vendix-bruno-test, vendix-backend, vendix-frontend, vendix-ecommerce-checkout, vendix-payment-processors
+   Resources: `docker logs --tail 40 vendix_backend`; `docker logs --tail 40 vendix_frontend`; `docker ps`
+   Business decision: El fix no puede cambiar el resultado de ventas sin promociones, ni bloquear configuraciones existentes de POS/e-commerce, ni introducir errores de watch-mode.
+   Why: Cierra la ejecucion validando que los cambios cruzados no dejaron errores de runtime ni regresiones economicas basicas.
+   Output: Resultado verificado en pruebas unitarias, auditoria zoneless, logs backend/frontend y recorrido manual POS/e-commerce.
+   Verification: `docker logs --tail 40 vendix_backend`, `docker logs --tail 40 vendix_frontend` y `docker ps` sin errores relevantes; recorrido manual crea venta POS sin promo, venta POS con promo, checkout e-commerce sin promo y checkout e-commerce con promo.
+
+## End-to-End Verification
+1. `npm run test -w apps/backend -- --runInBand src/domains/store/promotions/promotion-engine/promotion-engine.service.spec.ts src/domains/store/payments/payments.service.spec.ts src/domains/ecommerce/checkout/checkout.service.spec.ts src/domains/ecommerce/catalog/catalog.service.spec.ts src/domains/store/products/products.service.spec.ts src/domains/store/orders/orders.service.spec.ts`
+2. `npm run zoneless:audit`
+3. `docker logs --tail 40 vendix_backend`
+4. `docker logs --tail 40 vendix_frontend`
+5. `docker ps`
+6. Manual UI check at `http://localhost:4200/store/marketing/promotions`, `http://localhost:4200/store/pos`, `http://localhost:4200/products`, `http://localhost:4200/cart`, and `http://localhost:4200/checkout`: create product/category/general promotions, verify badges, create POS/e-commerce orders, and confirm order/payment totals match.
+
+## Knowledge Gaps
+- No existe una skill dedicada a promociones/cupones de venta end-to-end. Este fix formaliza un patron economico nuevo entre configuracion, catalogo, POS, checkout, orden y pago; al estabilizarlo se debe proponer una skill `vendix-promotions` para documentar reglas de stacking, base de descuento, snapshots historicos y verificacion.
+
+## Approval Request
+This plan is ready for human review. Reply **"ejecuta"**, **"apruebo"**, or **"procede"** to start execution under `how-to-dev`. Reply with corrections to revise the plan in place.

--- a/saludo-daniel.txt
+++ b/saludo-daniel.txt
@@ -1,0 +1,1 @@
+Hola, soy Daniel. Este es mi PR.


### PR DESCRIPTION
## Summary

Sincroniza `dev` → `main` con 8 commits acumulados:

- **Customers module (clientes)**: refactor end-to-end del flujo de creación/edición con tipos de documento DIAN colombianos (CC, CE, NIT, TI, RC, PA, PEP, PPT, DIE, NUIP), validación coherente backend↔frontend, unicidad por organización, normalización de `document_number`, y traducción completa al español de modal, lista, detalle, billetera, reseñas, stats, toasts y errores.
- **Sales flow + promotion engine**: overhaul cruzado backend/frontend para órdenes, promociones, POS y compras (PO).
- **Mobile org stores**: nuevo módulo CRUD completo para tiendas desde la app móvil de organización (PR #277).
- **Product source modal**: aspect-ratio default `free` + lightbox y `is_featured` en marcas/categorías.
- **Misc**: ajustes a notifications dropdown, support, help-center, inventario POP, variantes POS.

## Changes by area

### Backend
- `apps/backend/src/common/constants/document-types.ts` — catálogo DIAN (10 códigos, regex, label, maxLength)
- `apps/backend/src/common/validators/document-number.validator.ts` — `@DocumentNumberMatchesType()` decorator
- `apps/backend/src/domains/store/customers/` — DTOs con `@IsIn`, service con `normalizeDocument()` + unicidad org-wide, bulk template con catálogo
- Cambios menores en checkout, inventory, orders, payments, promotions, products, cash-registers, purchase-orders

### Frontend
- `apps/frontend/src/app/shared/constants/document-types.ts` — catálogo espejo con labels ES
- `apps/frontend/src/app/private/modules/store/customers/` — modal/list/details/reviews 100% en español, validators reactivos por tipo, helper de error translator centralizado
- `pos-customer-modal` alineado al catálogo compartido
- Cambios menores en POS (cart, variant-selector, product-selection, header dropdown, session modals), promotions, products, support, help-center

### Mobile
- `apps/mobile/app/(org-admin)/stores/` — CRUD completo, settings, filters, delete confirmation

### Tests
- `bruno/Vendix/Store/Customers/` — 4 nuevos tests: CC ok, NIT ok, invalid type (400), duplicate (409)

## Database migrations

Ninguna. La columna `users.document_type` se mantiene `VARCHAR(50)`; la validación se aplica en DTO (decisión: evitar migración destructiva sobre datos legacy `DNI`/`PASSPORT`/`LICENSE` que se renderizan como "Sin clasificar").

## Test plan

- [ ] Backend builds: `npm run build -w apps/backend`
- [ ] Frontend builds: `npm run build:prod -w apps/frontend`
- [ ] Bruno collection: `bruno run bruno/Vendix/Store/Customers --env <env>` (4/4)
- [ ] UI admin: crear cliente con CC válida, editar a NIT — confirmar toasts ES y validación dinámica
- [ ] UI POS: abrir customer modal — selector de tipos coincide con admin
- [ ] UI mobile org: CRUD de tiendas desde org-admin
- [ ] Validación negativa: número inválido para tipo seleccionado → mensaje ES "Número de documento inválido para …"
- [ ] Duplicado: dos clientes con misma CC/NIT en la organización → 409 con copy ES

## Notes

- Datos legacy `DNI`/`PASSPORT`/`LICENSE` permanecen en BD; se muestran "Sin clasificar" hasta corrección manual del usuario.
- 18 archivos adicionales (fiscal DIAN forms, profile-modal, ecommerce account, organization users) tienen catálogos hardcodeados de tipos de documento; quedan fuera de scope — requieren plan separado para unificación.