### PR TITLE
feat: enforce subscription gate by default + backfill early-access plan

### DIFF
--- a/apps/backend/prisma/migrations/20260529120000_backfill_early_access_production_stores/migration.sql
+++ b/apps/backend/prisma/migrations/20260529120000_backfill_early_access_production_stores/migration.sql
@@ -1,0 +1,61 @@
+-- DATA IMPACT:
+-- Tables affected: store_subscriptions (INSERT only — additive)
+-- Expected row changes: one new row per production-mode store that currently
+--   has NO subscription row. At authoring time this matched 14 active stores
+--   belonging to organizations with mode='production'. Demo/test stores are
+--   intentionally excluded.
+-- Destructive operations: none (no UPDATE/DELETE/DROP/TRUNCATE)
+-- FK/cascade risk: none — store_subscriptions.store_id is @unique and the
+--   INSERT only targets stores without an existing row.
+-- Idempotency: guarded by NOT EXISTS + store_id unique constraint; re-running
+--   inserts zero rows for stores that already have a subscription.
+-- Approval: documented in chat (apply early-access plan id=2 to production stores).
+--
+-- Notes:
+--   * Plan id 2 = 'early-access' (is_free=true, base_price=0, monthly).
+--   * resolved_features is copied live from subscription_plans.ai_feature_flags
+--     for plan 2 so it never drifts from a hardcoded snapshot.
+--   * Timestamps use UTC to match the @db.Timestamp(6) (no-tz) columns.
+
+INSERT INTO "store_subscriptions" (
+  "store_id",
+  "plan_id",
+  "paid_plan_id",
+  "state",
+  "current_period_start",
+  "current_period_end",
+  "next_billing_at",
+  "effective_price",
+  "vendix_base_price",
+  "partner_margin_amount",
+  "currency",
+  "auto_renew",
+  "resolved_features",
+  "resolved_at",
+  "created_at",
+  "updated_at"
+)
+SELECT
+  s."id",
+  2,
+  2,
+  'active'::"store_subscription_state_enum",
+  (now() AT TIME ZONE 'UTC'),
+  (now() AT TIME ZONE 'UTC') + INTERVAL '1 month',
+  (now() AT TIME ZONE 'UTC') + INTERVAL '1 month',
+  0,
+  0,
+  0,
+  'COP',
+  true,
+  (SELECT "ai_feature_flags" FROM "subscription_plans" WHERE "id" = 2),
+  (now() AT TIME ZONE 'UTC'),
+  (now() AT TIME ZONE 'UTC'),
+  (now() AT TIME ZONE 'UTC')
+FROM "stores" s
+JOIN "organizations" o ON o."id" = s."organization_id"
+WHERE o."mode" = 'production'
+  AND s."is_active" = true
+  AND NOT EXISTS (
+    SELECT 1 FROM "store_subscriptions" ss WHERE ss."store_id" = s."id"
+  );

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -110,8 +110,8 @@ import { RateLimitModule } from './common/services/rate-limit/rate-limit.module'
     // populated. Blocks writes under /api/store/** when the store has no
     // active subscription (or it's suspended/blocked/cancelled/expired).
     // Read methods, /api/store/subscriptions/**, and handlers decorated
