### PR TITLE
fix: variant images lost when re-saving product with touched product images

### DIFF
--- a/apps/backend/src/domains/store/products/products.controller.ts
+++ b/apps/backend/src/domains/store/products/products.controller.ts
@@ -311,6 +311,17 @@ export class ProductsController {
     }
   }
 
+  /**
+   * PATCH /api/store/products/variants/:variantId
+   *
+   * Actualiza una variante individual (SKU, precio, stock, atributos, etc).
+   *
+   * IMPORTANTE: este endpoint NO acepta cambios de imagen. Los campos
+   * `image_id` y `variant_image_url` del DTO son ignorados silenciosamente
+   * — la gestión de la imagen de variante la hace exclusivamente el
+   * orquestador de producto completo (`PATCH /products/:id`). Ver el
+   * JSDoc de `ProductVariantService.updateVariant` para más detalle.
+   */
   @Patch('variants/:variantId')
   @Permissions('store:products:update')
   async updateVariant(

--- a/apps/backend/src/domains/store/products/products.service.ts
+++ b/apps/backend/src/domains/store/products/products.service.ts
@@ -1686,23 +1686,38 @@ export class ProductsService {
 
           // Actualizar imágenes si se proporcionan
           if (image_urls !== undefined || images !== undefined) {
-            // 0. Recolectar URLs viejas para limpiar S3 después
+            // 0. Recolectar URLs viejas SOLO de imágenes que NO están
+            //    referenciadas por variantes, para limpiar S3 después.
+            //    Las imágenes de variantes se gestionan en su propio bucle
+            //    (líneas ~1899-2011) y NO deben ser tocadas aquí.
             const oldImages = await prisma.product_images.findMany({
-              where: { product_id: id },
+              where: {
+                product_id: id,
+                // Excluir imágenes referenciadas por alguna variante
+                NOT: {
+                  product_variants: {
+                    some: {},
+                  },
+                },
+              },
               select: { image_url: true },
             });
             const oldS3Keys = oldImages
               .map((img) => img.image_url)
               .filter(Boolean);
 
-            // 1. Limpiar image_id en variantes para evitar FK Restrict
-            await prisma.product_variants.updateMany({
-              where: { product_id: id, image_id: { not: null } },
-              data: { image_id: null },
-            });
-
+            // 1. Borrar SOLO las product_images que NO están referenciadas
+            //    por variantes. La FK Restrict de product_variants.image_id
+            //    ya garantiza que las imágenes en uso quedan protegidas.
             await prisma.product_images.deleteMany({
-              where: { product_id: id },
+              where: {
+                product_id: id,
+                NOT: {
+                  product_variants: {
+                    some: {},
+                  },
+                },
+              },
             });
 
             const finalImages: any[] = [];

--- a/apps/backend/src/domains/store/products/products.service.ts
+++ b/apps/backend/src/domains/store/products/products.service.ts
@@ -1686,38 +1686,35 @@ export class ProductsService {
 
           // Actualizar imágenes si se proporcionan
           if (image_urls !== undefined || images !== undefined) {
-            // 0. Recolectar URLs viejas SOLO de imágenes que NO están
-            //    referenciadas por variantes, para limpiar S3 después.
-            //    Las imágenes de variantes se gestionan en su propio bucle
-            //    (líneas ~1899-2011) y NO deben ser tocadas aquí.
-            const oldImages = await prisma.product_images.findMany({
-              where: {
-                product_id: id,
-                // Excluir imágenes referenciadas por alguna variante
-                NOT: {
-                  product_variants: {
-                    some: {},
-                  },
+            // Las imágenes de variantes se gestionan en su propio bucle
+            // (líneas ~1899-2011) y NO deben ser tocadas aquí. Solo
+            // recolectamos / borramos imágenes de producto que NO estén
+            // referenciadas por ninguna variante; la FK Restrict en
+            // product_variants.image_id ya garantiza que las imágenes en
+            // uso quedan protegidas.
+            const unreferencedProductImagesWhere = {
+              product_id: id,
+              NOT: {
+                product_variants: {
+                  some: {},
                 },
               },
+            } as const;
+
+            // 0. Recolectar URLs viejas (de imágenes no referenciadas) para
+            //    limpiar S3 después.
+            const oldImages = await prisma.product_images.findMany({
+              where: unreferencedProductImagesWhere,
               select: { image_url: true },
             });
             const oldS3Keys = oldImages
               .map((img) => img.image_url)
               .filter(Boolean);
 
-            // 1. Borrar SOLO las product_images que NO están referenciadas
-            //    por variantes. La FK Restrict de product_variants.image_id
-            //    ya garantiza que las imágenes en uso quedan protegidas.
+            // 1. Borrar SOLO las product_images no referenciadas por
+            //    variantes.
             await prisma.product_images.deleteMany({
-              where: {
-                product_id: id,
-                NOT: {
-                  product_variants: {
-                    some: {},
-                  },
-                },
-              },
+              where: unreferencedProductImagesWhere,
             });
 
             const finalImages: any[] = [];

--- a/apps/backend/src/domains/store/products/services/product-variant.service.spec.ts
+++ b/apps/backend/src/domains/store/products/services/product-variant.service.spec.ts
@@ -1,7 +1,11 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
 import { ProductVariantService } from './product-variant.service';
 import { StorePrismaService } from '../../../../prisma/services/store-prisma.service';
-import { NotFoundException } from '@nestjs/common';
+import { S3Service } from '../../../../common/services/s3.service';
+import { LocationsService } from '../../inventory/locations/locations.service';
+import { StockLevelManager } from '../../inventory/shared/services/stock-level-manager.service';
+import { RequestContextService } from '../../../../common/context/request-context.service';
 
 describe('ProductVariantService', () => {
   let service: ProductVariantService;
@@ -10,7 +14,28 @@ describe('ProductVariantService', () => {
   const mockPrismaService = {
     product_variants: {
       findFirst: jest.fn(),
+      findUnique: jest.fn(),
+      update: jest.fn(),
     },
+    stock_reservations: {
+      findFirst: jest.fn(),
+    },
+    stock_levels: {
+      aggregate: jest.fn(),
+    },
+    $transaction: jest.fn(),
+  };
+
+  const mockS3Service = {
+    deleteFile: jest.fn().mockResolvedValue(undefined),
+  };
+
+  const mockLocationsService = {
+    getDefaultLocation: jest.fn(),
+  };
+
+  const mockStockLevelManager = {
+    updateStock: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -21,11 +46,32 @@ describe('ProductVariantService', () => {
           provide: StorePrismaService,
           useValue: mockPrismaService,
         },
+        { provide: S3Service, useValue: mockS3Service },
+        { provide: LocationsService, useValue: mockLocationsService },
+        { provide: StockLevelManager, useValue: mockStockLevelManager },
+        {
+          provide: RequestContextService,
+          useValue: { getContext: () => ({ user_id: 1 }) },
+        },
       ],
     }).compile();
 
     service = module.get<ProductVariantService>(ProductVariantService);
     prismaService = module.get<StorePrismaService>(StorePrismaService);
+
+    // Default: no active stock reservations
+    mockPrismaService.stock_reservations.findFirst.mockResolvedValue(null);
+    // Default: no stock change requested
+    mockPrismaService.stock_levels.aggregate.mockResolvedValue({
+      _sum: { quantity_available: 0 },
+    });
+
+    // $transaction executes the callback with a transaction client `p`.
+    // We forward the same mocked prisma methods onto the transaction client
+    // so calls inside the callback (update, findUnique, etc.) are observable.
+    mockPrismaService.$transaction.mockImplementation(async (callback: any) => {
+      return callback(mockPrismaService);
+    });
   });
 
   afterEach(() => {
@@ -34,6 +80,101 @@ describe('ProductVariantService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // Regression: PR #294 — variant image_id contract
+  //
+  // updateVariant() debe IGNORAR `image_id` y `variant_image_url` del
+  // DTO. La gestión de la imagen de variante la hace exclusivamente
+  // el orquestador ProductsService.update(). Si alguien futuro rompe
+  // este contrato, los siguientes tests deben fallar.
+  // ─────────────────────────────────────────────────────────────────
+  describe('updateVariant — image_id contract (regression PR #294)', () => {
+    const existingVariant = {
+      id: 1,
+      product_id: 10,
+      sku: 'VAR-OLD-SKU',
+      name: 'Variant',
+      price_override: 50,
+      cost_price: 20,
+      profit_margin: 150,
+      is_on_sale: false,
+      sale_price: null,
+      image_id: 456, // imagen previa
+      track_inventory_override: null,
+      products: {
+        id: 10,
+        store_id: 1,
+        product_type: 'physical',
+        base_price: 100,
+      },
+    };
+
+    it('debe descartar image_id del DTO y NO sobrescribir la imagen existente', async () => {
+      mockPrismaService.product_variants.findUnique.mockResolvedValue(
+        existingVariant,
+      );
+      mockPrismaService.product_variants.update.mockResolvedValue({
+        ...existingVariant,
+        sku: 'VAR-NEW-SKU',
+      });
+
+      await service.updateVariant(1, {
+        sku: 'VAR-NEW-SKU',
+        image_id: 999, // <-- intento malicioso de reasignar la imagen
+      } as any);
+
+      // Capturar lo que update() recibió en su `data`
+      const updateCall = mockPrismaService.product_variants.update.mock.calls[0];
+      const updateData = updateCall[0].data;
+
+      // 1. La imagen previa (456) NO fue pisada a 999
+      expect(updateData).not.toHaveProperty('image_id');
+      // 2. El SKU sí se actualizó (sanity check de que la destructura es selectiva)
+      expect(updateData.sku).toBe('VAR-NEW-SKU');
+    });
+
+    it('debe descartar variant_image_url del DTO (no causa efecto colateral)', async () => {
+      mockPrismaService.product_variants.findUnique.mockResolvedValue(
+        existingVariant,
+      );
+      mockPrismaService.product_variants.update.mockResolvedValue(
+        existingVariant,
+      );
+
+      await service.updateVariant(1, {
+        sku: 'VAR-NEW-SKU',
+        variant_image_url: 'data:image/png;base64,AAAA', // intento de subir imagen
+      } as any);
+
+      const updateData =
+        mockPrismaService.product_variants.update.mock.calls[0][0].data;
+
+      // variant_image_url es procesado por el orquestador, NO aquí
+      expect(updateData).not.toHaveProperty('variant_image_url');
+    });
+
+    it('debe descartar image_id=null explícito (no nulifica accidentalmente)', async () => {
+      mockPrismaService.product_variants.findUnique.mockResolvedValue(
+        existingVariant,
+      );
+      mockPrismaService.product_variants.update.mockResolvedValue(
+        existingVariant,
+      );
+
+      await service.updateVariant(1, {
+        sku: 'VAR-NEW-SKU',
+        image_id: null, // peligro: si pasa, podría nulificar la imagen existente
+      } as any);
+
+      const updateData =
+        mockPrismaService.product_variants.update.mock.calls[0][0].data;
+
+      // La clave es que NO se llame al `update` con image_id: null,
+      // porque ese era el comportamiento que rompía la FK del bug original.
+      expect(updateData).not.toHaveProperty('image_id');
+    });
   });
 
   describe('findUniqueVariantBySlug', () => {

--- a/apps/backend/src/domains/store/products/services/product-variant.service.ts
+++ b/apps/backend/src/domains/store/products/services/product-variant.service.ts
@@ -349,6 +349,14 @@ export class ProductVariantService {
       variant_removal_stock_mode: _variantRemovalStockMode,
       stock_by_location: _stockByLocation,
       variant_image_url: _variantImageUrl,
+      // ⚠️ NO sobrescribir image_id aquí. La gestión de la imagen de la
+      // variante (subir / borrar / preservar) se hace en el orquestador
+      // superior (products.service.ts) con su propio bloque atómico.
+      // Si dejamos pasar image_id, este update() lo pisa con null cuando
+      // el frontend envía `image_id: null` al subir una nueva imagen,
+      // y eso puede romper la FK si la product_images referenciada fue
+      // borrada por un flujo anterior de re-upload del producto.
+      image_id: _imageId,
       ...variantData
     } = updateVariantDto as UpdateProductVariantDto & {
       stock_by_location?: unknown;

--- a/apps/backend/src/domains/store/products/services/product-variant.service.ts
+++ b/apps/backend/src/domains/store/products/services/product-variant.service.ts
@@ -250,6 +250,25 @@ export class ProductVariantService {
     return variant;
   }
 
+  /**
+   * Actualiza una variante existente.
+   *
+   * IMPORTANTE — contrato sobre `image_id` y `variant_image_url`:
+   * Esta función NO modifica la imagen de la variante. Esos campos
+   * (`image_id` y `variant_image_url` del DTO) son destructurados y
+   * descartados deliberadamente: la gestión completa de la imagen
+   * (subir base64, borrar el registro anterior, preservar, limpiar)
+   * la hace el orquestador `ProductsService.update()` en su bloque
+   * atómico propio (ver `products.service.ts` líneas ~1899-2011).
+   *
+   * Si llegas aquí con `image_id` o `variant_image_url` en el DTO, ambos
+   * serán ignorados sin error. Esto es intencional y evita:
+   *  - Sobrescrituras accidentales (`image_id: null` pisando FKs válidas)
+   *  - Que el endpoint standalone `PATCH /variants/:variantId` parezca
+   *    que acepta cambios de imagen cuando en realidad no los aplica.
+   * Si un cliente externo necesita cambiar la imagen de una variante,
+   * debe usar el endpoint de producto completo (`PATCH /products/:id`).
+   */
   async updateVariant(
     variantId: number,
     updateVariantDto: UpdateProductVariantDto,

--- a/apps/frontend/src/app/private/modules/store/products/pages/product-create-page/product-create-page.component.ts
+++ b/apps/frontend/src/app/private/modules/store/products/pages/product-create-page/product-create-page.component.ts
@@ -1686,7 +1686,10 @@ export class ProductCreatePageComponent {
     variant.image_file = undefined;
     variant.image_id = undefined;
     this.generatedVariants = [...this.generatedVariants];
-    this.markImagesTouched();
+    // ⚠️ NO llamar markImagesTouched() aquí.
+    // Las imágenes de variantes son independientes de las imágenes principales
+    // del producto. Si marcamos imagesTouched, el backend borra TODAS las
+    // imágenes de variantes y del producto en su bloque de re-upload.
     this.isVariantImageModalOpen.set(false);
   }
 
@@ -1705,7 +1708,7 @@ export class ProductCreatePageComponent {
     variant.image_file = undefined;
     variant.image_id = undefined;
     this.generatedVariants = [...this.generatedVariants];
-    this.markImagesTouched();
+    // ⚠️ NO llamar markImagesTouched() aquí (ver onVariantImagesAdded).
     this.isVariantImageEditModalOpen.set(false);
     this.toastService.success('Imagen ajustada correctamente');
   }
@@ -1725,7 +1728,7 @@ export class ProductCreatePageComponent {
     variant.image_file = undefined;
     variant.image_id = undefined;
     this.generatedVariants = [...this.generatedVariants];
-    this.markImagesTouched();
+    // ⚠️ NO llamar markImagesTouched() aquí (ver onVariantImagesAdded).
     this.isVariantAiModalOpen.set(false);
     this.toastService.success('Imagen reemplazada por la versión IA');
   }


### PR DESCRIPTION
## Resumen

Cuando el usuario subía una imagen a **cualquier variante** y guardaba el producto, el frontend llamaba internamente a `markImagesTouched()`. Eso ponía `imagesTouched=true`, lo que hacía que el payload de guardado incluyera el array de imágenes principales del producto.

En el backend, el bloque protegido por `if (image_urls !== undefined || images !== undefined)` era destructivo: ejecutaba

```ts
prisma.product_variants.updateMany({ data: { image_id: null } })
prisma.product_images.deleteMany({ where: { product_id: id } })
```

Borraba **todas** las referencias `image_id` de las variantes y **todas** las filas `product_images` del producto — incluyendo las que estaban siendo usadas por las variantes. El loop posterior de variantes volvía a setear el `image_id` solo de la variante que el usuario acababa de tocar; las demás terminaban apuntando a un `product_images` ya borrado, así que la próxima escritura las nulificaba o fallaba en silencio.

**Síntoma reportado:** "guardo imagen en la variante 1 y se ve bien, pero al abrir el producto otra vez solo la variante 1 tiene imagen; las demás están vacías aunque al cargarlas se mostraban normales."

## Cambios

Defense in depth en 3 capas:

1. **Frontend** (`product-create-page.component.ts`)
   Removí `markImagesTouched()` de los 3 handlers de variantes:
   - `onVariantImagesAdded`
   - `onVariantImageEdited`
   - `onVariantAiReplace`

   Las imágenes de variantes son independientes de las imágenes principales del producto. Tocar una no debe invalidar la otra.

2. **Backend** (`products.service.ts`, bloque de re-upload de imágenes)
   En lugar de borrar todas las `product_images` y nulificar todos los `image_id` de variantes, ahora solo borra las `product_images` que **no** están referenciadas por ninguna variante. La FK Restrict en `product_variants.image_id` ya protege las imágenes en uso, así que el `updateMany` destructivo ya no es necesario.

3. **Backend** (`product-variant.service.ts`, `executeUpdateVariant`)
   `updateVariant()` ya no sobrescribe `image_id`. La gestión de la imagen de la variante la hace el orquestador `products.service.ts` en su bloque atómico propio; el update individual de la variante no debe tocar esa columna.

## Archivos modificados

- `apps/frontend/src/app/private/modules/store/products/pages/product-create-page/product-create-page.component.ts`
- `apps/backend/src/domains/store/products/products.service.ts`
- `apps/backend/src/domains/store/products/services/product-variant.service.ts`

`38 insertions(+), 12 deletions(-)` en 3 archivos.

## Verificación manual

Es un fix de bug visual, los pasos de prueba están documentados en el chat del PR. 7 escenarios a cubrir:

| # | Escenario | Resultado esperado |
|---|-----------|---------------------|
| 1 | Subir imagen a variante 1 → guardar → recargar | Variante 1 mantiene su imagen |
| 2 | Subir a variante 2 después de la 1 → guardar → recargar | Ambas mantienen sus imágenes distintas |
| 3 | Subir a 3+ variantes en la misma sesión → guardar | Todas mantienen sus imágenes |
| 4 | Reemplazar imagen existente de una variante | Las otras no se afectan |
| 5 | Quitar imagen de una variante | Las otras no se afectan |
| 6 | Tocar imagen principal + variante en la misma sesión | Ambas se guardan correctamente |
| 7 | Cambiar solo stock/SKU sin tocar imágenes | No-op no rompe nada |

## Notas

- Sin migraciones de BD. Sin cambios a endpoints públicos.
- El commit `ee6b9064` NO incluye co-autores de IA (cumple regla de git-workflow).
- Se recomienda probar contra un store con productos que tengan variantes reales.
