### PR TITLE
Subscription gate enforcement + paid-checkout invoice fix

### DIFF
--- a/apps/backend/src/domains/store/subscriptions/controllers/subscription-checkout.controller.ts
+++ b/apps/backend/src/domains/store/subscriptions/controllers/subscription-checkout.controller.ts
@@ -773,22 +773,29 @@ export class SubscriptionCheckoutController {
       const subPending = sub as any;
       const previousPendingPlanId: number | null =
         subPending.pending_plan_id ?? null;
-      const planChangedWhilePending =
-        previousPendingPlanId != null && previousPendingPlanId !== dto.planId;
+      // issueInvoice() bills against sub.plan_id, so it MUST already point at
+      // the target plan before we emit. Two cases require (re)assignment:
+      //   - plan_id === null: a fresh pending_payment sub that was stranded
+      //     (created before the plan_id-at-creation fix, or a voided retry).
+      //   - plan_id !== dto.planId: the user switched plans while pending.
+      // applyResubscribe() sets plan_id + refreshes pricing/period WITHOUT
+      // touching `state` (stays pending_payment; promotion to active happens
+      // on payment via SubscriptionStateListener). It also lets issueInvoice
+      // detect+void any stale pending invoice for the previous plan.
+      const planNeedsAssignment =
+        sub.plan_id == null || sub.plan_id !== dto.planId;
 
-      if (planChangedWhilePending) {
-        // Plan changed while pending — refresh pricing/period so the next
-        // invoice reflects the latest selection. issueInvoice() will detect
-        // the plan mismatch on the existing pending row and void it.
+      if (planNeedsAssignment) {
         await this.proration.applyResubscribe(sub.id, dto.planId);
       }
 
       // issueInvoice handles both reuse (same plan, idempotent retries) and
-      // void+create (plan changed). Always non-null for a paid plan.
+      // void+create (plan changed). Always non-null for a paid plan now that
+      // plan_id is guaranteed to match the target.
       const invoice = await this.billing.issueInvoice(sub.id, {
         fromPlanId: subPending.paid_plan_id ?? sub.plan_id,
         toPlanId: dto.planId,
-        changeKind: planChangedWhilePending ? 'resubscribe' : undefined,
+        changeKind: planNeedsAssignment ? 'resubscribe' : undefined,
       });
 
       if (!invoice) {
@@ -1508,7 +1515,12 @@ export class SubscriptionCheckoutController {
       const created = await tx.store_subscriptions.create({
         data: {
           store_id: storeId,
-          plan_id: isFreePlan ? plan.id : null,
+          // Bill-against plan must be set even while pending_payment so
+          // issueInvoice() can emit the first invoice. The gate blocks by
+          // `state` (pending_payment → block) regardless of plan_id, and
+          // resolved_features stays empty until confirmPendingChange() runs,
+          // so no feature leaks before payment. Mirrors Path D (applyResubscribe).
+          plan_id: plan.id,
           paid_plan_id: isFreePlan ? plan.id : null,
           partner_override_id: null,
           state: initialState,

--- a/apps/frontend/src/app/private/modules/store/subscription/pages/picker/picker.component.ts
+++ b/apps/frontend/src/app/private/modules/store/subscription/pages/picker/picker.component.ts
@@ -25,10 +25,10 @@ import { SubscriptionPlan } from '../../interfaces/store-subscription.interface'
 type BillingCycle = 'monthly' | 'quarterly' | 'semiannual' | 'annual' | 'lifetime';
 
 const CYCLE_ORDER: BillingCycle[] = [
-  'monthly',
-  'quarterly',
-  'semiannual',
   'annual',
+  'semiannual',
+  'quarterly',
+  'monthly',
   'lifetime',
 ];
 
@@ -174,7 +174,7 @@ export class PickerComponent implements OnInit {
     }
 
     if (!selected || !cycles.includes(selected)) {
-      this.selectedCycle.set(cycles.includes('monthly') ? 'monthly' : cycles[0]);
+      this.selectedCycle.set(cycles.includes('annual') ? 'annual' : cycles[0]);
     }
   }
 }

--- a/apps/frontend/src/app/private/modules/store/subscription/pages/plans/plan-catalog.component.ts
+++ b/apps/frontend/src/app/private/modules/store/subscription/pages/plans/plan-catalog.component.ts
@@ -19,7 +19,7 @@ import { PricingCardSelectEvent } from '../../../../../../shared/components/pric
 type BillingCycle = 'monthly' | 'quarterly' | 'semiannual' | 'annual' | 'lifetime';
 
 const CYCLE_ORDER: BillingCycle[] = [
-  'monthly', 'quarterly', 'semiannual', 'annual', 'lifetime',
+  'annual', 'semiannual', 'quarterly', 'monthly', 'lifetime',
 ];
 
 const CYCLE_LABEL: Record<BillingCycle, string> = {
@@ -269,7 +269,7 @@ export class PlanCatalogComponent implements OnInit {
             this.plans.set(res.data);
             const cycles = this.availableCycles();
             if (cycles.length > 0 && !this.selectedCycle()) {
-              this.selectedCycle.set(cycles.includes('monthly') ? 'monthly' : cycles[0]);
+              this.selectedCycle.set(cycles.includes('annual') ? 'annual' : cycles[0]);
             }
           }
           this.loading.set(false);

--- a/apps/frontend/src/app/private/modules/super-admin/subscriptions/pages/gateway/gateway.component.html
+++ b/apps/frontend/src/app/private/modules/super-admin/subscriptions/pages/gateway/gateway.component.html
@@ -207,6 +207,62 @@
         </div>
       </div>
 
+      <!-- URL de Eventos (webhook de plataforma) -->
+      <div
+        class="bg-surface rounded-card border border-border p-4 md:p-6 space-y-3"
+      >
+        <div class="flex items-center gap-2">
+          <app-icon
+            name="webhook"
+            [size]="18"
+            customClasses="text-text-primary"
+          ></app-icon>
+          <h2
+            class="text-sm font-semibold text-text-primary uppercase tracking-wide"
+          >
+            URL de Eventos
+          </h2>
+        </div>
+
+        <p class="text-sm text-text-secondary">
+          Registra esta URL en el comercio Wompi
+          <strong>de la plataforma</strong> para que confirme los cobros de
+          suscripción. Es distinta de la URL de las tiendas — no la reutilices.
+        </p>
+
+        <div
+          class="flex items-center gap-2 bg-background border border-border rounded-md px-3 py-2"
+        >
+          <code class="text-xs md:text-sm text-text-primary break-all flex-1">
+            {{ platformWebhookUrl }}
+          </code>
+          <button
+            type="button"
+            class="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline shrink-0"
+            (click)="copyWebhookUrl()"
+          >
+            <app-icon
+              [name]="webhookUrlCopied() ? 'check' : 'copy'"
+              [size]="14"
+            ></app-icon>
+            {{ webhookUrlCopied() ? 'Copiado' : 'Copiar' }}
+          </button>
+        </div>
+
+        <p class="text-xs text-text-secondary">
+          Pégala en
+          <a
+            href="https://comercios.wompi.co"
+            target="_blank"
+            rel="noopener"
+            class="text-primary hover:underline"
+            >comercios.wompi.co</a
+          >
+          → Configuraciones avanzadas → Seguimiento de transacciones → URL de
+          Eventos.
+        </p>
+      </div>
+
       <!-- Configuración -->
       <div
         class="bg-surface rounded-card border border-border p-4 md:p-6 space-y-4"

--- a/apps/frontend/src/app/private/modules/super-admin/subscriptions/pages/gateway/gateway.component.ts
+++ b/apps/frontend/src/app/private/modules/super-admin/subscriptions/pages/gateway/gateway.component.ts
@@ -37,6 +37,7 @@ import {
   UpsertGatewayDto,
 } from '../../interfaces/platform-gateway.interface';
 import { GatewayAdminService } from '../../services/gateway-admin.service';
+import { environment } from '../../../../../../../environments/environment';
 
 /**
  * Reactive form shape for the Wompi platform-gateway configuration.
@@ -100,6 +101,14 @@ export class GatewayComponent {
   readonly selectedEnvironment = signal<GatewayEnvironment>('sandbox');
   readonly formInvalid = signal<boolean>(true);
   readonly secretsFilled = signal<boolean>(false);
+  readonly webhookUrlCopied = signal<boolean>(false);
+
+  /**
+   * Events URL the operator must register in the PLATFORM Wompi merchant
+   * (distinct from the per-store webhook). Derived from the API base so it
+   * stays correct across environments.
+   */
+  readonly platformWebhookUrl = `${environment.apiUrl}/platform/webhooks/wompi`;
 
   /**
    * `true` when the backend already has a valid (parseable) configuration.
@@ -303,6 +312,15 @@ export class GatewayComponent {
   onHeaderAction(id: string): void {
     if (id === 'test') this.onTest();
     if (id === 'save') this.onSave();
+  }
+
+  // ── Webhook URL ───────────────────────────────────────────────────
+
+  copyWebhookUrl(): void {
+    navigator.clipboard.writeText(this.platformWebhookUrl).then(() => {
+      this.webhookUrlCopied.set(true);
+      setTimeout(() => this.webhookUrlCopied.set(false), 2000);
+    });
   }
 
   // ── Test connection ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- **fix(billing):** paid checkout for a store with no prior subscription created the row with `plan_id=null`, so `issueInvoice()` returned null (`INVOICE_SKIPPED_NO_PLAN`) → no invoice, no Wompi widget, sub stranded in `pending_payment`; the retry then threw `SUBSCRIPTION_INTERNAL_ERROR` (500). Now `createFreshSubscription` sets `plan_id` for paid plans (mirrors Path D — gate blocks by `state`, `resolved_features` stays empty until `confirmPendingChange()`), and Path E calls `applyResubscribe` whenever `sub.plan_id` ≠ target, recovering already-stranded subs.
- **feat(gate):** enforce subscription gate by default + backfill early-access plan.
- **fix(domains):** treat failed domain-root statuses as unverified ownership.
- **frontend:** annual billing cycle prioritized (default + descending order) in plan catalog & picker; super-admin gateway UI surfaces the platform Wompi webhook events URL with a copy button.

## Impact
- Unblocks paid SaaS subscription checkout (e.g. store SMART HUB / `e-tech`, sub 34 — self-heals on next checkout attempt once deployed).
- Ships **enforce-gate-by-default** to prod (behavioral change for store write/AI gating).

## Test plan
- [x] `tsc --noEmit` backend — clean (exit 0)
- [x] Dev backend recompiles & boots clean
- [ ] Fresh paid checkout (store with no sub) → invoice `issued` + Wompi widget on first attempt
- [ ] Stranded `pending_payment` sub retry → invoice emitted, no 500
- [ ] Gate still blocks writes in `pending_payment` / terminal states
- [ ] Plan catalog shows annual cycle first, descending order

🤖 Generated with [Claude Code](https://claude.com/claude-code)