### PR TITLE
feat: planes de suscripción multi-ciclo + detalles markdown

### DIFF
--- a/apps/backend/prisma/migrations/20260529130000_add_plan_group_code_and_details_md/migration.sql
+++ b/apps/backend/prisma/migrations/20260529130000_add_plan_group_code_and_details_md/migration.sql
@@ -1,0 +1,24 @@
+-- DATA IMPACT:
+-- Tables affected: subscription_plans
+-- Expected row changes: additive columns plan_group_code (varchar 64) and
+--   details_md (text). Backfill sets plan_group_code = code for every existing
+--   row where plan_group_code IS NULL, so each pre-existing plan becomes a
+--   single-row group of itself. No rows are deleted or destroyed.
+-- Destructive operations: none (only ADD COLUMN + CREATE INDEX + guarded UPDATE)
+-- FK/cascade risk: none (no FKs added or dropped)
+-- Idempotency: guarded with IF NOT EXISTS and a WHERE filter on the backfill
+-- Approval: additive multi-cycle plan support (feat/subscription-plan-multi-cycle)
+
+-- 1. Multi-cycle grouping key. Plans sharing the same plan_group_code form a
+--    single logical plan exposed with multiple billing-cycle pricings.
+ALTER TABLE subscription_plans ADD COLUMN IF NOT EXISTS plan_group_code varchar(64);
+
+-- 2. Optional markdown details body for the plan group.
+ALTER TABLE subscription_plans ADD COLUMN IF NOT EXISTS details_md text;
+
+-- 3. Index for resolving a group by its shared code.
+CREATE INDEX IF NOT EXISTS subscription_plans_plan_group_code_idx ON subscription_plans(plan_group_code);
+
+-- 4. Backfill: existing plans become a group of themselves. Guarded by WHERE so
+--    re-running the migration never overwrites an already-set group code.
+UPDATE subscription_plans SET plan_group_code = code WHERE plan_group_code IS NULL;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -6652,6 +6652,8 @@ model subscription_plans {
   is_popular              Boolean                         @default(false)
   sort_order              Int                             @default(0)
   is_default              Boolean                         @default(false)
+  plan_group_code         String?                         @db.VarChar(64)
+  details_md              String?                         @db.Text
   parent_plan_id          Int?
   parent_plan             subscription_plans?             @relation("plan_lineage", fields: [parent_plan_id], references: [id])
   child_plans             subscription_plans[]            @relation("plan_lineage")
@@ -6671,6 +6673,7 @@ model subscription_plans {
 
   @@index([plan_type, state])
   @@index([is_promotional, promo_priority])
+  @@index([plan_group_code])
 }
 
 model partner_plan_overrides {

--- a/apps/backend/src/domains/superadmin/subscriptions/dto/index.ts
+++ b/apps/backend/src/domains/superadmin/subscriptions/dto/index.ts
@@ -1,4 +1,4 @@
-export { CreatePlanDto } from './plan.dto';
+export { CreatePlanDto, PlanPricingDto } from './plan.dto';
 export { UpdatePlanDto } from './update-plan.dto';
 export { PlanQueryDto } from './plan-query.dto';
 export {

--- a/apps/backend/src/domains/superadmin/subscriptions/dto/plan.dto.ts
+++ b/apps/backend/src/domains/superadmin/subscriptions/dto/plan.dto.ts
@@ -6,9 +6,29 @@ import {
   IsBoolean,
   IsObject,
   IsNotEmpty,
+  IsArray,
+  ValidateNested,
   MaxLength,
   Min,
 } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class PlanPricingDto {
+  @IsEnum(['monthly', 'quarterly', 'semiannual', 'annual'])
+  billing_cycle: string;
+
+  @IsNumber()
+  @Min(0)
+  price: number;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(3)
+  currency?: string;
+
+  @IsBoolean()
+  is_default: boolean;
+}
 
 export class CreatePlanDto {
   @IsString()
@@ -124,4 +144,22 @@ export class CreatePlanDto {
   @IsOptional()
   @IsNumber()
   parent_plan_id?: number;
+
+  // --- Multi-cycle support (additive) ---
+  // When provided with >= 1 item, create() produces one subscription_plans row
+  // per pricing, all sharing the same plan_group_code.
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => PlanPricingDto)
+  pricings?: PlanPricingDto[];
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(64)
+  plan_group_code?: string;
+
+  @IsOptional()
+  @IsString()
+  details_md?: string;
 }

--- a/apps/backend/src/domains/superadmin/subscriptions/services/plans.service.ts
+++ b/apps/backend/src/domains/superadmin/subscriptions/services/plans.service.ts
@@ -2,7 +2,12 @@ import { Injectable } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { GlobalPrismaService } from '../../../../prisma/services/global-prisma.service';
 import { VendixHttpException, ErrorCodes } from '../../../../common/errors';
-import { CreatePlanDto, UpdatePlanDto, PlanQueryDto } from '../dto';
+import {
+  CreatePlanDto,
+  UpdatePlanDto,
+  PlanQueryDto,
+  PlanPricingDto,
+} from '../dto';
 
 @Injectable()
 export class PlansService {
@@ -25,7 +30,50 @@ export class PlansService {
     return nextPlanType;
   }
 
+  /**
+   * Derive the per-cycle code for a non-default member of a multi-cycle group.
+   * The is_default pricing keeps the canonical `dto.code`; the rest get a
+   * `${code}-${billing_cycle}` suffix.
+   */
+  private deriveCycleCode(baseCode: string, billingCycle: string) {
+    return `${baseCode}-${billingCycle}`;
+  }
+
+  /**
+   * Build the subset of subscription_plans fields that are shared across every
+   * row of a multi-cycle group. Excludes per-cycle fields (code, billing_cycle,
+   * base_price, currency) and the group/identity fields handled by the caller.
+   */
+  private buildSharedCreateData(dto: CreatePlanDto, isPromotional: boolean) {
+    return {
+      name: dto.name,
+      description: dto.description || null,
+      state: (dto.state as any) || 'draft',
+      setup_fee: dto.is_free ? null : dto.setup_fee || null,
+      is_free: dto.is_free ?? false,
+      grace_period_soft_days: dto.grace_period_soft_days ?? 5,
+      grace_period_hard_days: dto.grace_period_hard_days ?? 10,
+      suspension_day: dto.suspension_day ?? 14,
+      cancellation_day: dto.cancellation_day ?? 45,
+      feature_matrix: (dto.feature_matrix ?? {}) as any,
+      ai_feature_flags: (dto.ai_feature_flags ?? {}) as any,
+      resellable: dto.resellable ?? !isPromotional,
+      max_partner_margin_pct: dto.max_partner_margin_pct || null,
+      is_promotional: isPromotional,
+      promo_rules: (dto.promo_rules as any) || null,
+      promo_priority: dto.promo_priority ?? 0,
+      is_popular: dto.is_popular ?? false,
+      sort_order: dto.sort_order ?? 0,
+      parent_plan_id: dto.parent_plan_id || null,
+      details_md: dto.details_md ?? null,
+    };
+  }
+
   async create(dto: CreatePlanDto) {
+    if (Array.isArray(dto.pricings) && dto.pricings.length > 0) {
+      return this.createMultiCycle(dto);
+    }
+
     const existing = await this.prisma.subscription_plans.findUnique({
       where: { code: dto.code },
     });
@@ -39,35 +87,106 @@ export class PlansService {
 
     return this.prisma.subscription_plans.create({
       data: {
+        ...this.buildSharedCreateData(dto, isPromotional),
         code: dto.code,
-        name: dto.name,
-        description: dto.description || null,
         plan_type: planType as any,
-        state: (dto.state as any) || 'draft',
         billing_cycle: (dto.billing_cycle as any) || 'monthly',
         base_price: dto.is_free ? 0 : dto.base_price,
         currency: dto.currency || 'COP',
-        setup_fee: dto.is_free ? null : dto.setup_fee || null,
-        is_free: dto.is_free ?? false,
-        grace_period_soft_days: dto.grace_period_soft_days ?? 5,
-        grace_period_hard_days: dto.grace_period_hard_days ?? 10,
-        suspension_day: dto.suspension_day ?? 14,
-        cancellation_day: dto.cancellation_day ?? 45,
-        feature_matrix: (dto.feature_matrix ?? {}) as any,
-        ai_feature_flags: (dto.ai_feature_flags ?? {}) as any,
-        resellable: dto.resellable ?? !isPromotional,
-        max_partner_margin_pct: dto.max_partner_margin_pct || null,
-        is_promotional: isPromotional,
+        plan_group_code: dto.plan_group_code ?? dto.code,
         redemption_code: this.normalizeRedemptionCode(dto.redemption_code),
-        promo_rules: (dto.promo_rules as any) || null,
-        promo_priority: dto.promo_priority ?? 0,
-        is_popular: dto.is_popular ?? false,
         is_default: dto.is_default ?? false,
-        sort_order: dto.sort_order ?? 0,
-        parent_plan_id: dto.parent_plan_id || null,
         updated_at: new Date(),
       },
     });
+  }
+
+  /**
+   * Multi-cycle create: one subscription_plans row per pricing, all sharing the
+   * same plan_group_code. Exactly one pricing must be is_default=true; that row
+   * keeps the canonical `dto.code`, the rest get a `${code}-${cycle}` suffix.
+   * Atomic: any code collision rolls back the whole group.
+   */
+  private async createMultiCycle(dto: CreatePlanDto) {
+    const pricings = dto.pricings as PlanPricingDto[];
+
+    const defaults = pricings.filter((p) => p.is_default === true);
+    if (defaults.length !== 1) {
+      throw new VendixHttpException(
+        ErrorCodes.SUBSCRIPTION_010,
+        'Exactly one pricing must be marked as is_default=true',
+      );
+    }
+
+    // Reject duplicate billing cycles within the same group.
+    const cycles = new Set<string>();
+    for (const p of pricings) {
+      if (cycles.has(p.billing_cycle)) {
+        throw new VendixHttpException(
+          ErrorCodes.SYS_CONFLICT_001,
+          `Duplicate billing_cycle '${p.billing_cycle}' in pricings`,
+        );
+      }
+      cycles.add(p.billing_cycle);
+    }
+
+    const planType = this.resolvePlanType(dto.plan_type, dto.is_promotional);
+    const isPromotional = planType === 'promotional';
+    const groupCode = dto.plan_group_code ?? dto.code;
+    const shared = this.buildSharedCreateData(dto, isPromotional);
+
+    return this.prisma.$transaction(
+      async (tx) => {
+        const created: any[] = [];
+
+        for (const pricing of pricings) {
+          const code = pricing.is_default
+            ? dto.code
+            : this.deriveCycleCode(dto.code, pricing.billing_cycle);
+
+          const conflict = await tx.subscription_plans.findUnique({
+            where: { code },
+          });
+          if (conflict) {
+            throw new VendixHttpException(
+              ErrorCodes.SYS_CONFLICT_001,
+              `Plan code '${code}' already exists`,
+            );
+          }
+
+          const row = await tx.subscription_plans.create({
+            data: {
+              ...shared,
+              code,
+              plan_type: planType as any,
+              billing_cycle: pricing.billing_cycle as any,
+              base_price: dto.is_free ? 0 : pricing.price,
+              currency: pricing.currency || dto.currency || 'COP',
+              plan_group_code: groupCode,
+              // redemption_code is @unique, so it can only live on one row.
+              redemption_code: pricing.is_default
+                ? this.normalizeRedemptionCode(dto.redemption_code)
+                : null,
+              // Row-level `is_default` is the GLOBAL "default plan" flag guarded
+              // by the partial unique index (only one active row may be true).
+              // The per-pricing `is_default` only marks the canonical CYCLE
+              // (the row that keeps `dto.code`), it must NOT leak into the
+              // global flag. Only the canonical row may carry the global flag,
+              // and only when the form explicitly opted in via dto.is_default.
+              is_default: pricing.is_default ? (dto.is_default ?? false) : false,
+              updated_at: new Date(),
+            },
+          });
+          created.push(row);
+        }
+
+        return {
+          plan_group_code: groupCode,
+          plans: created,
+        };
+      },
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+    );
   }
 
   async findAll(query: PlanQueryDto) {
@@ -130,7 +249,61 @@ export class PlansService {
       throw new VendixHttpException(ErrorCodes.SYS_NOT_FOUND_001);
     }
 
-    return plan;
+    // Resolve the multi-cycle group. A null plan_group_code (legacy/backfill
+    // edge) is treated as a single-row group keyed by its own code.
+    const groupCode = plan.plan_group_code ?? plan.code;
+    const groupRows = await this.prisma.subscription_plans.findMany({
+      where: {
+        plan_group_code: groupCode,
+        state: { not: 'archived' },
+      },
+      orderBy: { base_price: 'asc' },
+    });
+
+    // Fallback when the group resolution returns nothing (e.g. group code only
+    // set on this row but filtered out): expose the plan itself.
+    const source = groupRows.length > 0 ? groupRows : [plan];
+
+    const pricings = source.map((row) => ({
+      id: row.id,
+      code: row.code,
+      billing_cycle: row.billing_cycle,
+      price: row.base_price,
+      currency: row.currency,
+      // The canonical CYCLE is the row whose code equals the group code (it
+      // keeps the base code; the others carry a `-${cycle}` suffix). This is
+      // independent of the global `is_default` plan flag.
+      is_default: row.code === groupCode,
+      state: row.state,
+    }));
+
+    return {
+      ...plan,
+      plan_group_code: groupCode,
+      pricings,
+    };
+  }
+
+  /**
+   * Count how many store_subscriptions reference a plan row across any of the
+   * plan-pointing columns. Used to decide archive-vs-delete when a billing
+   * cycle is removed from a group: a referenced row is never hard-deleted.
+   */
+  private async countSubscriptionRefs(
+    tx: Prisma.TransactionClient,
+    planId: number,
+  ) {
+    return tx.store_subscriptions.count({
+      where: {
+        OR: [
+          { plan_id: planId },
+          { paid_plan_id: planId },
+          { pending_plan_id: planId },
+          { scheduled_plan_id: planId },
+          { promotional_plan_id: planId },
+        ],
+      },
+    });
   }
 
   async update(id: number, dto: UpdatePlanDto) {
@@ -151,6 +324,7 @@ export class PlansService {
       }
     }
 
+    const groupCode = existing.plan_group_code ?? existing.code;
     const nextIsFree = dto.is_free ?? existing.is_free;
     const nextPlanType = this.resolvePlanType(
       dto.plan_type,
@@ -163,72 +337,212 @@ export class PlansService {
       !nextIsPromotional;
     const redemptionCode = this.normalizeRedemptionCode(dto.redemption_code);
 
-    return this.prisma.subscription_plans.update({
-      where: { id },
-      data: {
-        ...(dto.code && { code: dto.code }),
-        ...(dto.name !== undefined && { name: dto.name }),
-        ...(dto.description !== undefined && { description: dto.description }),
-        plan_type: nextPlanType as any,
-        ...(dto.state && { state: dto.state as any }),
-        ...(dto.billing_cycle && { billing_cycle: dto.billing_cycle as any }),
-        ...(nextIsFree
-          ? { base_price: 0 }
-          : dto.base_price !== undefined
-            ? { base_price: dto.base_price }
-            : {}),
-        ...(dto.currency && { currency: dto.currency }),
-        ...(nextIsFree
-          ? { setup_fee: null }
-          : dto.setup_fee !== undefined
-            ? { setup_fee: dto.setup_fee }
-            : {}),
-        ...(dto.is_free !== undefined && { is_free: dto.is_free }),
-        ...(dto.grace_period_soft_days !== undefined && {
-          grace_period_soft_days: dto.grace_period_soft_days,
-        }),
-        ...(dto.grace_period_hard_days !== undefined && {
-          grace_period_hard_days: dto.grace_period_hard_days,
-        }),
-        ...(dto.suspension_day !== undefined && {
-          suspension_day: dto.suspension_day,
-        }),
-        ...(dto.cancellation_day !== undefined && {
-          cancellation_day: dto.cancellation_day,
-        }),
-        ...(dto.feature_matrix !== undefined && {
-          feature_matrix: dto.feature_matrix as any,
-        }),
-        ...(dto.ai_feature_flags !== undefined && {
-          ai_feature_flags: dto.ai_feature_flags as any,
-        }),
-        ...(isLeavingPromotional
-          ? { resellable: true }
-          : dto.resellable !== undefined
-            ? { resellable: dto.resellable }
-            : {}),
-        ...(dto.max_partner_margin_pct !== undefined && {
-          max_partner_margin_pct: dto.max_partner_margin_pct,
-        }),
-        is_promotional: nextIsPromotional,
-        ...(redemptionCode !== undefined && {
-          redemption_code: redemptionCode,
-        }),
-        ...(dto.promo_rules !== undefined && {
-          promo_rules: dto.promo_rules as any,
-        }),
-        ...(dto.promo_priority !== undefined && {
-          promo_priority: dto.promo_priority,
-        }),
-        ...(dto.is_popular !== undefined && { is_popular: dto.is_popular }),
-        ...(dto.is_default !== undefined && { is_default: dto.is_default }),
-        ...(dto.sort_order !== undefined && { sort_order: dto.sort_order }),
-        ...(dto.parent_plan_id !== undefined && {
-          parent_plan_id: dto.parent_plan_id,
-        }),
-        updated_at: new Date(),
+    // Fields shared by every row of a multi-cycle group. Excludes per-cycle
+    // fields (code, billing_cycle, base_price, currency), the global is_default
+    // flag, and the @unique redemption_code — those are handled per row below.
+    const sharedData: Prisma.subscription_plansUpdateManyMutationInput = {
+      ...(dto.name !== undefined && { name: dto.name }),
+      ...(dto.description !== undefined && { description: dto.description }),
+      plan_type: nextPlanType as any,
+      ...(dto.state && { state: dto.state as any }),
+      ...(nextIsFree
+        ? { setup_fee: null }
+        : dto.setup_fee !== undefined
+          ? { setup_fee: dto.setup_fee }
+          : {}),
+      ...(dto.is_free !== undefined && { is_free: dto.is_free }),
+      ...(dto.grace_period_soft_days !== undefined && {
+        grace_period_soft_days: dto.grace_period_soft_days,
+      }),
+      ...(dto.grace_period_hard_days !== undefined && {
+        grace_period_hard_days: dto.grace_period_hard_days,
+      }),
+      ...(dto.suspension_day !== undefined && {
+        suspension_day: dto.suspension_day,
+      }),
+      ...(dto.cancellation_day !== undefined && {
+        cancellation_day: dto.cancellation_day,
+      }),
+      ...(dto.feature_matrix !== undefined && {
+        feature_matrix: dto.feature_matrix as any,
+      }),
+      ...(dto.ai_feature_flags !== undefined && {
+        ai_feature_flags: dto.ai_feature_flags as any,
+      }),
+      ...(isLeavingPromotional
+        ? { resellable: true }
+        : dto.resellable !== undefined
+          ? { resellable: dto.resellable }
+          : {}),
+      ...(dto.max_partner_margin_pct !== undefined && {
+        max_partner_margin_pct: dto.max_partner_margin_pct,
+      }),
+      is_promotional: nextIsPromotional,
+      ...(dto.promo_rules !== undefined && {
+        promo_rules: dto.promo_rules as any,
+      }),
+      ...(dto.promo_priority !== undefined && {
+        promo_priority: dto.promo_priority,
+      }),
+      ...(dto.is_popular !== undefined && { is_popular: dto.is_popular }),
+      ...(dto.sort_order !== undefined && { sort_order: dto.sort_order }),
+      ...(dto.parent_plan_id !== undefined && {
+        parent_plan_id: dto.parent_plan_id,
+      }),
+      ...(dto.details_md !== undefined && { details_md: dto.details_md }),
+      updated_at: new Date(),
+    };
+
+    return this.prisma.$transaction(
+      async (tx) => {
+        // 1. Propagate shared fields to every non-archived row of the group.
+        await tx.subscription_plans.updateMany({
+          where: { plan_group_code: groupCode, state: { not: 'archived' } },
+          data: sharedData,
+        });
+
+        // 2. Per-cycle reconciliation when the caller sends a pricings array.
+        if (Array.isArray(dto.pricings)) {
+          const groupRows = await tx.subscription_plans.findMany({
+            where: { plan_group_code: groupCode, state: { not: 'archived' } },
+          });
+          const wantedCycles = new Set(
+            dto.pricings.map((p) => p.billing_cycle),
+          );
+
+          // 2a. Upsert each requested cycle.
+          for (const pricing of dto.pricings) {
+            const price = nextIsFree ? 0 : pricing.price;
+            const currency = pricing.currency || existing.currency || 'COP';
+            const row = groupRows.find(
+              (r) => r.billing_cycle === (pricing.billing_cycle as any),
+            );
+
+            if (row) {
+              await tx.subscription_plans.update({
+                where: { id: row.id },
+                data: { base_price: price, currency, updated_at: new Date() },
+              });
+            } else {
+              // New cycle: always non-canonical (the canonical row keeps the
+              // group code and is never recreated here).
+              const code = this.deriveCycleCode(
+                groupCode,
+                pricing.billing_cycle,
+              );
+              const conflict = await tx.subscription_plans.findUnique({
+                where: { code },
+              });
+              if (conflict) {
+                throw new VendixHttpException(
+                  ErrorCodes.SYS_CONFLICT_001,
+                  `Plan code '${code}' already exists`,
+                );
+              }
+              await tx.subscription_plans.create({
+                data: {
+                  name: dto.name ?? existing.name,
+                  description:
+                    dto.description !== undefined
+                      ? dto.description
+                      : existing.description,
+                  plan_type: nextPlanType as any,
+                  state: (dto.state as any) ?? existing.state,
+                  billing_cycle: pricing.billing_cycle as any,
+                  base_price: price,
+                  currency,
+                  setup_fee: nextIsFree
+                    ? null
+                    : (dto.setup_fee ?? existing.setup_fee),
+                  is_free: nextIsFree,
+                  grace_period_soft_days:
+                    dto.grace_period_soft_days ??
+                    existing.grace_period_soft_days,
+                  grace_period_hard_days:
+                    dto.grace_period_hard_days ??
+                    existing.grace_period_hard_days,
+                  suspension_day: dto.suspension_day ?? existing.suspension_day,
+                  cancellation_day:
+                    dto.cancellation_day ?? existing.cancellation_day,
+                  feature_matrix: (dto.feature_matrix ??
+                    existing.feature_matrix) as any,
+                  ai_feature_flags: (dto.ai_feature_flags ??
+                    existing.ai_feature_flags) as any,
+                  resellable: dto.resellable ?? existing.resellable,
+                  max_partner_margin_pct:
+                    dto.max_partner_margin_pct ??
+                    existing.max_partner_margin_pct,
+                  is_promotional: nextIsPromotional,
+                  promo_rules: (dto.promo_rules ?? existing.promo_rules) as any,
+                  promo_priority: dto.promo_priority ?? existing.promo_priority,
+                  is_popular: dto.is_popular ?? existing.is_popular,
+                  sort_order: dto.sort_order ?? existing.sort_order,
+                  parent_plan_id: dto.parent_plan_id ?? existing.parent_plan_id,
+                  details_md:
+                    dto.details_md !== undefined
+                      ? dto.details_md
+                      : existing.details_md,
+                  plan_group_code: groupCode,
+                  is_default: false,
+                  redemption_code: null,
+                  updated_at: new Date(),
+                },
+              });
+            }
+          }
+
+          // 2b. Cycles removed from the group: archive if referenced by any
+          //     subscription, otherwise hard-delete. NEVER delete a referenced
+          //     row (global rule 6 — no silent data loss).
+          for (const row of groupRows) {
+            if (wantedCycles.has(row.billing_cycle)) continue;
+            const refs = await this.countSubscriptionRefs(tx, row.id);
+            if (refs > 0) {
+              await tx.subscription_plans.update({
+                where: { id: row.id },
+                data: {
+                  state: 'archived',
+                  archived_at: new Date(),
+                  updated_at: new Date(),
+                },
+              });
+            } else {
+              await tx.subscription_plans.delete({ where: { id: row.id } });
+            }
+          }
+        } else {
+          // Legacy single-row path: per-cycle fields apply to the target row.
+          await tx.subscription_plans.update({
+            where: { id },
+            data: {
+              ...(dto.code && { code: dto.code }),
+              ...(dto.billing_cycle && {
+                billing_cycle: dto.billing_cycle as any,
+              }),
+              ...(nextIsFree
+                ? { base_price: 0 }
+                : dto.base_price !== undefined
+                  ? { base_price: dto.base_price }
+                  : {}),
+              ...(dto.currency && { currency: dto.currency }),
+              ...(dto.is_default !== undefined && {
+                is_default: dto.is_default,
+              }),
+              ...(redemptionCode !== undefined && {
+                redemption_code: redemptionCode,
+              }),
+              updated_at: new Date(),
+            },
+          });
+        }
+
+        return tx.subscription_plans.findMany({
+          where: { plan_group_code: groupCode },
+          orderBy: { base_price: 'asc' },
+        });
       },
-    });
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+    );
   }
 
   async archive(id: number) {

--- a/apps/frontend/src/app/private/modules/store/subscription/interfaces/store-subscription.interface.ts
+++ b/apps/frontend/src/app/private/modules/store/subscription/interfaces/store-subscription.interface.ts
@@ -17,6 +17,12 @@ export interface SubscriptionPlan {
    */
   is_free?: boolean;
   sort_order: number;
+  /**
+   * Rich plan details authored in Markdown by super-admin. Rendered as
+   * sanitized HTML in the store checkout below the plan details section.
+   * Optional + defensive: plans created before multi-cycle shipped omit it.
+   */
+  details_md?: string;
 }
 
 export interface PlanFeature {

--- a/apps/frontend/src/app/private/modules/store/subscription/pages/checkout/checkout.component.ts
+++ b/apps/frontend/src/app/private/modules/store/subscription/pages/checkout/checkout.component.ts
@@ -18,6 +18,7 @@ import {
   WompiWidgetConfig,
 } from '../../../../../../core/services/wompi-checkout.service';
 import { extractApiErrorMessage } from '../../../../../../core/utils/api-error-handler';
+import { markdownToHtml } from '../../../../../../shared/utils/markdown.util';
 
 // S2.1 — Map backend coupon validation `reason` codes to user-facing
 // Spanish copy. Kept inline (rather than i18n keys) to match the existing
@@ -242,6 +243,18 @@ const COUPON_REASON_COPY: Record<string, string> = {
                     }
                   </div>
                 </div>
+
+                <!-- Detalles enriquecidos del plan (Markdown del super-admin).
+                     Se renderiza el STRING HTML directamente con [innerHTML];
+                     Angular lo sanitiza automáticamente. No usar
+                     bypassSecurityTrustHtml. -->
+                @if (detailsHtml(); as html) {
+                  <div
+                    class="prose prose-sm max-w-none markdown-preview text-sm text-text-primary"
+                    [innerHTML]="html"
+                  ></div>
+                }
+
                 <div class="border-t border-border"></div>
               }
 
@@ -584,6 +597,15 @@ export class CheckoutComponent implements OnInit {
       if (code === null && !this.preview()) return;
       this.loadPreview(planId, code ?? undefined);
     }
+  });
+
+  // Rich plan details (Markdown → HTML string). We return a plain string and
+  // bind it with [innerHTML]; Angular's default sanitizer strips unsafe
+  // markup. Do NOT wrap this in DomSanitizer.bypassSecurityTrustHtml — that
+  // would disable sanitization and open an XSS vector on admin-authored copy.
+  readonly detailsHtml = computed<string>(() => {
+    const md = this.selectedPlan()?.details_md ?? '';
+    return md.trim() ? markdownToHtml(md) : '';
   });
 
   readonly freePlan = computed(() => this.preview()?.free_plan ?? null);

--- a/apps/frontend/src/app/private/modules/super-admin/subscriptions/interfaces/subscription-admin.interface.ts
+++ b/apps/frontend/src/app/private/modules/super-admin/subscriptions/interfaces/subscription-admin.interface.ts
@@ -81,6 +81,12 @@ export interface SubscriptionPlan {
   updated_at: string;
   archived_at: string | null;
 
+  // Multi-cycle pricing + rich details (server-authoritative)
+  details_md?: string;
+  plan_group_code?: string;
+  // All pricing rows of the plan group, returned by GET plans/:id
+  pricings?: PlanPricing[];
+
   // Derived helpers (kept for legacy consumers like plan-card / plans table)
   slug: string;            // alias of code
   is_active: boolean;      // state === 'active'

--- a/apps/frontend/src/app/private/modules/super-admin/subscriptions/pages/plans/plan-form.component.ts
+++ b/apps/frontend/src/app/private/modules/super-admin/subscriptions/pages/plans/plan-form.component.ts
@@ -29,6 +29,7 @@ import {
 import { AiFeatureMatrixComponent } from '../../components/ai-feature-matrix.component';
 import { PricingCycleEditorComponent } from '../../components/pricing-cycle-editor.component';
 import { GraceThresholdEditorComponent } from '../../components/grace-threshold-editor.component';
+import { MarkdownEditorComponent } from '../../../../../../shared/components/markdown-editor/markdown-editor.component';
 import { ToastService } from '../../../../../../shared/components/toast/toast.service';
 import { AIEngineService } from '../../../ai-engine/services/ai-engine.service';
 
@@ -74,6 +75,7 @@ interface PlanFormControls {
     AiFeatureMatrixComponent,
     PricingCycleEditorComponent,
     GraceThresholdEditorComponent,
+    MarkdownEditorComponent,
   ],
   template: `
     <div class="flex flex-col">
@@ -144,6 +146,23 @@ interface PlanFormControls {
                 [required]="true"
               ></app-selector>
             </div>
+          </div>
+
+          <!-- Detalles enriquecidos (markdown) -->
+          <div class="bg-surface rounded-card border border-border p-4 md:p-6 space-y-4">
+            <div class="space-y-1">
+              <h2 class="text-sm font-semibold text-text-primary uppercase tracking-wide">
+                Detalles del plan
+              </h2>
+              <p class="text-sm text-text-secondary">
+                Contenido enriquecido en Markdown que se muestra en el checkout de la tienda, debajo
+                de los detalles del plan. Ideal para describir beneficios, condiciones o comparativas.
+              </p>
+            </div>
+            <app-markdown-editor
+              [content]="detailsMd()"
+              (contentChange)="onDetailsMdChange($event)"
+            ></app-markdown-editor>
           </div>
 
           <!-- Partner -->
@@ -372,6 +391,7 @@ export class PlanFormComponent {
   readonly isFreePlan = signal(false);
   readonly aiFeatures = signal<AIFeatureFlags | undefined>(this.defaultAiFeatures());
   readonly pricing = signal<PlanPricing[] | undefined>(undefined);
+  readonly detailsMd = signal<string>('');
   readonly graceDays = signal<number | undefined>(undefined);
   readonly systemAiModels = signal<string[]>([]);
   private readonly paidPricingBeforeFree = signal<PlanPricing[] | undefined>(undefined);
@@ -686,11 +706,16 @@ export class PlanFormComponent {
         } else {
           this.form.controls.setup_fee.enable({ emitEvent: false });
         }
+        // Rehidratar TODOS los ciclos del grupo. El backend devuelve el grupo
+        // completo en `plan.pricings`; usamos eso como fuente y caemos a
+        // `plan.pricing` (legacy/derivado) solo si no llega el array.
+        const rehydratedPricing = (plan.pricings?.length ? plan.pricings : plan.pricing) ?? [];
         this.pricing.set(
           plan.is_free
-            ? plan.pricing.map((item) => ({ ...item, price: 0 }))
-            : plan.pricing,
+            ? rehydratedPricing.map((item) => ({ ...item, price: 0 }))
+            : rehydratedPricing,
         );
+        this.detailsMd.set(plan.details_md ?? '');
         this.graceDays.set(plan.grace_period_soft_days ?? plan.grace_threshold_days ?? 0);
       },
     });
@@ -702,6 +727,10 @@ export class PlanFormComponent {
 
   onPricingChange(pricing: PlanPricing[]): void {
     this.pricing.set(pricing);
+  }
+
+  onDetailsMdChange(value: string): void {
+    this.detailsMd.set(value ?? '');
   }
 
   onGraceChange(days: number): void {
@@ -746,11 +775,27 @@ export class PlanFormComponent {
     const raw = this.form.getRawValue();
     const isFree = Boolean(raw.is_free);
 
+    // Array completo de ciclos mapeado al contrato API
+    // ({ billing_cycle, price, currency, is_default }). En planes gratuitos el
+    // importe efectivo de cada ciclo se fuerza a 0.
+    const pricings = pricing.map((p) => ({
+      billing_cycle: p.billing_cycle,
+      price: isFree ? 0 : Number(p.price ?? 0),
+      currency: p.currency_code ?? 'COP',
+      is_default: Boolean(p.is_default),
+    }));
+
+    const detailsMd = this.detailsMd().trim();
+
     const payload: Record<string, any> = {
       ...raw,
+      // Campos canónicos derivados del ciclo default (back-compat)
       base_price: isFree ? 0 : Number(pricingFirst.price ?? 0),
       currency: pricingFirst.currency_code ?? 'COP',
       billing_cycle: pricingFirst.billing_cycle ?? 'monthly',
+      // Array completo de ciclos (multi-cycle)
+      pricings,
+      details_md: detailsMd || null,
       setup_fee: isFree ? null : raw.setup_fee,
       is_free: isFree,
       redemption_code: raw.redemption_code.trim() || null,

--- a/apps/frontend/src/app/private/modules/super-admin/subscriptions/services/subscription-admin.service.ts
+++ b/apps/frontend/src/app/private/modules/super-admin/subscriptions/services/subscription-admin.service.ts
@@ -145,6 +145,28 @@ export class SubscriptionAdminService {
     const currency = raw.currency ?? 'COP';
     const grace_period_soft_days = Number(raw.grace_period_soft_days ?? 0);
 
+    // Multi-cycle: GET plans/:id returns the full group as `pricings[]`. The
+    // backend rows expose `currency` (not `currency_code`), so normalize the
+    // shape into the FE `PlanPricing` contract. Falls back to the synthesized
+    // single-cycle row (from base_price) for list endpoints that omit it.
+    const mappedPricings: PlanPricing[] = Array.isArray(raw.pricings) && raw.pricings.length
+      ? raw.pricings.map((p: any) => ({
+          id: String(p.id ?? `${raw.id}-${this.normalizeBillingCycle(p.billing_cycle)}`),
+          billing_cycle: this.normalizeBillingCycle(p.billing_cycle) as PlanPricing['billing_cycle'],
+          price: this.toNumberOrZero(p.price),
+          currency_code: p.currency ?? p.currency_code ?? currency,
+          is_default: Boolean(p.is_default),
+        }))
+      : [
+          {
+            id: `${raw.id}-${billing_cycle}`,
+            billing_cycle: billing_cycle as PlanPricing['billing_cycle'],
+            price: base_price,
+            currency_code: currency,
+            is_default: true,
+          },
+        ];
+
     return {
       id: String(raw.id),
       code: raw.code ?? '',
@@ -185,19 +207,16 @@ export class SubscriptionAdminService {
       updated_at: raw.updated_at,
       archived_at: raw.archived_at ?? null,
 
+      // Multi-cycle + rich details
+      details_md: raw.details_md ?? undefined,
+      plan_group_code: raw.plan_group_code ?? undefined,
+      pricings: mappedPricings,
+
       // Derived legacy
       slug: raw.code ?? '',
       is_active: raw.state === 'active',
       is_public: Boolean(raw.resellable),
-      pricing: [
-        {
-          id: `${raw.id}-${billing_cycle}`,
-          billing_cycle: (billing_cycle as PlanPricing['billing_cycle']),
-          price: base_price,
-          currency_code: currency,
-          is_default: true,
-        },
-      ],
+      pricing: mappedPricings,
       grace_threshold_days: grace_period_soft_days,
     };
   }


### PR DESCRIPTION
## Resumen

Los planes de suscripción ahora pueden ofrecer **varios ciclos de facturación** (mensual/anual/…) gestionados como un grupo, más un campo **markdown de detalles** que se renderiza en el checkout debajo de los detalles del plan.

Diseño **aditivo y backward-compatible**: los planes legacy de un solo ciclo siguen funcionando (su `plan_group_code` se rellena con su propio `code`).

### Contexto
En prod, `Emprendedor Pro` y `Empresarial Pro` solo existían en ciclo anual: la tienda no mostraba el ciclo mensual. La causa era doble — faltaban las filas mensuales **y** el formulario super-admin aplanaba los ciclos al guardar (enviaba un `billing_cycle` escalar). El backend solo creaba una fila por request.

### Cambios
**Backend**
- `schema.prisma`: `plan_group_code` (nullable, indexado) y `details_md` (text).
- `plan.dto.ts`: `PlanPricingDto`, `pricings[]`, `plan_group_code`, `details_md`.
- `plans.service.ts`:
  - `create` multi-ciclo: una fila por ciclo en transacción `Serializable`, compartiendo `plan_group_code`; la default conserva el `code`, las demás `${code}-${cycle}`.
  - `update`: propaga campos compartidos al grupo, hace upsert por ciclo y **archiva (nunca borra)** filas-ciclo referenciadas por `store_subscriptions`.
  - `findOne`: devuelve los `pricings` del grupo.
  - Desacopla el ciclo canónico (`code === plan_group_code`) del flag global `is_default` (protegido por índice único parcial).

**Frontend**
- `plan-form`: envía y rehidrata **todos** los ciclos (`pricings[]`) + editor markdown (reúsa `MarkdownEditorComponent`). Corrige la causa raíz del bug.
- `checkout`: renderiza el markdown del plan con `[innerHTML]` sanitizado por Angular (sin `bypassSecurityTrustHtml`).
- Interfaces store/admin actualizadas.

### Verificación
- `npm run build -w apps/backend` ✅
- `npm run build:prod -w apps/frontend` ✅
- Migración aplicada en dev + buildcheck Docker: backend levanta sin errores con cliente Prisma regenerado, `GET /api/public/plans` responde OK, backfill confirmado (todas las filas con `plan_group_code`).

## ⚠️ DATABASE MIGRATION
> **ATENCIÓN**: este PR requiere correr migraciones antes del deploy. Tras `migrate deploy`, regenerar el cliente Prisma **dentro del container** y reiniciar el backend.

\`\`\`sql
ALTER TABLE subscription_plans ADD COLUMN IF NOT EXISTS plan_group_code varchar(64);
ALTER TABLE subscription_plans ADD COLUMN IF NOT EXISTS details_md text;
CREATE INDEX IF NOT EXISTS subscription_plans_plan_group_code_idx ON subscription_plans(plan_group_code);
UPDATE subscription_plans SET plan_group_code = code WHERE plan_group_code IS NULL;
\`\`\`

## Post-deploy
Agregar el ciclo mensual + precio a `Emprendedor Pro` y `Empresarial Pro` desde el formulario super-admin corregido (sin inserción de datos por migración).