### PR TITLE
fix(backend): unblock prod build — exclude dev scripts + fix type errors

### DIFF
--- a/apps/backend/prisma/seeds/vendix-platform-org.seed.ts
+++ b/apps/backend/prisma/seeds/vendix-platform-org.seed.ts
@@ -557,10 +557,10 @@ async function ensurePlatformOrganizationSettings(
     where: { organization_id: organizationId },
     create: {
       organization_id: organizationId,
-      settings: nextSettings as Prisma.InputJsonValue,
+      settings: nextSettings as unknown as Prisma.InputJsonValue,
     },
     update: {
-      settings: nextSettings as Prisma.InputJsonValue,
+      settings: nextSettings as unknown as Prisma.InputJsonValue,
       updated_at: new Date(),
     },
   });

--- a/apps/backend/src/domains/superadmin/invoicing/vendor-support-documents/vendor-support-fiscal.service.ts
+++ b/apps/backend/src/domains/superadmin/invoicing/vendor-support-documents/vendor-support-fiscal.service.ts
@@ -20,7 +20,7 @@ import {
 const SETTINGS_KEY = 'vendor_support_fiscal';
 const DECIMAL_ZERO = new Prisma.Decimal(0);
 
-interface VendorSupportFiscalSettings {
+export interface VendorSupportFiscalSettings {
   is_enabled: boolean;
   auto_transmit: boolean;
   environment: VendorSupportFiscalEnvironment;

--- a/apps/backend/tsconfig.build.json
+++ b/apps/backend/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "tests", "dist", "**/*spec.ts"]
+  "exclude": ["node_modules", "test", "tests", "dist", "scripts", "**/*spec.ts"]
 }


### PR DESCRIPTION
nest build typechecked the whole repo because tsconfig.build.json did not exclude scripts/. roku-demo and verify-superadmin are dev-only tooling run via ts-node, never compiled to dist, so they do not belong in the prod build.

- tsconfig.build.json: exclude scripts/ (resolves 37 TS18047/18048 errors)
- vendor-support-fiscal.service.ts: export VendorSupportFiscalSettings (TS4053)
- vendix-platform-org.seed.ts: cast settings via unknown for Prisma.InputJsonValue (TS2352)