### PR TITLE
fix(productos): persistir cambios de estado con cache HTTP y UI optimista

### DIFF
--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -24,6 +24,26 @@ async function bootstrap() {
   );
   app.use(urlencoded({ limit: '50mb', extended: true }));
 
+  // Disable HTTP caching on private API endpoints.
+  // Bug fix: el backend emitía ETag (Express por defecto) pero NO Cache-Control,
+  // lo que permitía al browser cachear GETs a /api/*. Al re-abrir un producto
+  // recién editado, el browser servía la respuesta vieja y los cambios no se
+  // veían aplicados, aunque el PATCH sí había persistido.
+  // Las rutas explícitamente públicas (sitemap.xml, robots.txt, healthcheck,
+  // imágenes S3 firmadas) ya tienen sus propios Cache-Control en sus handlers
+  // y NO empiezan con /api/, así que este middleware no las afecta.
+  app.use((req, res, next) => {
+    if (req.path.startsWith('/api/')) {
+      res.setHeader(
+        'Cache-Control',
+        'no-store, no-cache, must-revalidate, proxy-revalidate',
+      );
+      res.setHeader('Pragma', 'no-cache');
+      res.setHeader('Expires', '0');
+    }
+    next();
+  });
+
   // Initialize domain configuration
   DomainConfigService.initialize();
 

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -163,9 +163,11 @@ async function bootstrap() {
       'Accept',
       'Origin',
       'X-Requested-With',
+      'Cache-Control',
+      'Pragma',
       'x-store-id',
     ],
-    exposedHeaders: ['Authorization'],
+    exposedHeaders: ['Authorization', 'Cache-Control', 'Pragma'],
   });
 
   // Swagger configuration (disabled in development to save memory and avoid SWC metadata issues)

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -24,7 +24,7 @@ async function bootstrap() {
   );
   app.use(urlencoded({ limit: '50mb', extended: true }));
 
-  // Disable HTTP caching on private API endpoints.
+  // Deshabilita la cache HTTP en endpoints privados de la API.
   // Bug fix: el backend emitía ETag (Express por defecto) pero NO Cache-Control,
   // lo que permitía al browser cachear GETs a /api/*. Al re-abrir un producto
   // recién editado, el browser servía la respuesta vieja y los cambios no se
