### PR TITLE
fix: failed domain-root status no marca propiedad como verificada

### DIFF
--- a/apps/backend/src/common/services/domains/domain-custom-hosting.util.ts
+++ b/apps/backend/src/common/services/domains/domain-custom-hosting.util.ts
@@ -108,7 +108,7 @@ export interface DomainHostingRecord {
   certificate_issued_at?: Date | string | null;
 }
 
-const VERIFIED_DOMAIN_STATUSES = new Set([
+export const VERIFIED_DOMAIN_STATUSES = new Set([
   'pending_certificate',
   'issuing_certificate',
   'pending_alias',

--- a/apps/backend/src/common/services/domains/domain-root-hosting.util.spec.ts
+++ b/apps/backend/src/common/services/domains/domain-root-hosting.util.spec.ts
@@ -80,4 +80,34 @@ describe('domain-root-hosting.util', () => {
       ]),
     );
   });
+
+  it('keeps ownership pending and re-exposes the TXT when ownership failed', () => {
+    const payload = buildDomainRootDnsInstructions({
+      root: {
+        id: 1,
+        hostname: 'gorrerolicor.online',
+        status: 'failed_ownership',
+        ssl_status: 'pending',
+        last_verified_at: null,
+        verification_token: 'vdx_test',
+      },
+      routingEndpoint: 'd123.cloudfront.net',
+      verificationToken: 'vdx_test',
+    });
+
+    expect(payload.ownership_status).toBe('pending');
+    expect(
+      payload.stages?.find((stage) => stage.key === 'ownership')?.status,
+    ).toBe('failed');
+    expect(payload.instructions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          group: 'ownership',
+          record_type: 'TXT',
+          provider_host: '_vendix-verify',
+          value: 'vdx_test',
+        }),
+      ]),
+    );
+  });
 });

--- a/apps/backend/src/common/services/domains/domain-root-hosting.util.ts
+++ b/apps/backend/src/common/services/domains/domain-root-hosting.util.ts
@@ -4,6 +4,7 @@ import {
   DomainDnsInstructionsPayload,
   DomainProvisioningStage,
   DomainValidationRecord,
+  VERIFIED_DOMAIN_STATUSES,
   getDomainSslConfig,
 } from './domain-custom-hosting.util';
 
@@ -143,7 +144,7 @@ export function buildDomainRootDnsInstructions(params: {
       : undefined;
 
   const ownershipComplete =
-    !!root.last_verified_at || root.status !== 'pending_ownership';
+    !!root.last_verified_at || VERIFIED_DOMAIN_STATUSES.has(root.status);
   const certificateComplete =
     root.ssl_status === 'issued' || certificateStatus === 'ISSUED';
   const routingComplete =


### PR DESCRIPTION
## Resumen
Corrige el cálculo de propiedad verificada en las instrucciones DNS de dominios root.

`buildDomainRootDnsInstructions` marcaba `ownershipComplete` para cualquier status distinto de `pending_ownership`. Un root en `failed_ownership` se mostraba como propiedad verificada (paso en verde) y ocultaba el TXT de verificación, dejando al usuario sin forma de re-agregar el registro tras borrarlo.

Ahora reutiliza el set canónico `VERIFIED_DOMAIN_STATUSES`: un fallo de propiedad mantiene el paso en estado fallido y vuelve a exponer el TXT.

## Cambios
- `domain-custom-hosting.util.ts`: exporta `VERIFIED_DOMAIN_STATUSES`.
- `domain-root-hosting.util.ts`: usa ese set para `ownershipComplete`.
- `domain-root-hosting.util.spec.ts`: test para el caso `failed_ownership`.

## Test plan
- [x] `npx jest domain-root-hosting domain-custom-hosting` → 11 tests verdes
- [ ] Tras deploy: dominio en `failed_ownership` muestra el paso en rojo y re-expone el TXT

Sin migraciones de base de datos.