### PR TITLE
fix(checkout): prevent submitting order when no shipping zone covers the address

### DIFF
--- a/apps/frontend/src/app/private/modules/ecommerce/pages/checkout/checkout.component.html
+++ b/apps/frontend/src/app/private/modules/ecommerce/pages/checkout/checkout.component.html
@@ -231,9 +231,9 @@
             @if (!cartHasOnlyServices) {
               <h2>Opciones de Envio</h2>
             }
-            @if (!cartHasOnlyServices && shipping_options.length > 0) {
+            @if (!cartHasOnlyServices && shipping_options().length > 0) {
               <div class="payment-list" style="margin-bottom: 2rem">
-                @for (option of shipping_options; track option.id) {
+                @for (option of shipping_options(); track option.id) {
                   <div
                     class="payment-card"
                     [class.selected]="selected_shipping_option_id === option.id"
@@ -451,7 +451,12 @@
               variant="primary"
               (clicked)="placeOrder()"
               [loading]="is_submitting() || wompiWidgetLoading()"
-              [disabled]="is_submitting() || wompiWidgetLoading()"
+              [disabled]="is_submitting() || wompiWidgetLoading() || !canConfirmOrder()"
+              [title]="
+                !cartHasOnlyServices && shipping_options().length === 0
+                  ? 'No hay opciones de envío para esta ubicación'
+                  : null
+              "
             >
               @if (!is_submitting() && !wompiWidgetLoading()) {
                 <app-icon

--- a/apps/frontend/src/app/private/modules/ecommerce/pages/checkout/checkout.component.ts
+++ b/apps/frontend/src/app/private/modules/ecommerce/pages/checkout/checkout.component.ts
@@ -9,7 +9,7 @@ import {
   viewChild,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { firstValueFrom } from 'rxjs';
+import { firstValueFrom, debounceTime, distinctUntilChanged, filter } from 'rxjs';
 import { CommonModule } from '@angular/common';
 import { RouterModule, Router } from '@angular/router';
 import {
@@ -31,6 +31,7 @@ import {
 } from '../../services/checkout.service';
 import { WompiService } from '../../../../../shared/services/wompi.service';
 import { AccountService, Address } from '../../services/account.service';
+import { extractApiErrorMessage } from '../../../../../core/utils/api-error-handler';
 import {
   CatalogService,
   EcommerceProduct,
@@ -145,6 +146,24 @@ export class CheckoutComponent implements OnInit {
   readonly requiresPaymentInstructions = computed(() => {
     const t = this.selectedPaymentMethodObj()?.type;
     return t === 'bank_transfer' || t === 'voucher';
+  });
+
+  /**
+   * Disables the "Confirmar Pedido" button when the order cannot be placed
+   * in a valid state. For physical-item carts the user must have a shipping
+   * method selected; when no shipping options come back from the calculator
+   * (e.g. the tenant has no shipping zone configured for the picked city),
+   * we block the button so the user does not hit a 400 from the backend.
+   */
+  readonly canConfirmOrder = computed(() => {
+    if (this.is_submitting() || this.wompiWidgetLoading()) return false;
+    if (!this.cartHasOnlyServices) {
+      // Carrito tiene ítems físicos: necesita método de envío seleccionado
+      // y al menos una opción de la zona correspondiente.
+      if (this.shipping_options().length === 0) return false;
+      if (this.selected_shipping_method_id == null) return false;
+    }
+    return true;
   });
 
   // Flag to prevent cart-empty redirect after successful checkout
@@ -353,6 +372,20 @@ export class CheckoutComponent implements OnInit {
       }
     });
 
+    // Re-fetch shipping options when the user picks a new city. The
+    // `nextStep` flow still calls loadShippingOptions on Address→Payment,
+    // but this lets the "no options" state show up in real time without
+    // requiring the user to advance steps. The 300ms debounce coalesces
+    // rapid clicks on the city dropdown.
+    cityControl?.valueChanges
+      .pipe(
+        debounceTime(300),
+        distinctUntilChanged(),
+        filter(() => !this.cartHasOnlyServices && this.address_form.valid),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => this.loadShippingOptions());
+
     // Load departments for default country
     this.loadDepartments();
   }
@@ -501,7 +534,7 @@ export class CheckoutComponent implements OnInit {
   }
 
   // Shipping
-  shipping_options: any[] = [];
+  readonly shipping_options = signal<any[]>([]);
   selected_shipping_method_id: number | null = null;
   selected_shipping_option_id: number | null = null;
   selected_shipping_method_type: string | null = null;
@@ -556,7 +589,7 @@ export class CheckoutComponent implements OnInit {
     this.is_loading.set(true);
     this.cart_service.getShippingEstimates(address).subscribe({
       next: (options) => {
-        this.shipping_options = options;
+        this.shipping_options.set(options);
         if (options.length > 0) {
           // Default select first or cheapest?
           // Select first
@@ -734,7 +767,7 @@ export class CheckoutComponent implements OnInit {
       // Check shipping selection (only for physical items)
       if (
         !this.cartHasOnlyServices &&
-        this.shipping_options.length > 0 &&
+        this.shipping_options().length > 0 &&
         !this.selected_shipping_method_id
       ) {
         this.error_message.set('Por favor selecciona un método de envío');
@@ -980,7 +1013,7 @@ export class CheckoutComponent implements OnInit {
                 },
                 error: (err) => {
                   this.wompiWidgetLoading.set(false);
-                  const msg = this.extractErrorMessage(err);
+                  const msg = extractApiErrorMessage(err);
                   this.error_message.set(msg);
                   this.toast.error(msg, 'Error al preparar pago');
                 },
@@ -989,7 +1022,7 @@ export class CheckoutComponent implements OnInit {
         },
         error: (err) => {
           this.wompiWidgetLoading.set(false);
-          const msg = this.extractErrorMessage(err);
+          const msg = extractApiErrorMessage(err);
           this.error_message.set(msg);
           this.toast.error(msg, 'Error al procesar el pedido');
         },
@@ -1022,7 +1055,7 @@ export class CheckoutComponent implements OnInit {
       },
       error: (err) => {
         this.is_submitting.set(false);
-        const msg = this.extractErrorMessage(err);
+        const msg = extractApiErrorMessage(err);
         this.error_message.set(msg);
         this.toast.error(msg, 'Error al procesar el pedido');
       },
@@ -1143,13 +1176,6 @@ export class CheckoutComponent implements OnInit {
         'Error',
       );
     }
-  }
-
-  private extractErrorMessage(err: any): string {
-    const msg = err?.error?.message;
-    if (typeof msg === 'string') return msg;
-    if (msg?.message) return msg.message;
-    return 'Ocurrió un error inesperado';
   }
 
   goToCart(): void {


### PR DESCRIPTION
## Resumen

Cierra el bug del checkout e-commerce donde el backend devolvía 400 ORD_SHIP_REQUIRED_001 cuando el usuario elegía una ciudad sin zona de envío configurada por el tenant. El usuario veía un toast en inglés con el dev string y el botón Confirmar Pedido quedaba habilitado (la UI no prevenía el caso).

### Bug original (reporte del usuario)

Reproducción: en https://e-tech-shop.vendix.online/checkout, usuario guest (y registrado) con ciudad != Riohacha. El backend respondía con error_code ORD_SHIP_REQUIRED_001. El síntoma explícito del usuario: en los datos puse ubicación diferente al de Riohacha y me dio este error, solo así me dio este error.

### Causa raíz (no es un caso especial de Riohacha)

Investigación con grep confirmó: 0 matches de Riohacha en cualquier parte del código fuente (apps/backend/src/, apps/frontend/src/, libs/, scripts/). El comportamiento observado se debe a la config de la tabla shipping_zones del tenant: solo tiene una zona que cubre La Guajira. Para cualquier otra ciudad, el calculador retorna [] desde POST /shipping/calculate, el frontend deja selected_shipping_method_id = null, y el usuario llega al backend sin método de envío.

El backend está haciendo su trabajo (checkout.service.ts:697-699 rechaza correctamente). El problema es de 3 capas en el frontend que, sumadas, permitían llegar al estado de error 400:

1. checkout.component.ts:555-579 — Cuando getShippingEstimates retorna [], no bloquea el botón Confirmar Pedido.
2. mismo:735-740 — La validación de nextStep solo cubre length > 0 && !selected, no el caso length === 0.
3. mismo:1023-1028 — error_message muestra el devMessage en inglés, ignora el mapeo error_code → ERROR_MESSAGES.

### Solución (3 cambios frontend-only)

1. canConfirmOrder computed signal — bloquea el botón Confirmar Pedido cuando hay ítems físicos pero shipping_options().length === 0 o selected_shipping_method_id == null. Sigue el patrón de purchase-order-create.component.ts:780,795. Bindea [disabled]+[title] en el template.

2. Re-fetch de shipping al cambiar ciudad — nueva suscripción en setupLocationData() que observa cityControl.valueChanges con debounceTime(300) + distinctUntilChanged() + filter() (solo carritos con ítems físicos y form válido). Refleja el estado no hay opciones en tiempo real sin retroceder al paso de Address.

3. Localización del toast de error — reemplazo de 3 llamadas a this.extractErrorMessage(err) por extractApiErrorMessage(err) (helper de core/utils/api-error-handler.ts:72) que mapea ORD_SHIP_REQUIRED_001 → Debes asignar un método de envío antes de continuar. (ya existía en error-messages.ts:188). Se elimina el método privado extractErrorMessage.

### Cambio mecánico: shipping_options a signal

Para soportar #1, el campo plano shipping_options: any[] = [] se convierte a readonly shipping_options = signal<any[]>([]). Conversión mecánica de 4 referencias (3 en TS, 1 en HTML), consistente con el resto del componente.

## Verificación

- Build limpio: Application bundle generation complete en docker logs vendix_frontend (38.3s)
- Watch mode: Page reload sent to client(s) después de cada cambio
- Test manual recipe:
  1. https://e-tech-shop.vendix.online/checkout (Ctrl+Shift+R)
  2. Como guest, agregar producto físico al carrito
  3. Llenar dirección: country=CO, department=La Guajira, city=Neiva
  4. Click Continuar
  5. Esperado: inline error 'No hay opciones de envío' + botón Confirmar Pedido deshabilitado con tooltip
  6. Cambiar ciudad a Riohacha → re-fetch automático, botón se habilita
  7. Volver a Neiva → botón se deshabilita
  8. Forzar placeOrder() desde DevTools → toast en español: Debes asignar un método de envío antes de continuar.

## Archivos tocados

- apps/frontend/src/app/private/modules/ecommerce/pages/checkout/checkout.component.ts (+48/-14)
- apps/frontend/src/app/private/modules/ecommerce/pages/checkout/checkout.component.html (+8/-3)

Total: 2 archivos, +56/-17.

## Decisiones de scope

- Solo frontend. Backend rechaza correctamente.
- POP cart y e-commerce cart: mismo anti-pattern, tickets separados.
- Migrar selected_shipping_method_id/_option_id/_method_type/shipping_cost a signals: refactor más amplio, no aporta a este bug.
- Nuevo error code backend ORD_SHIP_NO_ZONE_001: innecesario; el copy localizado ya existe y el frontend previene el caso.
- Configurar zonas adicionales en shipping_zones del tenant: ACCIÓN MANUAL del admin, no código. Documentado abajo.

## Follow-up: acción manual del tenant (no es código)

La tabla shipping_zones del tenant e-tech-shop.vendix.online solo tiene una zona configurada que cubre Riohacha/La Guajira. Para cubrir otras ciudades, el admin del tenant debe ir al panel admin → Configuración de envíos → Zonas, agregar zonas para los departamentos/ciudades que se quieran cubrir, y definir las tarifas de envío correspondientes.

Sin esta acción en el admin panel, el fix del frontend previene el 400 con UX clara, pero las ciudades fuera de La Guajira seguirán sin poder completar checkout. El frontend está listo; falta config de datos.

## Skills usadas

how-to-dev, how-to-plan, git-workflow, vendix-frontend, vendix-zoneless-signals, vendix-frontend-component, vendix-ecommerce-checkout, vendix-error-handling, vendix-validation, pr-code-review, buildcheck-dev