@@ -158,13 +158,13 @@ async function bootstrap() {
     credentials: true,
     methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
     allowedHeaders: [
-      'Content-Type',
-      'Authorization',
       'Accept',
-      'Origin',
-      'X-Requested-With',
+      'Authorization',
       'Cache-Control',
+      'Content-Type',
+      'Origin',
       'Pragma',
+      'X-Requested-With',
       'x-store-id',
     ],
     exposedHeaders: ['Authorization', 'Cache-Control', 'Pragma'],

--- a/apps/frontend/src/app/app.config.ts
+++ b/apps/frontend/src/app/app.config.ts
@@ -17,6 +17,7 @@ import { provideStoreDevtools } from '@ngrx/store-devtools';
 import { firstValueFrom, timeout, catchError, of, filter } from 'rxjs';
 import { authInterceptorFn } from './core/interceptors/auth.interceptor';
 import { subscriptionPaywallInterceptor } from './core/interceptors/subscription-paywall.interceptor';
+import { cacheBustingInterceptor } from './core/interceptors/cache-busting.interceptor';
 import { RouteManagerService } from './core/services/route-manager.service';
 import { tenantReducer, TenantEffects } from './core/store/tenant';
 import { authReducer, AuthEffects } from './core/store/auth';
@@ -81,8 +82,13 @@ export const appConfig: ApplicationConfig = {
       withFetch(),
       // Order matters: auth runs first (handles 401 + token refresh) and
       // the paywall interceptor runs last so it can react to the final
-      // 402/403 response after retries.
-      withInterceptors([authInterceptorFn, subscriptionPaywallInterceptor]),
+      // 402/403 response after retries. cacheBusting runs after auth to
+      // avoid stripping the Authorization header on cache-bust clones.
+      withInterceptors([
+        authInterceptorFn,
+        cacheBustingInterceptor,
+        subscriptionPaywallInterceptor,
+      ]),
     ),
 
     // NgRx Store Configuration

--- a/apps/frontend/src/app/core/interceptors/cache-busting.interceptor.spec.ts
+++ b/apps/frontend/src/app/core/interceptors/cache-busting.interceptor.spec.ts
@@ -1,0 +1,67 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import {
+  HttpClient,
+  provideHttpClient,
+  withInterceptors,
+} from '@angular/common/http';
+import { cacheBustingInterceptor } from './cache-busting.interceptor';
+import { environment } from '../../../environments/environment';
+
+describe('cacheBustingInterceptor', () => {
+  let httpMock: HttpTestingController;
+  let httpClient: HttpClient;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptors([cacheBustingInterceptor])),
+        provideHttpClientTesting(),
+      ],
+    });
+
+    httpMock = TestBed.inject(HttpTestingController);
+    httpClient = TestBed.inject(HttpClient);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should add Cache-Control: no-cache to GET requests targeting the API', () => {
+    httpClient.get(`${environment.apiUrl}/products`).subscribe();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/products`);
+    expect(req.request.headers.get('Cache-Control')).toBe('no-cache');
+  });
+
+  it('should not add Cache-Control to GET requests targeting non-API URLs', () => {
+    httpClient.get('https://cdn.example.com/asset.png').subscribe();
+
+    const req = httpMock.expectOne('https://cdn.example.com/asset.png');
+    expect(req.request.headers.get('Cache-Control')).toBeNull();
+  });
+
+  it('should not add Cache-Control to non-GET requests targeting the API', () => {
+    httpClient.post(`${environment.apiUrl}/products`, {}).subscribe();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/products`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.headers.get('Cache-Control')).toBeNull();
+  });
+
+  it('should preserve existing headers when adding Cache-Control', () => {
+    httpClient
+      .get(`${environment.apiUrl}/products`, {
+        headers: { 'X-Custom': 'value' },
+      })
+      .subscribe();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/products`);
+    expect(req.request.headers.get('Cache-Control')).toBe('no-cache');
+    expect(req.request.headers.get('X-Custom')).toBe('value');
+  });
+});

--- a/apps/frontend/src/app/core/interceptors/cache-busting.interceptor.ts
+++ b/apps/frontend/src/app/core/interceptors/cache-busting.interceptor.ts
@@ -1,0 +1,34 @@
+import {
+  HttpEvent,
+  HttpHandlerFn,
+  HttpInterceptorFn,
+  HttpRequest,
+} from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+
+/**
+ * Cache-busting interceptor para APIs privadas.
+ *
+ * Complementa el middleware `no-store` del backend (ver `apps/backend/src/main.ts`).
+ * Si alguien en el futuro quita o cambia ese middleware, este interceptor
+ * blinda al frontend añadiendo `Cache-Control: no-cache` a todas las
+ * requests GET hacia la API.
+ *
+ * Solo afecta GETs: los POST/PATCH/DELETE nunca se cachean por defecto
+ * en el browser, así que no necesitan intervención.
+ *
+ * No afecta URLs fuera de `environment.apiUrl` (assets, S3, fonts, etc.).
+ */
+export const cacheBustingInterceptor: HttpInterceptorFn = (
+  req: HttpRequest<unknown>,
+  next: HttpHandlerFn,
+): Observable<HttpEvent<unknown>> => {
+  if (req.method === 'GET' && req.url.startsWith(environment.apiUrl)) {
+    const cloned = req.clone({
+      setHeaders: { 'Cache-Control': 'no-cache' },
+    });
+    return next(cloned);
+  }
+  return next(req);
+};

--- a/apps/frontend/src/app/private/modules/store/products/products.component.ts
+++ b/apps/frontend/src/app/private/modules/store/products/products.component.ts
@@ -336,9 +336,15 @@ export class ProductsComponent {
       .updateProduct(product.id, { state: nextState } as UpdateProductDto)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
-        next: () => {
+        next: (updatedProduct) => {
+          // Actualización optimista del signal local con la respuesta del
+          // backend (que ya trae el producto completo vía findOne). Esto evita
+          // depender de loadProducts() que puede devolver datos cacheados por
+          // el browser (bug fixeado con Cache-Control: no-store + interceptor).
+          this.products.update((list) =>
+            list.map((p) => (p.id === updatedProduct.id ? updatedProduct : p)),
+          );
           this.toastService.success(`Producto ${verb} correctamente`);
-          this.loadProducts();
           this.loadStats();
         },
         error: (error: any) => {


### PR DESCRIPTION
## Resumen

Cierra el bug de UX "los cambios de producto no se guardan" combinando el
fix original de tres capas de `42feccfd` con un follow-up de CORS preflight
que faltaba en ese commit, más un test unitario y limpieza del PR.

### Problema original

Alternar el estado activo de un producto en `/admin/products` no persistía
visualmente tras refrescar el navegador. El cambio sí llegaba a la base de
datos, pero el siguiente render de la página re-obtenía una lista vieja
desde la cache HTTP del navegador.

### Fix de tres capas (de `42feccfd`)

1. **Middleware de respuesta en backend** — `apps/backend/src/main.ts:27-44`
   setea `Cache-Control: no-store` en cada respuesta de `/api/*` para que
   el navegador y cualquier proxy al frente nunca sirvan una copia cacheada.
2. **Interceptor de cache-busting en frontend** —
   `apps/frontend/src/app/core/interceptors/cache-busting.interceptor.ts`
   agrega `Cache-Control: no-cache` a cada request `GET /api/*` para que
   los intermediarios tampoco reusen un body cacheado.
3. **UI optimista** —
   `apps/frontend/src/app/private/modules/store/products/products.component.ts:336-348`
   actualiza el signal local con la respuesta del PATCH en vez de llamar a
   `loadProducts()` de nuevo (lo que competiría con la capa de cache).

### Follow-up: CORS preflight no se actualizó (`1dce591c`)

El interceptor nuevo envía `Cache-Control` en cada GET, lo que hace que el
navegador dispare un preflight de CORS. La lista de `allowedHeaders` de
`app.enableCors` no se actualizó para incluir `Cache-Control` ni `Pragma`,
así que el preflight rechazaba la request antes de llegar al backend.

Síntoma: cada llamada al API desde `vendix.com` a `api.vendix.com` fallaba
con

```
Request header field cache-control is not allowed by
Access-Control-Allow-Headers in preflight response.
```

Esto rompió el login y más de 15 endpoints (dashboard, notificaciones,
productos, impuestos, settings, currencies, etc.) — todos compartían la
misma causa raíz.

Fix: agregar `Cache-Control` y `Pragma` tanto a `allowedHeaders` como a
`exposedHeaders` en `apps/backend/src/main.ts`.

### Test unitario + limpieza (`080547b7`)

Cierra el hueco #1 que dejó la self-review: el interceptor no tenía test.
Se agregan 4 casos en
`apps/frontend/src/app/core/interceptors/cache-busting.interceptor.spec.ts`:

- GET a `environment.apiUrl` → añade `Cache-Control: no-cache`
- GET a URL fuera de la API → no añade `Cache-Control`
- POST a `environment.apiUrl` → no añade `Cache-Control` (el check es solo GET)
- GET con headers custom → añade `Cache-Control` sin pisar los existentes

Adicionalmente, en `apps/backend/src/main.ts`:

- `allowedHeaders` reordenado alfabéticamente para que los dos nuevos
  entries (`Cache-Control`, `Pragma`) encajen en la convención de la lista.
- El comentario del middleware traducido al español para mantener
  consistencia con el resto del bloque.

## Verificación

- `curl -X OPTIONS` contra `https://api.vendix.com/api/public/currencies/active`
  con header `Access-Control-Request-Headers: cache-control` devuelve
  `204 No Content` con la lista esperada en `Access-Control-Allow-Headers`.
- Tras reconstruir `vendix_backend`, el login y el dashboard cargan limpios
  en el navegador sin errores de CORS en la consola.
- `ng test` corre el spec del interceptor y cubre los 4 casos mencionados
  arriba (la ejecución queda en CI por falta de Chrome local).

## Archivos tocados por la rama contra `dev`

- `apps/backend/src/main.ts` — middleware de Cache-Control en respuesta
  + CORS allowedHeaders/exposedHeaders
- `apps/frontend/src/app/app.config.ts` — registro del interceptor
- `apps/frontend/src/app/core/interceptors/cache-busting.interceptor.ts`
  — archivo nuevo
- `apps/frontend/src/app/core/interceptors/cache-busting.interceptor.spec.ts`
  — archivo nuevo (test unitario)
- `apps/frontend/src/app/private/modules/store/products/products.component.ts`
  — actualización optimista de UI

## Self-review

| Categoría   | Puntuación | Nota |
|-------------|------------|------|
| Security    | 95/100     | Cambio aditivo, sin regresiones; `no-store` mejora seguridad de cache |
| Logic       | 80/100     | Race condition teórica en doble-toggle rápido del mismo producto |
| Syntax      | 100/100    | TypeScript compila limpio |
| Core Files  | 75/100     | Toca `main.ts` y `app.config.ts`, pero el cambio es acotado y reversible |
| PR Scope    | 95/100     | 5 archivos, todos del mismo fix, sin drive-by |
| Quality     | 88/100     | Test presente, comentarios en español, orden alfabético |
| **Total**   | **89/100** | **APPROVE con comentarios menores** |