-    // with @SkipSubscriptionGate() pass through. Enforce mode is gated by
-    // the STORE_GATE_ENFORCE env var (currently 'true' in dev/prod).
+    // with @SkipSubscriptionGate() pass through. Enforce is the code default;
+    // set STORE_GATE_ENFORCE=false to fall back to log-only observation.
     {
       provide: APP_GUARD,
       useClass: StoreOperationsGuard,

--- a/apps/backend/src/domains/store/subscriptions/config/subscription-gate.config.ts
+++ b/apps/backend/src/domains/store/subscriptions/config/subscription-gate.config.ts
@@ -3,8 +3,10 @@ import { Injectable, Logger } from '@nestjs/common';
 /**
  * Canonical configuration for the subscription gate system.
  *
- * Default mode is **log-only** (observe without blocking).
- * Enforce mode is activated only when `STORE_GATE_ENFORCE === 'true'`.
+ * Default mode is **enforce**: stores without an active/trial subscription are
+ * blocked from store writes. The gate can be turned back to observe-only by
+ * explicitly setting `STORE_GATE_ENFORCE=false` (deprecated alias
+ * `AI_GATE_ENFORCE=false`), e.g. for a temporary incident bypass.
  *
  * Backwards-compat alias `AI_GATE_ENFORCE` is still honored for one release
  * but emits a deprecation warning on startup.
@@ -25,9 +27,11 @@ export class SubscriptionGateConfig {
   }
 
   private _loadConfig(): void {
+    // Enforce by default. Disabled only when explicitly opted out with
+    // STORE_GATE_ENFORCE=false (or the deprecated AI_GATE_ENFORCE=false).
     this._enforce =
-      process.env.STORE_GATE_ENFORCE === 'true' ||
-      process.env.AI_GATE_ENFORCE === 'true';
+      process.env.STORE_GATE_ENFORCE !== 'false' &&
+      process.env.AI_GATE_ENFORCE !== 'false';
     this._logOnly = !this._enforce;
     this._cronDryRun = process.env.SUBSCRIPTION_CRON_DRY_RUN === 'true';
 
@@ -40,7 +44,7 @@ export class SubscriptionGateConfig {
 
   /**
    * Returns `true` when the gate should actively block requests.
-   * Default is `false` (log-only) to preserve UX during rollout.
+   * Default is `true` (enforce); opt out with `STORE_GATE_ENFORCE=false`.
    */
   isEnforce(): boolean {
     return this._enforce;

--- a/apps/backend/src/domains/store/subscriptions/guards/store-operations.guard.spec.ts
+++ b/apps/backend/src/domains/store/subscriptions/guards/store-operations.guard.spec.ts
@@ -39,6 +39,21 @@ describe('StoreOperationsGuard', () => {
     } as any;
   }
 
+  // Build the guard AFTER setting the enforce env vars: SubscriptionGateConfig
+  // reads and caches them at construction time, so the env must be set first.
+  function makeGuard() {
+    guard = new StoreOperationsGuard(
+      reflector as any,
+      access as any,
+      new SubscriptionGateConfig(),
+    );
+    logger = {
+      warn: jest
+        .spyOn((guard as any).logger, 'warn')
+        .mockImplementation(() => undefined),
+    };
+  }
+
   beforeEach(() => {
     reflector = { getAllAndOverride: jest.fn().mockReturnValue(false) };
     access = { canUseModule: jest.fn() };
@@ -50,16 +65,8 @@ describe('StoreOperationsGuard', () => {
     delete process.env.STORE_GATE_ENFORCE;
     delete process.env.AI_GATE_ENFORCE;
 
-    guard = new StoreOperationsGuard(
-      reflector as any,
-      access as any,
-      new SubscriptionGateConfig(),
-    );
-    logger = {
-      warn: jest
-        .spyOn((guard as any).logger, 'warn')
-        .mockImplementation(() => undefined),
-    };
+    // Default build with no env override → enforce (the new code default).
+    makeGuard();
   });
 
   afterEach(() => {
@@ -103,6 +110,7 @@ describe('StoreOperationsGuard', () => {
 
   it('blocks when state=suspended and enforce=true', async () => {
     process.env.STORE_GATE_ENFORCE = 'true';
+    makeGuard();
     access.canUseModule.mockResolvedValue({
       allowed: false,
       mode: 'block',
@@ -120,7 +128,9 @@ describe('StoreOperationsGuard', () => {
     expect(caught).toBeInstanceOf(VendixHttpException);
   });
 
-  it('passes (log-only) when state=suspended and enforce=false', async () => {
+  it('passes (log-only) when state=suspended and STORE_GATE_ENFORCE=false', async () => {
+    process.env.STORE_GATE_ENFORCE = 'false';
+    makeGuard();
     access.canUseModule.mockResolvedValue({
       allowed: false,
       mode: 'block',


### PR DESCRIPTION
## Summary
- Hace que el gate de suscripción **enforce por default** en código (`SubscriptionGateConfig`): tiendas sin suscripción `active`/`trial` quedan bloqueadas en escrituras `/api/store/**`. Se desactiva solo con `STORE_GATE_ENFORCE=false`.
- **Causa raíz:** enforce dependía de un env var que nunca se seteó en prod (`STORE_GATE_ENFORCE` está `<unset>`), dejando el gate en modo log-only → todas las tiendas sin plan operaban completo.
- **Backfill:** asigna el plan `early-access` (id=2, gratis, mensual) a las tiendas **activas de organizaciones `mode=production`** que no tenían fila de suscripción (14 al momento de autoría), para que el enforce no bloquee tiendas legítimas existentes. Demo/test excluidas.
- Arregla un test del guard que ya fallaba en `main` (construía el config antes de fijar el env var; el config cachea en construcción).

## ⚠️ DATABASE MIGRATION
> **ATENCIÓN**: requiere correr migraciones antes/durante el deploy. Es aditiva (solo INSERT), idempotente, sin operaciones destructivas. Dry-run en prod (transacción + ROLLBACK) confirmó **14 filas**.

\`\`\`sql
INSERT INTO "store_subscriptions" (
  "store_id","plan_id","paid_plan_id","state",
  "current_period_start","current_period_end","next_billing_at",
  "effective_price","vendix_base_price","partner_margin_amount","currency","auto_renew",
  "resolved_features","resolved_at","created_at","updated_at"
)
SELECT
  s."id", 2, 2, 'active'::"store_subscription_state_enum",
  (now() AT TIME ZONE 'UTC'),
  (now() AT TIME ZONE 'UTC') + INTERVAL '1 month',
  (now() AT TIME ZONE 'UTC') + INTERVAL '1 month',
  0, 0, 0, 'COP', true,
  (SELECT "ai_feature_flags" FROM "subscription_plans" WHERE "id" = 2),
  (now() AT TIME ZONE 'UTC'), (now() AT TIME ZONE 'UTC'), (now() AT TIME ZONE 'UTC')
FROM "stores" s
JOIN "organizations" o ON o."id" = s."organization_id"
WHERE o."mode" = 'production' AND s."is_active" = true
  AND NOT EXISTS (SELECT 1 FROM "store_subscriptions" ss WHERE ss."store_id" = s."id");
\`\`\`

## Efectos al activar (por diseño, no bugs)
- Tiendas demo/test sin suscripción → bloqueadas en escritura.
- 2da+ tienda de una misma org → nace `no_plan` → bloqueada.
- Signups nuevos (1ra tienda) → nacen `trial` → no se bloquean (onboarding crea la fila atómicamente).

## Test plan
- [x] `store-operations.guard.spec.ts` 10/10 pass (incluye fix del test roto).
- [x] `subscription-access.service.spec.ts` pass.
- [x] Dry-run migración en prod (ROLLBACK): 14 filas, SQL válido.
- [x] `tsc --noEmit` sin errores.
- [ ] Nota: 28 tests preexistentes fallan en 4 specs por mock `withoutScope` (ajenos a este PR).