### PR TITLE
feat(products): download current products as editable xlsx template

### DIFF
--- a/apps/backend/src/domains/store/products/products-bulk.controller.ts
+++ b/apps/backend/src/domains/store/products/products-bulk.controller.ts
@@ -109,6 +109,35 @@ export class ProductsBulkController {
   }
 
   /**
+   * Descarga un XLSX con los productos actuales de la tienda, en el mismo
+   * formato de la plantilla de Carga Masiva + 3 columnas informativas.
+   * Pensado para auditoría rápida y para que el cliente edite y re-cargue.
+   */
+  @Get('export')
+  @Permissions('store:products:read')
+  async exportCurrentProducts(@Res() res: Response) {
+    try {
+      const buffer =
+        await this.productsBulkService.exportCurrentProductsAsTemplate();
+      const filename = `productos_actuales_${new Date().toISOString().split('T')[0]}.xlsx`;
+
+      res.set({
+        'Content-Type':
+          'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        'Content-Disposition': `attachment; filename="${filename}"`,
+        'Content-Length': buffer.length,
+      });
+
+      res.end(buffer);
+    } catch (error) {
+      res.status(500).json({
+        success: false,
+        error: { message: error.message },
+      });
+    }
+  }
+
+  /**
    * Carga masiva desde archivo Excel/CSV
    */
   @Post('upload/file')

--- a/apps/backend/src/domains/store/products/products-bulk.service.ts
+++ b/apps/backend/src/domains/store/products/products-bulk.service.ts
@@ -839,13 +839,13 @@ export class ProductsBulkService {
   }
 
   /**
-   * Genera la plantilla de carga masiva en formato Excel (.xlsx)
+   * Devuelve los encabezados en Español de la plantilla de productos físicos.
+   * Reutilizado por `generateExcelTemplate` y `exportCurrentProductsAsTemplate`
+   * para garantizar que el archivo exportado sea 100% compatible con la
+   * carga masiva (round-trip: editar + re-cargar funciona sin cambios).
    */
