### PR TITLE
fix(frontend): proxy /api to api.vendix.com in dev to bypass CORS

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -4,7 +4,7 @@
     "scripts": {
         "// ----- DEVELOPMENT -----": "",
         "ng": "ng",
-        "start": "ng serve",
+        "start": "ng serve --proxy-config proxy.conf.json",
         "build": "ng build",
         "watch": "ng build --watch --configuration development",
         "test": "ng test",

--- a/apps/frontend/proxy.conf.json
+++ b/apps/frontend/proxy.conf.json
@@ -1,0 +1,8 @@
+{
+  "/api": {
+    "target": "https://api.vendix.com",
+    "secure": false,
+    "changeOrigin": true,
+    "logLevel": "info"
+  }
+}

--- a/apps/frontend/src/environments/environment.development.ts
+++ b/apps/frontend/src/environments/environment.development.ts
@@ -1,7 +1,8 @@
 export const environment = {
   production: false,
-  // apiUrl points to local backend for development
-  apiUrl: 'https://api.vendix.com/api',
+  // apiUrl is relative so Angular's dev-server proxy forwards /api/* to https://api.vendix.com
+  // (avoids CORS by keeping the request same-origin at localhost:4200)
+  apiUrl: '/api',
   vendixDomain: 'vendix.com',
 
   // Configuración para desarrollo


### PR DESCRIPTION
## What

Adds an Angular dev-server proxy so the local frontend (`localhost:4200`) can call the API at `https://api.vendix.com` without hitting CORS errors.

## Why

Local development was failing: the browser blocks cross-origin requests to the API. Routing the calls through Angular's dev-server proxy keeps them same-origin at `localhost:4200`.

## How

- `apps/frontend/proxy.conf.json` (new): maps `/api/*` → `https://api.vendix.com` with `secure: false` (skips SSL cert verification; toggle to `true` if your network blocks MITM certs)
- `apps/frontend/package.json`: `start` script now passes `--proxy-config proxy.conf.json`
- `apps/frontend/src/environments/environment.development.ts`: `apiUrl` is now relative `/api` instead of the absolute `https://api.vendix.com/api`

## How to test

```bash
cd apps/frontend
npm start
# open http://localhost:4200
# network tab should show /api/* requests (not direct api.vendix.com)
# no CORS errors in console
```

## Notes

- Affects **only the development environment** — production builds still hit the absolute URL
- `secure: false` is a deliberate dev-only convenience; switch to `true` if you hit cert issues on your machine