-  async generateExcelTemplate(
-    type: BulkExcelTemplateRequest = 'products',
-  ): Promise<Buffer> {
-    const templateType = type;
-    const productHeaders = [
+  getProductTemplateHeaders(): string[] {
+    return [
       'Nombre',
       'SKU',
       'Tipo',
@@ -867,6 +867,16 @@ export class ProductsBulkService {
       'En Oferta',
       'Precio Oferta',
     ];
+  }
+
+  /**
+   * Genera la plantilla de carga masiva en formato Excel (.xlsx)
+   */
+  async generateExcelTemplate(
+    type: BulkExcelTemplateRequest = 'products',
+  ): Promise<Buffer> {
+    const templateType = type;
+    const productHeaders = this.getProductTemplateHeaders();
     const serviceHeaders = [
       'Nombre',
       'SKU',
@@ -1077,6 +1087,147 @@ export class ProductsBulkService {
         ? 'Plantilla Servicios'
         : 'Plantilla Productos',
     );
+
+    return XLSX.write(wb, { type: 'buffer', bookType: 'xlsx' });
+  }
+
+  /**
+   * Genera un XLSX con los productos actuales de la tienda, usando los mismos
+   * encabezados de la plantilla de Carga Masiva + 3 columnas informativas
+   * (Precio Compra, Cantidad Actual, Tiene Imagen).
+   *
+   * El archivo es round-trip compatible con `generateExcelTemplate('products')`:
+   * las 20 columnas editables pueden modificarse y re-cargarse con el flujo
+   * existente. Las 3 columnas informativas son ignoradas por el parser al
+   * re-cargar (no existen en `HEADER_MAP`).
+   *
+   * Implementa cursor pagination interna en chunks de 500 para evitar cargar
+   * catálogos grandes en memoria de golpe.
+   */
+  async exportCurrentProductsAsTemplate(): Promise<Buffer> {
+    const context = RequestContextService.getContext();
+    const storeId = context?.store_id;
+    if (!storeId) {
+      throw new BadRequestException('No se pudo determinar la tienda actual');
+    }
+
+    const baseHeaders = this.getProductTemplateHeaders();
+    const extraHeaders = ['Precio Compra', 'Cantidad Actual', 'Tiene Imagen'];
+    const headers = [...baseHeaders, ...extraHeaders];
+
+    const rows: Record<string, any>[] = [];
+    const CHUNK_SIZE = 500;
+    let cursor: number | undefined = undefined;
+
+    // Iteración con cursor por `id` para evitar drift en catálogos grandes
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const products = await this.prisma.products.findMany({
+        where: { store_id: storeId },
+        orderBy: { id: 'asc' },
+        take: CHUNK_SIZE,
+        ...(cursor !== undefined && { skip: 1, cursor: { id: cursor } }),
+        include: {
+          brands: { select: { name: true } },
+          product_categories: {
+            include: { categories: { select: { name: true } } },
+          },
+          product_tax_assignments: {
+            select: { tax_category_id: true },
+          },
+          product_images: { where: { is_main: true }, take: 1 },
+          product_variants: { select: { id: true } },
+          stock_levels: {
+            select: {
+              product_variant_id: true,
+              quantity_available: true,
+            },
+          },
+        },
+      });
+
+      if (products.length === 0) break;
+
+      for (const p of products) {
+        const hasVariants = (p.product_variants?.length ?? 0) > 0;
+        const stockLevelsForTotals = hasVariants
+          ? (p.stock_levels ?? []).filter(
+              (sl) => sl.product_variant_id !== null,
+            )
+          : p.stock_levels ?? [];
+        const totalStock = stockLevelsForTotals.reduce(
+          (sum, sl) => sum + (sl.quantity_available ?? 0),
+          0,
+        );
+        const hasImage = (p.product_images?.length ?? 0) > 0;
+
+        rows.push({
+          Nombre: p.name,
+          SKU: p.sku ?? '',
+          Tipo: p.product_type === 'service' ? 'servicio' : 'físico',
+          Estado:
+            p.state === 'active'
+              ? 'activo'
+              : p.state === 'inactive'
+                ? 'inactivo'
+                : 'archivado',
+          'Controla Inventario': p.track_inventory ? 'sí' : 'no',
+          'Precio Venta': p.base_price ? Number(p.base_price) : 0,
+          Descripción: p.description ?? '',
+          Marca: p.brands?.name ?? '',
+          Categorías:
+            p.product_categories
+              ?.map((pc) => pc.categories?.name)
+              .filter(Boolean)
+              .join(', ') ?? '',
+          'Impuestos IDs':
+            p.product_tax_assignments
+              ?.map((a) => a.tax_category_id)
+              .filter(Boolean)
+              .join(', ') ?? '',
+          'Tipo Precio': p.pricing_type === 'weight' ? 'peso' : 'unidad',
+          'Disponible Ecommerce': p.available_for_ecommerce ? 'sí' : 'no',
+          Destacado: p.is_featured ? 'sí' : 'no',
+          'Permite Cambiar Precio POS': p.allow_pos_price_override ? 'sí' : 'no',
+          'Usa Listas de Precio': (p as any).has_multiple_price_tiers
+            ? 'sí'
+            : 'no',
+          'Unidades por Empaque':
+            (p as any).units_per_package !== null &&
+            (p as any).units_per_package !== undefined
+              ? Number((p as any).units_per_package)
+              : '',
+          'Empaque Descuenta Múltiples Unidades': (
+            p as any
+          ).package_consumes_multiple_stock
+            ? 'sí'
+            : 'no',
+          Peso: p.weight ? Number(p.weight) : '',
+          'En Oferta': p.is_on_sale ? 'sí' : 'no',
+          'Precio Oferta': p.sale_price ? Number(p.sale_price) : 0,
+          'Precio Compra': p.cost_price ? Number(p.cost_price) : '',
+          'Cantidad Actual': totalStock,
+          'Tiene Imagen': hasImage ? 'sí' : 'no',
+        });
+      }
+
+      if (products.length < CHUNK_SIZE) break;
+      cursor = products[products.length - 1].id;
+    }
+
+    // Si la tienda no tiene productos, igual devolver una hoja con los headers
+    // (fila vacía) para que el usuario vea la estructura esperada.
+    const ws = XLSX.utils.json_to_sheet(rows.length > 0 ? rows : [], {
+      header: headers,
+    });
+
+    const colWidths = headers.map((h) => ({
+      wch: Math.max(h.length + 5, 20),
+    }));
+    ws['!cols'] = colWidths;
+
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, 'Productos Actuales');
 
     return XLSX.write(wb, { type: 'buffer', bookType: 'xlsx' });
   }

--- a/apps/frontend/src/app/private/modules/store/products/components/product-list/product-list.component.ts
+++ b/apps/frontend/src/app/private/modules/store/products/components/product-list/product-list.component.ts
@@ -72,6 +72,7 @@ export class ProductListComponent {
   readonly toggleState = output<Product>();
   readonly bulkUpload = output<void>();
   readonly bulkImageUpload = output<void>();
+  readonly downloadCurrentProducts = output<void>();
   readonly sort = output<{ column: string; direction: 'asc' | 'desc' | null }>();
   readonly pageChange = output<number>();
 
@@ -135,6 +136,11 @@ export class ProductListComponent {
     },
     { label: 'Carga Masiva', icon: 'upload-cloud', action: 'bulk-upload' },
     { label: 'Carga de Imágenes', icon: 'image', action: 'bulk-image-upload' },
+    {
+      label: 'Descargar Plantilla con Productos Actuales',
+      icon: 'file-spreadsheet',
+      action: 'download-current-products',
+    },
   ];
 
   // Table configuration
@@ -389,6 +395,9 @@ export class ProductListComponent {
         break;
       case 'bulk-image-upload':
         this.bulkImageUpload.emit();
+        break;
+      case 'download-current-products':
+        this.downloadCurrentProducts.emit();
         break;
     }
   }

--- a/apps/frontend/src/app/private/modules/store/products/products.component.ts
+++ b/apps/frontend/src/app/private/modules/store/products/products.component.ts
@@ -1,5 +1,6 @@
 import { Component, inject, DestroyRef, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { firstValueFrom } from 'rxjs';
 import { Router, ActivatedRoute } from '@angular/router';
 
 // Services
@@ -99,6 +100,7 @@ import { StatsComponent } from '../../../../shared/components/stats/stats.compon
         (toggleState)="onToggleProductState($event)"
         (bulkUpload)="openBulkUploadModal()"
         (bulkImageUpload)="openBulkImageUploadModal()"
+        (downloadCurrentProducts)="onDownloadCurrentProducts()"
         (pageChange)="changePage($event)"
       ></app-product-list>
 
@@ -166,6 +168,9 @@ export class ProductsComponent {
   isBulkUploadModalOpen = false;
   isBulkImageUploadModalOpen = false;
   isCreatingProduct = false;
+
+  // Estado de descarga de plantilla
+  readonly isExporting = signal(false);
 
   constructor() {
     // Asegurar que la moneda esté cargada
@@ -391,6 +396,46 @@ export class ProductsComponent {
   onBulkImageUploadComplete(): void {
     this.isBulkImageUploadModalOpen = false;
     this.loadProducts();
+  }
+
+  // Descargar Plantilla con Productos Actuales
+  async onDownloadCurrentProducts(): Promise<void> {
+    if (this.isExporting()) return;
+    this.isExporting.set(true);
+    try {
+      const blob = await firstValueFrom(
+        this.productsService.exportCurrentProducts(),
+      );
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      const dateStr = new Date().toISOString().split('T')[0];
+      link.download = `productos_actuales_${dateStr}.xlsx`;
+      link.click();
+      window.URL.revokeObjectURL(url);
+      this.notifyDownloadResult(true);
+    } catch (err) {
+      this.notifyDownloadResult(false, err);
+    } finally {
+      this.isExporting.set(false);
+    }
+  }
+
+  /**
+   * Feedback de usuario para la descarga de la plantilla.
+   * Decidí qué mensajes mostrar y cómo extraer el mensaje real del error.
+   * Pista: this.toastService expone .success() / .warning() / .error(msg, title?, duration?).
+   * Para errores: extractApiErrorMessage(err) devuelve el mensaje legible del backend.
+   */
+  private notifyDownloadResult(success: boolean, err?: unknown): void {
+    if (success) {
+      this.toastService.success('Plantilla con productos descargada');
+      return;
+    }
+    const message =
+      extractApiErrorMessage(err) ||
+      'Error al descargar la plantilla de productos';
+    this.toastService.error(message, 'Error al exportar');
   }
   // Helpers
   getGrowthPercentage(val: number): string {

--- a/apps/frontend/src/app/private/modules/store/products/services/products.service.ts
+++ b/apps/frontend/src/app/private/modules/store/products/services/products.service.ts
@@ -447,6 +447,19 @@ export class ProductsService {
       .pipe(catchError(this.handleError));
   }
 
+  /**
+   * Descarga un XLSX con los productos actuales de la tienda, en el mismo
+   * formato de la plantilla de Carga Masiva + 3 columnas informativas
+   * (Precio Compra, Cantidad Actual, Tiene Imagen).
+   */
+  exportCurrentProducts(): Observable<Blob> {
+    return this.http
+      .get(`${this.apiUrl}/store/products/bulk/export`, {
+        responseType: 'blob',
+      })
+      .pipe(catchError(this.handleError));
+  }
+
   uploadBulkProducts(file: File): Observable<any> {
     const formData = new FormData();
     formData.append('file', file);


### PR DESCRIPTION
## Summary

Agrega una nueva opción "Descargar Plantilla con Productos Actuales" en el dropdown de Acciones de `/admin/products`. Genera un XLSX con todos los productos de la tienda, usando **el mismo formato de la plantilla de Carga Masiva** (round-trip compatible: se puede editar y re-cargar con el flujo existente) más **3 columnas informativas** adicionales.

### Columnas (23 en total)
**Las 20 columnas de la plantilla de Carga Masiva** (editables y round-trip):
Nombre, SKU, Tipo, Estado, Controla Inventario, Precio Venta, Descripción, Marca, Categorías, Impuestos IDs, Tipo Precio, Disponible Ecommerce, Destacado, Permite Cambiar Precio POS, Usa Listas de Precio, Unidades por Empaque, Empaque Descuenta Múltiples Unidades, Peso, En Oferta, Precio Oferta.

**+ 3 columnas informativas** (ignoradas al re-cargar, no existen en `HEADER_MAP`):
- Precio Compra (`cost_price`)
- Cantidad Actual (suma de `stock_levels.quantity_available` con dedup de variantes)
- Tiene Imagen (booleano basado en `product_images`)

## Cambios

### Backend
- `products-bulk.service.ts`: refactor menor — extrae `getProductTemplateHeaders()` para mantener la plantilla y el export alineados. Nuevo método `exportCurrentProductsAsTemplate()` con cursor pagination en chunks de 500.
- `products-bulk.controller.ts`: nuevo endpoint `GET /store/products/bulk/export` con permiso `store:products:read`.

### Frontend
- `products.service.ts`: método `exportCurrentProducts(): Observable<Blob>`.
- `product-list.component.ts`: nuevo `output downloadCurrentProducts`, nueva entrada en `dropdownActions` con icono `file-spreadsheet`, case en `onActionClick`.
- `products.component.ts`: signal `isExporting` para guard anti-doble-click, handler `onDownloadCurrentProducts()` con try/catch/finally, helper `notifyDownloadResult()` con feedback vía `toastService` + `extractApiErrorMessage`.

## Casos de uso

1. **Auditoría rápida**: el cliente descarga el catálogo completo para revisarlo fuera de la app.
2. **Edición masiva**: el cliente edita precios/nombres en Excel y re-carga con "Carga Masiva" (mismo formato = mismo parser).
3. **Identificar productos sin imagen**: la columna `Tiene Imagen` permite filtrar visualmente y luego usar "Carga de Imágenes" con los SKUs identificados.

## Verificación

- [x] `tsc --noEmit` backend: sin errores en archivos modificados.
- [x] `tsc --noEmit -p tsconfig.app.json` frontend: 0 errores totales.
- [x] Docker containers healthy (backend/frontend/nginx/postgres/redis).

### Tests manuales pendientes
- [x] Dropdown muestra 4 acciones: Nuevo Producto, Carga Masiva, Carga de Imágenes, **Descargar Plantilla con Productos Actuales**.
- [x] Click → descarga `productos_actuales_YYYY-MM-DD.xlsx`.
- [x] XLSX abre correctamente con 23 columnas y una fila por producto.
- [x] Round-trip: editar archivo + re-cargar con "Carga Masiva" funciona.
- [ ] Catálogo grande (>1000 productos): el cursor pagination responde sin timeout.
- [x] Producto con variantes: `Cantidad Actual` es la suma de stocks de variantes.