### PR TITLE
chore(mobile): config cleanup for web + APK packaging

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -31,6 +31,7 @@
       "supportsTablet": true
     },
     "android": {
+      "package": "com.quickss.vendix",
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"

--- a/apps/mobile/app/(store-admin)/customers.tsx
+++ b/apps/mobile/app/(store-admin)/customers.tsx
@@ -1,18 +1,32 @@
-import { useCallback, useMemo, useState } from 'react';
-import { FlatList, Pressable, RefreshControl, StyleSheet, Text, View } from 'react-native';
+import { useCallback, useMemo, useRef, useState } from 'react';
+import {
+  FlatList,
+  Pressable,
+  RefreshControl,
+  StyleSheet,
+  Text,
+  View,
+  TextInput,
+  Modal,
+  Dimensions,
+  ScrollView,
+} from 'react-native';
 import { useRouter } from 'expo-router';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Ionicons } from '@expo/vector-icons';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { CustomerService } from '@/features/store/services/customer.service';
 import { useTenantStore } from '@/core/store/tenant.store';
-import type { Customer, CustomerState, CustomerStats } from '@/features/store/types';
+import type { Customer, CustomerState, CustomerStats, UpdateCustomerDto, CreateCustomerDto } from '@/features/store/types';
+import { Avatar } from '@/shared/components/avatar/avatar';
 import { EmptyState } from '@/shared/components/empty-state/empty-state';
 import { Icon } from '@/shared/components/icon/icon';
-import { RecordCard } from '@/shared/components/record-card/record-card';
-import { SearchBar } from '@/shared/components/search-bar/search-bar';
 import { Spinner } from '@/shared/components/spinner/spinner';
 import { StatsGrid } from '@/shared/components/stats-card/stats-grid';
+import { ConfirmDialog } from '@/shared/components/confirm-dialog/confirm-dialog';
+import { toastSuccess, toastError } from '@/shared/components/toast/toast.store';
 import { formatCurrency } from '@/shared/utils/currency';
-import { formatRelative } from '@/shared/utils/date';
+import { formatDate, formatRelative } from '@/shared/utils/date';
 import { borderRadius, colorScales, colors, shadows, spacing, typography } from '@/shared/theme';
 
 const STATE_FILTERS: { label: string; value?: CustomerState }[] = [
@@ -25,41 +39,135 @@ function customerName(customer: Customer): string {
   return `${customer.first_name || ''} ${customer.last_name || ''}`.trim() || 'Cliente sin nombre';
 }
 
-const CustomerCard = ({ customer, onPress }: { customer: Customer; onPress: () => void }) => {
+type CustomerCardProps = {
+  customer: Customer;
+  onView: () => void;
+  onEdit: () => void;
+  onMoreActions: (ref: View, item: Customer) => void;
+};
+
+const CustomerCard = ({ customer, onView, onEdit, onMoreActions }: CustomerCardProps) => {
   const fullName = customerName(customer);
   const orders = Number(customer.total_orders ?? 0);
+  const isActive = customer.state === 'active';
+  const moreBtnRef = useRef<View>(null);
 
   return (
-    <RecordCard
-      title={fullName}
-      subtitle={customer.email || customer.document_number || 'Sin correo registrado'}
-      media={{ avatarName: fullName }}
-      badges={[
-        {
-          label: customer.state === 'active' ? 'Activo' : 'Inactivo',
-          variant: customer.state === 'active' ? 'success' : 'warning',
-        },
-      ]}
-      details={[
-        { label: 'Teléfono', value: customer.phone || 'Sin teléfono', icon: 'phone' },
-        { label: 'Órdenes', value: orders, icon: 'shopping-bag' },
-        {
-          label: 'Última compra',
-          value: customer.last_purchase_at ? formatRelative(customer.last_purchase_at) : 'Sin compras',
-          icon: 'calendar',
-        },
-        {
-          label: 'Documento',
-          value: customer.document_number || 'No registrado',
-          icon: 'file-text',
-        },
-      ]}
-      footerLabel="Total gastado"
-      footerValue={formatCurrency(customer.total_spent ?? 0)}
-      footerTone="success"
-      onPress={onPress}
-      style={{ marginHorizontal: spacing[4] }}
-    />
+    <View style={styles.customerCard}>
+      {/* Top row: avatar (user icon) + nombre/email + badge estado (estilo web) */}
+      <View style={styles.cardTopRow}>
+        <View style={styles.cardMedia}>
+          <Icon name="user" size={22} color={colorScales.gray[500]} />
+        </View>
+
+        <View style={styles.cardCenter}>
+          <Text style={styles.cardTitle} numberOfLines={1}>{fullName}</Text>
+          <Text style={styles.cardEmail} numberOfLines={1}>
+            {customer.email || 'Sin correo registrado'}
+          </Text>
+        </View>
+
+        <View
+          style={[
+            styles.cardStatusBadge,
+            { backgroundColor: isActive ? colorScales.green[50] : colorScales.blue[50] },
+          ]}
+        >
+          <Text
+            style={[
+              styles.cardStatusBadgeText,
+              { color: isActive ? colorScales.green[700] : colorScales.blue[700] },
+            ]}
+          >
+            {isActive ? 'Activo' : 'Inactivo'}
+          </Text>
+        </View>
+      </View>
+
+      {/* Detalles: 5 items en grid 3+2 — Teléfono / Documento / Pedidos (row 1) + Última compra / Registrado (row 2) */}
+      {/* Row 1: 3 columnas */}
+      <View style={styles.cardDetailsRow3}>
+        <View style={styles.cardDetailItemThird}>
+          <View style={styles.cardDetailLabelRow}>
+            <Icon name="phone" size={11} color={colorScales.gray[400]} />
+            <Text style={styles.cardDetailLabel}>TELÉFONO</Text>
+          </View>
+          <Text style={styles.cardDetailValue} numberOfLines={1}>
+            {customer.phone || '—'}
+          </Text>
+        </View>
+
+        <View style={styles.cardDetailItemThird}>
+          <View style={styles.cardDetailLabelRow}>
+            <Icon name="credit-card" size={11} color={colorScales.gray[400]} />
+            <Text style={styles.cardDetailLabel}>DOCUMENTO</Text>
+          </View>
+          <Text style={styles.cardDetailValue} numberOfLines={1}>
+            {customer.document_number || '—'}
+          </Text>
+        </View>
+
+        <View style={styles.cardDetailItemThird}>
+          <View style={styles.cardDetailLabelRow}>
+            <Icon name="shopping-bag" size={11} color={colorScales.gray[400]} />
+            <Text style={styles.cardDetailLabel}>PEDIDOS</Text>
+          </View>
+          <Text style={styles.cardDetailValue} numberOfLines={1}>{orders}</Text>
+        </View>
+      </View>
+
+      {/* Row 2: 2 columnas */}
+      <View style={styles.cardDetailsRow2}>
+        <View style={styles.cardDetailItemHalf}>
+          <View style={styles.cardDetailLabelRow}>
+            <Icon name="clock" size={11} color={colorScales.gray[400]} />
+            <Text style={styles.cardDetailLabel}>ÚLTIMA COMPRA</Text>
+          </View>
+          <Text style={styles.cardDetailValue} numberOfLines={1}>
+            {customer.last_purchase_at ? formatRelative(customer.last_purchase_at) : '—'}
+          </Text>
+        </View>
+
+        <View style={styles.cardDetailItemHalf}>
+          <View style={styles.cardDetailLabelRow}>
+            <Icon name="calendar" size={11} color={colorScales.gray[400]} />
+            <Text style={styles.cardDetailLabel}>REGISTRADO</Text>
+          </View>
+          <Text style={styles.cardDetailValue} numberOfLines={1}>
+            {customer.created_at ? formatDate(customer.created_at) : '—'}
+          </Text>
+        </View>
+      </View>
+
+      {/* Footer: Total gastado + 3 acciones (Ver / Editar / Eliminar) — estilo web */}
+      <View style={styles.cardFooter}>
+        <View style={styles.cardFooterLeft}>
+          <Text style={styles.cardFooterLabel}>TOTAL GASTADO</Text>
+          <Text style={styles.cardFooterValue}>
+            {formatCurrency(customer.total_spent ?? 0)}
+          </Text>
+        </View>
+        <View style={styles.cardActions}>
+          {/* Ver: ojo gris (popup) */}
+          <Pressable onPress={onView} hitSlop={6} style={styles.cardActionView}>
+            <Icon name="eye" size={16} color={colorScales.gray[500]} />
+          </Pressable>
+          {/* Editar: lápiz azul (popup) */}
+          <Pressable onPress={onEdit} hitSlop={6} style={styles.cardActionEdit}>
+            <Icon name="edit" size={16} color={colorScales.blue[600]} />
+          </Pressable>
+          {/* Eliminar: 3 puntos gris oscuro (popup) */}
+          <Pressable
+            ref={moreBtnRef}
+            onPress={() => onMoreActions(moreBtnRef.current as View, customer)}
+            hitSlop={6}
+            style={styles.cardActionMore}
+          >
+            <Ionicons name="ellipsis-horizontal" size={16} color={colorScales.gray[700]} />
+          </Pressable>
+        </View>
+      </View>
+    </View>
   );
 };
 
@@ -76,11 +184,62 @@ const CustomerStatsGrid = ({ stats }: { stats: CustomerStats | undefined }) => (
 
 export default function CustomersScreen() {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const [search, setSearch] = useState('');
   const [stateFilter, setStateFilter] = useState<CustomerState | undefined>();
-  const [showFilterDropdown, setShowFilterDropdown] = useState(false);
   const [page, setPage] = useState(1);
   const storeId = useTenantStore((s) => s.storeId);
+  const screenW = Dimensions.get('window').width;
+  const insets = useSafeAreaInsets();
+
+  // Popups de Acciones (+) y Filtros — estilo web (options-dropdown)
+  const [showActions, setShowActions] = useState(false);
+  const [showFilters, setShowFilters] = useState(false);
+  const [showFilterTypeList, setShowFilterTypeList] = useState(false);
+  const actionsBtnRef = useRef<View>(null);
+  const filterBtnRef = useRef<View>(null);
+  const [actionsPos, setActionsPos] = useState({ top: 0, right: 0 });
+  const [filterPos, setFilterPos] = useState({ top: 0, right: 0 });
+
+  // Estado del popup "más opciones" por card (Eliminar)
+  const [cardMoreAnchor, setCardMoreAnchor] = useState<{ top: number; right: number; item: Customer } | null>(null);
+
+  // Estado del confirm dialog de eliminación
+  const [deleteTarget, setDeleteTarget] = useState<Customer | null>(null);
+
+  // Estado del modal Ver (popup eye)
+  const [viewTarget, setViewTarget] = useState<Customer | null>(null);
+
+  // Estado del modal Editar (popup pencil) + form
+  const [editTarget, setEditTarget] = useState<Customer | null>(null);
+  const [editFirstName, setEditFirstName] = useState('');
+  const [editLastName, setEditLastName] = useState('');
+  const [editEmail, setEditEmail] = useState('');
+  const [editPhone, setEditPhone] = useState('');
+  const [editDocumentType, setEditDocumentType] = useState<string>('');
+  const [editDocument, setEditDocument] = useState('');
+  const [showEditDocTypeDropdown, setShowEditDocTypeDropdown] = useState(false);
+  const [editErrors, setEditErrors] = useState<Record<string, string>>({});
+
+  // Estado del modal Nuevo Cliente (popup) + form
+  const [createModalOpen, setCreateModalOpen] = useState(false);
+  const [createFirstName, setCreateFirstName] = useState('');
+  const [createLastName, setCreateLastName] = useState('');
+  const [createEmail, setCreateEmail] = useState('');
+  const [createPhone, setCreatePhone] = useState('');
+  const [createDocumentType, setCreateDocumentType] = useState<string>('');
+  const [createDocumentNumber, setCreateDocumentNumber] = useState('');
+  const [showCreateDocTypeDropdown, setShowCreateDocTypeDropdown] = useState(false);
+  const [createErrors, setCreateErrors] = useState<Record<string, string>>({});
+
+  // Tipos de documento (alineado con customer-modal web)
+  const CREATE_DOCUMENT_TYPES = [
+    { value: 'CC', label: 'Cédula de Ciudadanía' },
+    { value: 'CE', label: 'Cédula de Extranjería' },
+    { value: 'NIT', label: 'NIT' },
+    { value: 'PAS', label: 'Pasaporte' },
+    { value: 'TI', label: 'Tarjeta de Identidad' },
+  ];
 
   const { data: stats } = useQuery({
     queryKey: ['customer-stats', storeId],
@@ -105,6 +264,51 @@ export default function CustomersScreen() {
       }),
   });
 
+  // Mutación: eliminar cliente (estilo web: toast success/error + invalidar queries)
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => CustomerService.delete(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['customers'] });
+      queryClient.invalidateQueries({ queryKey: ['customer-stats'] });
+      toastSuccess('Cliente eliminado correctamente');
+    },
+    onError: (error: any) => {
+      const message = error?.response?.data?.message || error?.message || 'Error al eliminar el cliente';
+      toastError(typeof message === 'string' ? message : 'Error al eliminar el cliente');
+    },
+  });
+
+  // Mutación: actualizar cliente (popup Editar)
+  const updateMutation = useMutation({
+    mutationFn: ({ id, data }: { id: string; data: UpdateCustomerDto }) =>
+      CustomerService.update(id, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['customers'] });
+      queryClient.invalidateQueries({ queryKey: ['customer-stats'] });
+      toastSuccess('Cliente actualizado correctamente');
+      setEditTarget(null);
+    },
+    onError: (error: any) => {
+      const message = error?.response?.data?.message || error?.message || 'Error al actualizar el cliente';
+      toastError(typeof message === 'string' ? message : 'Error al actualizar el cliente');
+    },
+  });
+
+  // Mutación: crear cliente (popup Nuevo Cliente)
+  const createMutation = useMutation({
+    mutationFn: (data: CreateCustomerDto) => CustomerService.create(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['customers'] });
+      queryClient.invalidateQueries({ queryKey: ['customer-stats'] });
+      toastSuccess('Cliente creado exitosamente');
+      closeCreateModal();
+    },
+    onError: (error: any) => {
+      const message = error?.response?.data?.message || error?.message || 'Error al crear el cliente';
+      toastError(typeof message === 'string' ? message : 'Error al crear el cliente');
+    },
+  });
+
   const customers = pageData?.data ?? [];
   const pagination = pageData?.pagination;
   const totalPages = pagination?.totalPages ?? 1;
@@ -114,14 +318,185 @@ export default function CustomersScreen() {
     setPage(1);
   }, []);
 
+  // Mostrar popup "más opciones" (Eliminar) — mide posición del botón
+  const handleMoreActions = useCallback(
+    (ref: View, item: Customer) => {
+      ref.measureInWindow((x, y, w, h) => {
+        setCardMoreAnchor({ top: y + h + 6, right: screenW - x - w, item });
+      });
+    },
+    [screenW],
+  );
+
+  // Abrir confirm dialog de eliminar
+  const handleAskDelete = useCallback((item: Customer) => {
+    setCardMoreAnchor(null);
+    setDeleteTarget(item);
+  }, []);
+
+  // Confirmar eliminar
+  const handleConfirmDelete = useCallback(() => {
+    if (!deleteTarget) return;
+    const id = deleteTarget.id;
+    setDeleteTarget(null);
+    deleteMutation.mutate(id);
+  }, [deleteTarget, deleteMutation]);
+
+  // Abrir popup de Acciones del botón (+) — mide posición
+  const openActions = useCallback(() => {
+    actionsBtnRef.current?.measureInWindow((x, y, w, h) => {
+      setActionsPos({ top: y + h + 6, right: screenW - x - w });
+      setShowActions(true);
+    });
+  }, [screenW]);
+
+  // Abrir popup de Filtros del botón filtro — mide posición
+  const openFilters = useCallback(() => {
+    filterBtnRef.current?.measureInWindow((x, y, w, h) => {
+      setFilterPos({ top: y + h + 6, right: screenW - x - w });
+      setShowFilters(true);
+      setShowFilterTypeList(false);
+    });
+  }, [screenW]);
+
+  // Acción: Carga Masiva — mismo `action: 'bulk-upload'` de la web (pendiente para mobile)
+  const handleBulkUpload = useCallback(() => {
+    setShowActions(false);
+    setShowFilters(false);
+    toastError('Carga masiva próximamente disponible');
+  }, []);
+
+  // Acción: Nuevo Cliente — abre popup modal con el form de creación
+  const openCreateModal = useCallback(() => {
+    setShowActions(false);
+    setShowFilters(false);
+    setCreateFirstName('');
+    setCreateLastName('');
+    setCreateEmail('');
+    setCreatePhone('');
+    setCreateDocumentType('');
+    setCreateDocumentNumber('');
+    setCreateErrors({});
+    setShowCreateDocTypeDropdown(false);
+    setCreateModalOpen(true);
+  }, []);
+
+  const closeCreateModal = useCallback(() => {
+    setCreateModalOpen(false);
+    setCreateErrors({});
+    setShowCreateDocTypeDropdown(false);
+  }, []);
+
+  const handleSubmitCreate = useCallback(() => {
+    setCreateErrors({});
+    const newErrors: Record<string, string> = {};
+    if (!createFirstName.trim()) {
+      newErrors.firstName = 'El nombre es requerido';
+    } else if (createFirstName.trim().length < 2) {
+      newErrors.firstName = 'Mínimo 2 caracteres';
+    }
+    if (!createLastName.trim()) {
+      newErrors.lastName = 'El apellido es requerido';
+    } else if (createLastName.trim().length < 2) {
+      newErrors.lastName = 'Mínimo 2 caracteres';
+    }
+    if (!createEmail.trim()) {
+      newErrors.email = 'El email es requerido';
+    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(createEmail)) {
+      newErrors.email = 'Ingresa un email válido';
+    }
+    if (createPhone.trim() && !/^[\d+#*\s()-]+$/.test(createPhone.trim())) {
+      newErrors.phone = 'El teléfono solo admite números y + # * ( ) -';
+    }
+    if (Object.keys(newErrors).length > 0) {
+      setCreateErrors(newErrors);
+      toastError('Revisa los campos marcados');
+      return;
+    }
+    const dto: CreateCustomerDto = {
+      first_name: createFirstName.trim(),
+      last_name: createLastName.trim(),
+      email: createEmail.trim(),
+      phone: createPhone.trim() || undefined,
+      document_type: createDocumentType || undefined,
+      document_number: createDocumentNumber.trim() || undefined,
+    };
+    createMutation.mutate(dto);
+  }, [createFirstName, createLastName, createEmail, createPhone, createDocumentType, createDocumentNumber, createMutation]);
+
+  // Abrir popup Ver (eye) — muestra detalles del cliente
+  const handleView = useCallback((item: Customer) => {
+    setViewTarget(item);
+  }, []);
+
+  // Abrir popup Editar (pencil) — pre-rellena form con datos del cliente
+  const handleEdit = useCallback((item: Customer) => {
+    setEditTarget(item);
+    setEditFirstName(item.first_name || '');
+    setEditLastName(item.last_name || '');
+    setEditEmail(item.email || '');
+    setEditPhone(item.phone || '');
+    setEditDocumentType(item.document_type || '');
+    setEditDocument(item.document_number || '');
+    setShowEditDocTypeDropdown(false);
+    setEditErrors({});
+  }, []);
+
+  const closeEditModal = useCallback(() => {
+    setEditTarget(null);
+    setEditErrors({});
+    setShowEditDocTypeDropdown(false);
+  }, []);
+
+  const handleSaveEdit = useCallback(() => {
+    if (!editTarget) return;
+    setEditErrors({});
+    // Validar
+    const newErrors: Record<string, string> = {};
+    if (!editFirstName.trim()) {
+      newErrors.firstName = 'El nombre es requerido';
+    } else if (editFirstName.trim().length < 2) {
+      newErrors.firstName = 'Mínimo 2 caracteres';
+    }
+    if (!editLastName.trim()) {
+      newErrors.lastName = 'El apellido es requerido';
+    } else if (editLastName.trim().length < 2) {
+      newErrors.lastName = 'Mínimo 2 caracteres';
+    }
+    if (!editEmail.trim()) {
+      newErrors.email = 'El email es requerido';
+    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(editEmail)) {
+      newErrors.email = 'Ingresa un email válido';
+    }
+    if (editPhone.trim() && !/^[\d+#*\s()-]+$/.test(editPhone.trim())) {
+      newErrors.phone = 'El teléfono solo admite números y + # * ( ) -';
+    }
+    if (Object.keys(newErrors).length > 0) {
+      setEditErrors(newErrors);
+      toastError('Revisa los campos marcados');
+      return;
+    }
+    const dto: UpdateCustomerDto = {
+      first_name: editFirstName.trim(),
+      last_name: editLastName.trim(),
+      email: editEmail.trim(),
+      phone: editPhone.trim() || undefined,
+      document_type: editDocumentType || undefined,
+      document_number: editDocument.trim() || undefined,
+    };
+    updateMutation.mutate({ id: editTarget.id, data: dto });
+  }, [editTarget, editFirstName, editLastName, editEmail, editPhone, editDocumentType, editDocument, updateMutation]);
+
   const renderCustomer = useCallback(
     ({ item }: { item: Customer }) => (
       <CustomerCard
         customer={item}
-        onPress={() => router.push(`/(store-admin)/customers/${item.id}` as never)}
+        onView={() => handleView(item)}
+        onEdit={() => handleEdit(item)}
+        onMoreActions={handleMoreActions}
       />
     ),
-    [router],
+    [handleView, handleEdit, handleMoreActions],
   );
 
   const paginationRange = useMemo(() => {
@@ -173,51 +548,41 @@ export default function CustomersScreen() {
             <CustomerStatsGrid stats={stats} />
             <Text style={styles.title}>Todos los Clientes ({pagination?.total ?? 0})</Text>
             <View style={styles.searchRow}>
-              <SearchBar
-                value={search}
-                onChangeText={handleSearch}
-                onClear={() => handleSearch('')}
-                placeholder="Buscar clientes..."
-                style={styles.searchBar}
-              />
+              <View style={styles.searchInputWrap}>
+                <Ionicons name="search-outline" size={16} color={colorScales.gray[400]} style={styles.searchIcon} />
+                <TextInput
+                  style={styles.searchInputField}
+                  value={search}
+                  onChangeText={handleSearch}
+                  placeholder="Buscar clientes..."
+                  placeholderTextColor={colorScales.gray[400]}
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  returnKeyType="search"
+                />
+                {search.length > 0 && (
+                  <Pressable onPress={() => handleSearch('')} hitSlop={8}>
+                    <Ionicons name="close" size={16} color={colorScales.gray[400]} />
+                  </Pressable>
+                )}
+              </View>
               <Pressable
-                onPress={() => router.push('/(store-admin)/customers/create' as never)}
-                style={styles.searchActionBtn}
+                ref={actionsBtnRef}
+                onPress={openActions}
+                style={styles.iconBtn}
+                hitSlop={6}
               >
-                <Icon name="plus" size={18} color={colors.primary} />
+                <Icon name="plus" size={20} color={colors.primary} />
               </Pressable>
               <Pressable
-                onPress={() => setShowFilterDropdown((p) => !p)}
-                style={styles.searchFilterBtn}
+                ref={filterBtnRef}
+                onPress={openFilters}
+                style={styles.iconBtn}
+                hitSlop={6}
               >
                 <Icon name="filter" size={18} color={colors.primary} />
               </Pressable>
             </View>
-            {showFilterDropdown && (
-              <View style={styles.filterDropdown}>
-                {STATE_FILTERS.map((f) => (
-                  <Pressable
-                    key={f.label}
-                    onPress={() => {
-                      setStateFilter(f.value);
-                      setShowFilterDropdown(false);
-                      setPage(1);
-                    }}
-                    style={[
-                      styles.filterOption,
-                      f.value === stateFilter && styles.filterOptionActive,
-                    ]}
-                  >
-                    <Icon
-                      name="check"
-                      size={14}
-                      color={f.value === stateFilter ? colors.primary : 'transparent'}
-                    />
-                    <Text style={styles.filterOptionText}>{f.label}</Text>
-                  </Pressable>
-                ))}
-              </View>
-            )}
           </View>
         }
         ListEmptyComponent={
@@ -265,15 +630,574 @@ export default function CustomersScreen() {
           ) : null
         }
         refreshControl={<RefreshControl refreshing={isRefetching} onRefresh={refetch} />}
-        contentContainerStyle={styles.listContent}
+        contentContainerStyle={[styles.listContent, { paddingBottom: insets.bottom + spacing[6] }]}
       />
 
-      <Pressable
-        onPress={() => router.push('/(store-admin)/customers/create' as never)}
-        style={styles.fab}
+      {/* Popup de Acciones (botón +) — dropdownActions web: Carga Masiva + Nuevo Cliente */}
+      <Modal visible={showActions} transparent animationType="fade" onRequestClose={() => setShowActions(false)}>
+        <Pressable style={styles.dropdownBackdrop} onPress={() => setShowActions(false)} />
+        <View style={[styles.dropdownPositioner, { top: actionsPos.top, right: actionsPos.right }]}>
+          <View style={[styles.dropdownArrow, { marginRight: 14 }]} />
+          <View style={styles.dropdown}>
+            <Pressable style={styles.dropdownItem} onPress={handleBulkUpload}>
+              <View style={styles.dropdownIconWrap}>
+                <Ionicons name="cloud-upload-outline" size={18} color={colorScales.gray[500]} />
+              </View>
+              <Text style={styles.dropdownItemText}>Carga Masiva</Text>
+            </Pressable>
+            <View style={styles.dropdownDivider} />
+            <Pressable style={styles.dropdownItem} onPress={openCreateModal}>
+              <View style={[styles.dropdownIconWrap, { backgroundColor: colorScales.green[50] }]}>
+                <Ionicons name="add-outline" size={18} color={colors.primary} />
+              </View>
+              <Text style={styles.dropdownItemPrimary}>Nuevo Cliente</Text>
+            </Pressable>
+          </View>
+        </View>
+      </Modal>
+
+      {/* Popup de Filtros (botón filtro) — options-dropdown web: Filtros (Estado) + Acciones */}
+      <Modal
+        visible={showFilters}
+        transparent
+        animationType="fade"
+        onRequestClose={() => { setShowFilters(false); setShowFilterTypeList(false); }}
       >
-        <Icon name="plus" size={24} color={colors.background} />
-      </Pressable>
+        <Pressable
+          style={styles.dropdownBackdrop}
+          onPress={() => { setShowFilters(false); setShowFilterTypeList(false); }}
+        />
+        <View style={[styles.dropdownPositioner, { top: filterPos.top, right: filterPos.right }]}>
+          <View style={[styles.dropdownArrow, { marginRight: Math.max(filterPos.right, 14) }]} />
+          <View style={styles.filterPopup}>
+            {/* Header: Filtros */}
+            <View style={styles.filterPopupHeader}>
+              <Text style={styles.filterPopupTitle}>Filtros</Text>
+            </View>
+            {/* Body: Estado select */}
+            <View style={styles.filterPopupBody}>
+              <Text style={styles.filterPopupLabel}>Estado</Text>
+              <Pressable
+                style={styles.filterPopupSelect}
+                onPress={() => setShowFilterTypeList(!showFilterTypeList)}
+              >
+                <Text style={styles.filterPopupSelectText}>
+                  {STATE_FILTERS.find((f) => f.value === stateFilter)?.label ?? 'Todos'}
+                </Text>
+                <Ionicons
+                  name={showFilterTypeList ? 'chevron-up' : 'chevron-down'}
+                  size={16}
+                  color={colorScales.gray[500]}
+                />
+              </Pressable>
+              {showFilterTypeList && (
+                <View style={styles.filterPopupOptionsList}>
+                  {STATE_FILTERS.map((opt) => (
+                    <Pressable
+                      key={opt.label}
+                      style={[
+                        styles.filterPopupOption,
+                        opt.value === stateFilter && styles.filterPopupOptionActive,
+                      ]}
+                      onPress={() => {
+                        setStateFilter(opt.value);
+                        setPage(1);
+                        setShowFilterTypeList(false);
+                        setShowFilters(false);
+                      }}
+                    >
+                      <Text
+                        style={[
+                          styles.filterPopupOptionText,
+                          opt.value === stateFilter && styles.filterPopupOptionTextActive,
+                        ]}
+                      >
+                        {opt.label}
+                      </Text>
+                      {opt.value === stateFilter && (
+                        <Ionicons name="checkmark" size={16} color={colors.primary} />
+                      )}
+                    </Pressable>
+                  ))}
+                </View>
+              )}
+            </View>
+            {/* Acciones: Carga Masiva + Nuevo Cliente */}
+            <View style={styles.filterPopupActionsDivider} />
+            <View style={styles.filterPopupActions}>
+              <Pressable style={styles.dropdownItem} onPress={handleBulkUpload}>
+                <View style={styles.dropdownIconWrap}>
+                  <Ionicons name="cloud-upload-outline" size={18} color={colorScales.gray[500]} />
+                </View>
+                <Text style={styles.dropdownItemText}>Carga Masiva</Text>
+              </Pressable>
+              <View style={styles.dropdownDivider} />
+              <Pressable style={styles.dropdownItem} onPress={openCreateModal}>
+                <View style={[styles.dropdownIconWrap, { backgroundColor: colorScales.green[50] }]}>
+                  <Ionicons name="add-outline" size={18} color={colors.primary} />
+                </View>
+                <Text style={styles.dropdownItemPrimary}>Nuevo Cliente</Text>
+              </Pressable>
+            </View>
+          </View>
+        </View>
+      </Modal>
+
+      {/* Popup "más opciones" por card (Eliminar) — mismo estilo que locations.tsx */}
+      {cardMoreAnchor && (
+        <Modal visible transparent animationType="fade" onRequestClose={() => setCardMoreAnchor(null)}>
+          <Pressable style={styles.dropdownBackdrop} onPress={() => setCardMoreAnchor(null)} />
+          <View style={[styles.dropdownPositioner, { top: cardMoreAnchor.top, right: cardMoreAnchor.right }]}>
+            <View style={[styles.dropdownArrow, { marginRight: 14 }]} />
+            <View style={styles.dropdown}>
+              <Pressable
+                style={styles.dropdownItem}
+                onPress={() => handleAskDelete(cardMoreAnchor.item)}
+              >
+                <View style={[styles.dropdownIconWrap, { backgroundColor: colorScales.red[50] }]}>
+                  <Ionicons name="trash" size={18} color={colorScales.red[600]} />
+                </View>
+                <Text style={styles.dropdownItemDanger}>Eliminar</Text>
+              </Pressable>
+            </View>
+          </View>
+        </Modal>
+      )}
+
+      {/* Confirm dialog de eliminación — estilo web */}
+      <ConfirmDialog
+        visible={!!deleteTarget}
+        onClose={() => setDeleteTarget(null)}
+        onConfirm={handleConfirmDelete}
+        title="Eliminar cliente"
+        message={
+          deleteTarget
+            ? `¿Estás seguro de que quieres eliminar a "${customerName(deleteTarget)}"? Esta acción no se puede deshacer.`
+            : ''
+        }
+        confirmLabel="Eliminar"
+        cancelLabel="Cancelar"
+        destructive
+        loading={deleteMutation.isPending}
+      />
+
+      {/* Modal Ver (popup eye) — muestra detalles del cliente estilo web */}
+      <Modal visible={!!viewTarget} transparent animationType="fade" onRequestClose={() => setViewTarget(null)}>
+        <View style={styles.createModalOverlay}>
+          <View style={styles.createModal}>
+            {/* Header */}
+            <View style={styles.createHeader}>
+              <View style={styles.createHeaderText}>
+                <Text style={styles.createTitle}>Detalle del Cliente</Text>
+                <Text style={styles.createSubtitle}>Información completa del cliente</Text>
+              </View>
+              <Pressable onPress={() => setViewTarget(null)} hitSlop={8} style={styles.createCloseBtn}>
+                <Ionicons name="close" size={22} color={colorScales.gray[500]} />
+              </Pressable>
+            </View>
+
+            {/* Body: avatar + nombre + status + grid de detalles */}
+            <ScrollView style={styles.createBody} contentContainerStyle={styles.createBodyContent} showsVerticalScrollIndicator={false}>
+              {viewTarget && (
+                <>
+                  <View style={styles.viewProfileRow}>
+                    <Avatar name={customerName(viewTarget)} size="lg" style={styles.viewAvatar} />
+                    <View style={{ flex: 1 }}>
+                      <Text style={styles.viewName}>{customerName(viewTarget)}</Text>
+                      <Text style={styles.viewEmail}>{viewTarget.email || 'Sin correo'}</Text>
+                      <View
+                        style={[
+                          styles.viewStatusBadge,
+                          { backgroundColor: viewTarget.state === 'active' ? colorScales.green[50] : colorScales.gray[100] },
+                        ]}
+                      >
+                        <Text
+                          style={[
+                            styles.viewStatusBadgeText,
+                            { color: viewTarget.state === 'active' ? colorScales.green[700] : colorScales.gray[500] },
+                          ]}
+                        >
+                          {viewTarget.state === 'active' ? 'Activo' : 'Inactivo'}
+                        </Text>
+                      </View>
+                    </View>
+                  </View>
+
+                  <View style={styles.viewGrid}>
+                    <View style={styles.viewGridItem}>
+                      <View style={styles.viewGridLabelRow}>
+                        <Icon name="phone" size={13} color={colorScales.gray[400]} />
+                        <Text style={styles.viewGridLabel}>TELÉFONO</Text>
+                      </View>
+                      <Text style={styles.viewGridValue}>{viewTarget.phone || '—'}</Text>
+                    </View>
+                    <View style={styles.viewGridItem}>
+                      <View style={styles.viewGridLabelRow}>
+                        <Icon name="credit-card" size={13} color={colorScales.gray[400]} />
+                        <Text style={styles.viewGridLabel}>DOCUMENTO</Text>
+                      </View>
+                      <Text style={styles.viewGridValue}>{viewTarget.document_number || '—'}</Text>
+                    </View>
+                    <View style={styles.viewGridItem}>
+                      <View style={styles.viewGridLabelRow}>
+                        <Icon name="shopping-bag" size={13} color={colorScales.gray[400]} />
+                        <Text style={styles.viewGridLabel}>PEDIDOS</Text>
+                      </View>
+                      <Text style={styles.viewGridValue}>{Number(viewTarget.total_orders ?? 0)}</Text>
+                    </View>
+                    <View style={styles.viewGridItem}>
+                      <View style={styles.viewGridLabelRow}>
+                        <Icon name="dollar-sign" size={13} color={colorScales.gray[400]} />
+                        <Text style={styles.viewGridLabel}>TOTAL GASTADO</Text>
+                      </View>
+                      <Text style={styles.viewGridValue}>{formatCurrency(viewTarget.total_spent ?? 0)}</Text>
+                    </View>
+                    <View style={styles.viewGridItem}>
+                      <View style={styles.viewGridLabelRow}>
+                        <Icon name="clock" size={13} color={colorScales.gray[400]} />
+                        <Text style={styles.viewGridLabel}>ÚLTIMA COMPRA</Text>
+                      </View>
+                      <Text style={styles.viewGridValue}>{viewTarget.last_purchase_at ? formatRelative(viewTarget.last_purchase_at) : '—'}</Text>
+                    </View>
+                    <View style={styles.viewGridItem}>
+                      <View style={styles.viewGridLabelRow}>
+                        <Icon name="calendar" size={13} color={colorScales.gray[400]} />
+                        <Text style={styles.viewGridLabel}>REGISTRADO</Text>
+                      </View>
+                      <Text style={styles.viewGridValue}>{viewTarget.created_at ? formatDate(viewTarget.created_at) : '—'}</Text>
+                    </View>
+                  </View>
+                </>
+              )}
+            </ScrollView>
+
+            {/* Footer: Cerrar + Ver detalle completo */}
+            <View style={styles.createFooter}>
+              <Pressable style={styles.cancelBtn} onPress={() => setViewTarget(null)}>
+                <Text style={styles.cancelBtnText}>Cerrar</Text>
+              </Pressable>
+              <View style={styles.actionSpacer} />
+              <Pressable
+                style={styles.confirmBtn}
+                onPress={() => {
+                  const id = viewTarget?.id;
+                  setViewTarget(null);
+                  if (id) router.push(`/(store-admin)/customers/${id}` as never);
+                }}
+              >
+                <Text style={styles.confirmBtnText}>Ver detalle completo</Text>
+              </Pressable>
+            </View>
+          </View>
+        </View>
+      </Modal>
+
+      {/* Modal Editar (popup pencil) — form con datos del cliente (estilo web) */}
+      <Modal visible={!!editTarget} transparent animationType="fade" onRequestClose={closeEditModal}>
+        <View style={styles.createModalOverlay}>
+          <View style={styles.createModal}>
+            {/* Header */}
+            <View style={styles.createHeader}>
+              <View style={styles.createHeaderText}>
+                <Text style={styles.createTitle}>Editar cliente</Text>
+                <Text style={styles.createSubtitle}>Administra la información del cliente</Text>
+              </View>
+              <Pressable onPress={closeEditModal} hitSlop={8} style={styles.createCloseBtn}>
+                <Ionicons name="close" size={22} color={colorScales.gray[500]} />
+              </Pressable>
+            </View>
+
+            <ScrollView style={styles.createBody} contentContainerStyle={styles.createBodyContent} showsVerticalScrollIndicator={false} keyboardShouldPersistTaps="handled">
+              {/* Email */}
+              <View>
+                <Text style={styles.editFormLabel}>EMAIL <Text style={styles.requiredStar}>*</Text></Text>
+                <TextInput
+                  style={[styles.editInput, !!editErrors.email && styles.editInputError]}
+                  value={editEmail}
+                  onChangeText={(v) => { setEditEmail(v); setEditErrors((p) => { const n = { ...p }; delete n.email; return n; }); }}
+                  placeholder="cliente@ejemplo.com"
+                  placeholderTextColor={colorScales.gray[400]}
+                  keyboardType="email-address"
+                  autoCapitalize="none"
+                />
+                {!!editErrors.email && <Text style={styles.editErrorText}>{editErrors.email}</Text>}
+              </View>
+
+              {/* Nombre + Apellido (row) */}
+              <View style={styles.editRow}>
+                <View style={{ flex: 1 }}>
+                  <Text style={styles.editFormLabel}>NOMBRE <Text style={styles.requiredStar}>*</Text></Text>
+                  <TextInput
+                    style={[styles.editInput, !!editErrors.firstName && styles.editInputError]}
+                    value={editFirstName}
+                    onChangeText={(v) => { setEditFirstName(v); setEditErrors((p) => { const n = { ...p }; delete n.firstName; return n; }); }}
+                    placeholder="Ej. María"
+                    placeholderTextColor={colorScales.gray[400]}
+                  />
+                  {!!editErrors.firstName && <Text style={styles.editErrorText}>{editErrors.firstName}</Text>}
+                </View>
+                <View style={{ flex: 1 }}>
+                  <Text style={styles.editFormLabel}>APELLIDO <Text style={styles.requiredStar}>*</Text></Text>
+                  <TextInput
+                    style={[styles.editInput, !!editErrors.lastName && styles.editInputError]}
+                    value={editLastName}
+                    onChangeText={(v) => { setEditLastName(v); setEditErrors((p) => { const n = { ...p }; delete n.lastName; return n; }); }}
+                    placeholder="Ej. Rodríguez"
+                    placeholderTextColor={colorScales.gray[400]}
+                  />
+                  {!!editErrors.lastName && <Text style={styles.editErrorText}>{editErrors.lastName}</Text>}
+                </View>
+              </View>
+
+              {/* Teléfono */}
+              <View>
+                <Text style={styles.editFormLabel}>TELÉFONO</Text>
+                <TextInput
+                  style={[styles.editInput, !!editErrors.phone && styles.editInputError]}
+                  value={editPhone}
+                  onChangeText={(v) => { setEditPhone(v); setEditErrors((p) => { const n = { ...p }; delete n.phone; return n; }); }}
+                  placeholder="+57 300 567 8900"
+                  placeholderTextColor={colorScales.gray[400]}
+                  keyboardType="phone-pad"
+                />
+                {!!editErrors.phone && <Text style={styles.editErrorText}>{editErrors.phone}</Text>}
+              </View>
+
+              {/* Tipo documento + Nº documento (row) — estilo web */}
+              <View style={styles.editRow}>
+                <View style={{ flex: 1 }}>
+                  <Text style={styles.editFormLabel}>TIPO DOCUMENTO</Text>
+                  <Pressable
+                    style={[styles.editInput, styles.createSelectTrigger]}
+                    onPress={() => setShowEditDocTypeDropdown((v) => !v)}
+                  >
+                    <Text style={[
+                      styles.createSelectText,
+                      !editDocumentType && styles.createSelectPlaceholder,
+                    ]}>
+                      {CREATE_DOCUMENT_TYPES.find((d) => d.value === editDocumentType)?.label
+                        || 'Seleccionar tipo'}
+                    </Text>
+                    <Ionicons
+                      name={showEditDocTypeDropdown ? 'chevron-up' : 'chevron-down'}
+                      size={16}
+                      color={colorScales.gray[500]}
+                    />
+                  </Pressable>
+                  {showEditDocTypeDropdown && (
+                    <View style={styles.createSelectDropdown}>
+                      {CREATE_DOCUMENT_TYPES.map((d) => (
+                        <Pressable
+                          key={d.value}
+                          onPress={() => {
+                            setEditDocumentType(d.value);
+                            setShowEditDocTypeDropdown(false);
+                          }}
+                          style={[
+                            styles.createSelectOption,
+                            editDocumentType === d.value && styles.editStateChipActive,
+                          ]}
+                        >
+                          <Text style={[
+                            styles.createSelectOptionText,
+                            editDocumentType === d.value && styles.editStateChipTextActive,
+                          ]}>
+                            {d.label}
+                          </Text>
+                          {editDocumentType === d.value && (
+                            <Ionicons name="checkmark" size={16} color={colors.primary} />
+                          )}
+                        </Pressable>
+                      ))}
+                    </View>
+                  )}
+                </View>
+                <View style={{ flex: 1 }}>
+                  <Text style={styles.editFormLabel}>Nº DOCUMENTO</Text>
+                  <TextInput
+                    style={styles.editInput}
+                    value={editDocument}
+                    onChangeText={setEditDocument}
+                    placeholder="12345678"
+                    placeholderTextColor={colorScales.gray[400]}
+                  />
+                </View>
+              </View>
+            </ScrollView>
+
+            {/* Footer: Cancelar (oscuro) + Actualizar (primary verde) — estilo web */}
+            <View style={styles.createFooter}>
+              <Pressable style={styles.cancelBtn} onPress={closeEditModal}>
+                <Text style={styles.cancelBtnText}>Cancelar</Text>
+              </Pressable>
+              <View style={styles.actionSpacer} />
+              <Pressable
+                style={[styles.confirmBtn, updateMutation.isPending && styles.confirmBtnDisabled]}
+                onPress={handleSaveEdit}
+                disabled={updateMutation.isPending}
+              >
+                <Text style={styles.confirmBtnText}>
+                  {updateMutation.isPending ? 'Actualizando...' : 'Actualizar'}
+                </Text>
+              </Pressable>
+            </View>
+          </View>
+        </View>
+      </Modal>
+
+      {/* Modal Nuevo Cliente (popup) — estilo web con campos de la imagen */}
+      <Modal visible={createModalOpen} transparent animationType="fade" onRequestClose={closeCreateModal}>
+        <View style={styles.createModalOverlay}>
+          <View style={styles.createModal}>
+            {/* Header */}
+            <View style={styles.createHeader}>
+              <View style={styles.createHeaderText}>
+                <Text style={styles.createTitle}>Crear cliente</Text>
+                <Text style={styles.createSubtitle}>Administra la información del cliente</Text>
+              </View>
+              <Pressable onPress={closeCreateModal} hitSlop={8} style={styles.createCloseBtn}>
+                <Ionicons name="close" size={22} color={colorScales.gray[500]} />
+              </Pressable>
+            </View>
+
+            <ScrollView style={styles.createBody} contentContainerStyle={styles.createBodyContent} showsVerticalScrollIndicator={false} keyboardShouldPersistTaps="handled">
+              {/* Correo electrónico */}
+              <View>
+                <Text style={styles.createFormLabel}>CORREO ELECTRONICO <Text style={styles.requiredStar}>*</Text></Text>
+                <TextInput
+                  style={[styles.createInput, !!createErrors.email && styles.editInputError]}
+                  value={createEmail}
+                  onChangeText={(v) => { setCreateEmail(v); setCreateErrors((p) => { const n = { ...p }; delete n.email; return n; }); }}
+                  placeholder="cliente@ejemplo.com"
+                  placeholderTextColor={colorScales.gray[400]}
+                  keyboardType="email-address"
+                  autoCapitalize="none"
+                />
+                {!!createErrors.email && <Text style={styles.editErrorText}>{createErrors.email}</Text>}
+              </View>
+
+              {/* Nombre + Apellido (row) */}
+              <View style={styles.editRow}>
+                <View style={{ flex: 1 }}>
+                  <Text style={styles.createFormLabel}>NOMBRE <Text style={styles.requiredStar}>*</Text></Text>
+                  <TextInput
+                    style={[styles.createInput, !!createErrors.firstName && styles.editInputError]}
+                    value={createFirstName}
+                    onChangeText={(v) => { setCreateFirstName(v); setCreateErrors((p) => { const n = { ...p }; delete n.firstName; return n; }); }}
+                    placeholder="Ej. María"
+                    placeholderTextColor={colorScales.gray[400]}
+                  />
+                  {!!createErrors.firstName && <Text style={styles.editErrorText}>{createErrors.firstName}</Text>}
+                </View>
+                <View style={{ flex: 1 }}>
+                  <Text style={styles.createFormLabel}>APELLIDO <Text style={styles.requiredStar}>*</Text></Text>
+                  <TextInput
+                    style={[styles.createInput, !!createErrors.lastName && styles.editInputError]}
+                    value={createLastName}
+                    onChangeText={(v) => { setCreateLastName(v); setCreateErrors((p) => { const n = { ...p }; delete n.lastName; return n; }); }}
+                    placeholder="Ej. Rodríguez"
+                    placeholderTextColor={colorScales.gray[400]}
+                  />
+                  {!!createErrors.lastName && <Text style={styles.editErrorText}>{createErrors.lastName}</Text>}
+                </View>
+              </View>
+
+              {/* Teléfono */}
+              <View>
+                <Text style={styles.createFormLabel}>TELÉFONO</Text>
+                <TextInput
+                  style={[styles.createInput, !!createErrors.phone && styles.editInputError]}
+                  value={createPhone}
+                  onChangeText={(v) => { setCreatePhone(v); setCreateErrors((p) => { const n = { ...p }; delete n.phone; return n; }); }}
+                  placeholder="+57 300 000 0000"
+                  placeholderTextColor={colorScales.gray[400]}
+                  keyboardType="phone-pad"
+                />
+                {!!createErrors.phone && <Text style={styles.editErrorText}>{createErrors.phone}</Text>}
+              </View>
+
+              {/* Tipo de documento + Número de documento (row) */}
+              <View style={styles.editRow}>
+                <View style={{ flex: 1 }}>
+                  <Text style={styles.createFormLabel}>TIPO DE DOCUMENTO</Text>
+                  <Pressable
+                    style={[styles.createInput, styles.createSelectTrigger]}
+                    onPress={() => setShowCreateDocTypeDropdown((v) => !v)}
+                  >
+                    <Text style={[
+                      styles.createSelectText,
+                      !createDocumentType && styles.createSelectPlaceholder,
+                    ]}>
+                      {CREATE_DOCUMENT_TYPES.find((d) => d.value === createDocumentType)?.label
+                        || 'Selecciona un tipo'}
+                    </Text>
+                    <Ionicons
+                      name={showCreateDocTypeDropdown ? 'chevron-up' : 'chevron-down'}
+                      size={16}
+                      color={colorScales.gray[500]}
+                    />
+                  </Pressable>
+                  {showCreateDocTypeDropdown && (
+                    <View style={styles.createSelectDropdown}>
+                      {CREATE_DOCUMENT_TYPES.map((d) => (
+                        <Pressable
+                          key={d.value}
+                          onPress={() => {
+                            setCreateDocumentType(d.value);
+                            setShowCreateDocTypeDropdown(false);
+                          }}
+                          style={[
+                            styles.createSelectOption,
+                            createDocumentType === d.value && styles.editStateChipActive,
+                          ]}
+                        >
+                          <Text style={[
+                            styles.createSelectOptionText,
+                            createDocumentType === d.value && styles.editStateChipTextActive,
+                          ]}>
+                            {d.label}
+                          </Text>
+                          {createDocumentType === d.value && (
+                            <Ionicons name="checkmark" size={16} color={colors.primary} />
+                          )}
+                        </Pressable>
+                      ))}
+                    </View>
+                  )}
+                </View>
+                <View style={{ flex: 1 }}>
+                  <Text style={styles.createFormLabel}>NÚMERO DE DOCUMENTO</Text>
+                  <TextInput
+                    style={styles.createInput}
+                    value={createDocumentNumber}
+                    onChangeText={setCreateDocumentNumber}
+                    placeholder={createDocumentType ? 'Selecciona primero el tipo' : 'Selecciona primero el tipo'}
+                    placeholderTextColor={colorScales.gray[400]}
+                    editable={!!createDocumentType}
+                  />
+                </View>
+              </View>
+            </ScrollView>
+
+            {/* Footer: Cancelar + Crear — estilo web */}
+            <View style={styles.createFooter}>
+              <Pressable style={styles.cancelBtn} onPress={closeCreateModal}>
+                <Text style={styles.cancelBtnText}>Cancelar</Text>
+              </Pressable>
+              <View style={styles.actionSpacer} />
+              <Pressable
+                style={[styles.confirmBtn, createMutation.isPending && styles.confirmBtnDisabled]}
+                onPress={handleSubmitCreate}
+                disabled={createMutation.isPending}
+              >
+                <Text style={styles.confirmBtnText}>
+                  {createMutation.isPending ? 'Creando...' : 'Crear'}
+                </Text>
+              </Pressable>
+            </View>
+          </View>
+        </View>
+      </Modal>
     </View>
   );
 }
@@ -293,102 +1217,431 @@ const styles = StyleSheet.create({
     backgroundColor: colorScales.gray[50],
   },
   title: {
-    fontSize: typography.fontSize.lg,
-    fontWeight: typography.fontWeight.bold,
+    fontSize: typography.fontSize.base,
+    fontWeight: typography.fontWeight.bold as any,
     color: colorScales.gray[900],
-    marginBottom: spacing[4],
-    marginTop: spacing[2],
+    marginTop: spacing[3],
+    marginBottom: spacing[2],
     paddingHorizontal: spacing[4],
   },
   searchRow: {
     flexDirection: 'row',
+    alignItems: 'center',
     gap: spacing[2],
-    marginBottom: spacing[5],
     paddingHorizontal: spacing[4],
+    paddingBottom: spacing[3],
   },
-  searchBar: {
+  searchInputWrap: {
     flex: 1,
-    height: 44,
-    backgroundColor: colors.background,
-    borderRadius: 12,
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: colorScales.gray[50],
+    borderRadius: borderRadius.lg,
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[2],
     borderWidth: 1,
     borderColor: colorScales.gray[200],
+    minHeight: 40,
     shadowColor: '#000',
     shadowOffset: { width: 0, height: 1 },
     shadowOpacity: 0.04,
     shadowRadius: 3,
     elevation: 1,
   },
-  searchActionBtn: {
-    width: 44,
-    height: 44,
-    borderRadius: 12,
+  searchIcon: { marginRight: spacing[2] },
+  searchInputField: {
+    flex: 1,
+    fontSize: typography.fontSize.sm,
+    fontFamily: typography.fontFamily,
+    color: colorScales.gray[900],
+    padding: 0,
+    height: '100%',
+  },
+  iconBtn: {
+    width: 40,
+    height: 40,
+    borderRadius: borderRadius.lg,
+    backgroundColor: colors.background,
+    borderWidth: 1.5,
+    borderColor: colors.primary,
     alignItems: 'center',
     justifyContent: 'center',
-    borderWidth: 1,
-    borderColor: colors.primary,
-    backgroundColor: colors.background,
     shadowColor: '#000',
     shadowOffset: { width: 0, height: 1 },
     shadowOpacity: 0.04,
     shadowRadius: 3,
     elevation: 1,
   },
-  searchFilterBtn: {
-    width: 44,
-    height: 44,
-    borderRadius: 12,
+  /* === Modales Ver / Editar — estilo web (mismo patrón que locations.tsx createModal) === */
+  createModalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.4)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: spacing[4],
+  },
+  createModal: {
+    backgroundColor: colors.background,
+    borderRadius: borderRadius.lg,
+    borderWidth: 1,
+    borderColor: colorScales.gray[200],
+    width: '100%',
+    maxWidth: 520,
+    maxHeight: '90%',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 8 },
+    shadowOpacity: 0.15,
+    shadowRadius: 24,
+    elevation: 8,
+  },
+  createHeader: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: spacing[3],
+    paddingHorizontal: spacing[4],
+    paddingTop: spacing[4],
+    paddingBottom: spacing[3],
+    borderBottomWidth: 1,
+    borderBottomColor: colorScales.gray[100],
+  },
+  createHeaderText: { flex: 1 },
+  createTitle: {
+    fontSize: typography.fontSize.lg,
+    fontWeight: typography.fontWeight.bold as any,
+    fontFamily: typography.fontFamily,
+    color: colorScales.gray[900],
+  },
+  createSubtitle: {
+    fontSize: typography.fontSize.xs,
+    color: colorScales.gray[500],
+    marginTop: 2,
+  },
+  createCloseBtn: { padding: spacing[1] },
+  createBody: { flexGrow: 0, flexShrink: 1, maxHeight: 480 },
+  createBodyContent: { padding: spacing[4], gap: spacing[3] },
+  createFooter: {
+    flexDirection: 'row',
+    paddingHorizontal: spacing[4],
+    paddingTop: spacing[3],
+    paddingBottom: spacing[4],
+    borderTopWidth: 1,
+    borderTopColor: colorScales.gray[200],
+    backgroundColor: colors.background,
+    gap: spacing[2],
+  },
+  cancelBtn: {
+    flex: 1,
+    paddingVertical: 10,
+    borderRadius: borderRadius.full,
+    backgroundColor: colorScales.gray[900],
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  cancelBtnText: {
+    fontSize: 13,
+    fontWeight: typography.fontWeight.bold as any,
+    color: colors.background,
+  },
+  actionSpacer: { width: spacing[3] },
+  confirmBtn: {
+    flex: 1,
+    paddingVertical: 10,
+    borderRadius: borderRadius.full,
+    backgroundColor: colorScales.green[100],
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  confirmBtnDisabled: { backgroundColor: colorScales.gray[100] },
+  confirmBtnText: {
+    fontSize: 13,
+    fontWeight: typography.fontWeight.bold as any,
+    color: colorScales.green[800],
+  },
+
+  /* Modal Ver — header con avatar + nombre + status + grid de detalles */
+  viewProfileRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+    paddingBottom: spacing[2],
+  },
+  viewAvatar: {
+    width: 56,
+    height: 56,
+  },
+  viewName: {
+    fontSize: typography.fontSize.base,
+    fontWeight: typography.fontWeight.bold as any,
+    fontFamily: typography.fontFamily,
+    color: colorScales.gray[900],
+  },
+  viewEmail: {
+    fontSize: typography.fontSize.sm,
+    fontFamily: typography.fontFamily,
+    color: colorScales.gray[500],
+    marginTop: 2,
+  },
+  viewStatusBadge: {
+    alignSelf: 'flex-start',
+    marginTop: spacing[1],
+    paddingHorizontal: spacing[2.5],
+    paddingVertical: 3,
+    borderRadius: borderRadius.full,
+  },
+  viewStatusBadgeText: {
+    fontSize: 10,
+    fontWeight: typography.fontWeight.bold as any,
+    fontFamily: typography.fontFamily,
+    textTransform: 'uppercase',
+    letterSpacing: 0.3,
+  },
+  viewGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing[2],
+    marginTop: spacing[2],
+  },
+  viewGridItem: {
+    flexGrow: 1,
+    flexBasis: '47%',
+    minWidth: 126,
+    borderRadius: borderRadius.md,
+    backgroundColor: colorScales.gray[50],
     borderWidth: 1,
+    borderColor: colorScales.gray[100],
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[2],
+  },
+  viewGridLabelRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[1],
+  },
+  viewGridLabel: {
+    fontSize: 10,
+    fontWeight: typography.fontWeight.bold as any,
+    fontFamily: typography.fontFamily,
+    color: colorScales.gray[500],
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  viewGridValue: {
+    marginTop: 2,
+    fontSize: typography.fontSize.sm,
+    fontWeight: typography.fontWeight.semibold as any,
+    fontFamily: typography.fontFamily,
+    color: colorScales.gray[800],
+  },
+
+  /* Modal Editar — form */
+  editRow: { flexDirection: 'row', gap: spacing[3] },
+  editFormLabel: {
+    fontSize: 10,
+    fontWeight: typography.fontWeight.bold as any,
+    fontFamily: typography.fontFamily,
+    color: colorScales.gray[500],
+    marginBottom: spacing[1.5],
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  editInput: {
+    borderWidth: 1,
+    borderColor: colorScales.gray[200],
+    borderRadius: borderRadius.md,
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[2.5],
+    fontSize: 14,
+    color: colorScales.gray[900],
+    backgroundColor: colors.background,
+    fontFamily: typography.fontFamily,
+  },
+  editInputError: { borderColor: colorScales.red[500] },
+  editErrorText: {
+    fontSize: 11,
+    color: colorScales.red[600],
+    marginTop: spacing[1],
+  },
+  editStateRow: { flexDirection: 'row', gap: spacing[2] },
+  editStateChip: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing[1.5],
+    paddingVertical: spacing[2.5],
+    paddingHorizontal: spacing[3],
+    borderRadius: borderRadius.md,
+    borderWidth: 1,
+    borderColor: colorScales.gray[200],
+    backgroundColor: colors.background,
+  },
+  editStateChipActive: {
+    backgroundColor: colorScales.green[50],
+    borderColor: colorScales.green[500],
+  },
+  editStateChipText: {
+    fontSize: 13,
+    fontWeight: typography.fontWeight.medium as any,
+    fontFamily: typography.fontFamily,
+    color: colorScales.gray[700],
+  },
+  editStateChipTextActive: {
+    color: colors.primary,
+    fontWeight: typography.fontWeight.bold as any,
+  },
+
+  /* Modal Nuevo Cliente — form con campos de la imagen */
+  createFormLabel: {
+    fontSize: 10,
+    fontWeight: typography.fontWeight.bold as any,
+    fontFamily: typography.fontFamily,
+    color: colorScales.gray[500],
+    marginBottom: spacing[1.5],
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  requiredStar: { color: colorScales.red[500] },
+  createInput: {
+    borderWidth: 1,
+    borderColor: colorScales.gray[200],
+    borderRadius: borderRadius.md,
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[2.5],
+    fontSize: 14,
+    color: colorScales.gray[900],
+    backgroundColor: colors.background,
+    fontFamily: typography.fontFamily,
+  },
+  createSelectTrigger: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: spacing[2.5],
+  },
+  createSelectText: {
+    flex: 1,
+    fontSize: 14,
+    fontFamily: typography.fontFamily,
+    color: colorScales.gray[900],
+  },
+  createSelectPlaceholder: { color: colorScales.gray[400] },
+  createSelectDropdown: {
+    marginTop: spacing[1],
+    borderWidth: 1,
+    borderColor: colorScales.gray[200],
+    borderRadius: borderRadius.md,
+    backgroundColor: colors.background,
+    overflow: 'hidden',
+  },
+  createSelectOption: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: spacing[2.5],
+    paddingHorizontal: spacing[3],
+    borderBottomWidth: 1,
+    borderBottomColor: colorScales.gray[100],
+  },
+  createSelectOptionText: {
+    fontSize: 14,
+    fontFamily: typography.fontFamily,
+    color: colorScales.gray[700],
+  },
+
+  /* === Filter popup (estilo web options-dropdown) === */
+  filterPopup: {
+    backgroundColor: colors.background,
+    borderRadius: borderRadius.lg,
+    borderWidth: 1,
+    borderColor: colorScales.gray[200],
+    width: 220,
+    ...shadows.lg,
+    overflow: 'hidden',
+  },
+  filterPopupHeader: {
+    paddingHorizontal: spacing[4],
+    paddingTop: spacing[3],
+    paddingBottom: spacing[2],
+    borderBottomWidth: 1,
+    borderBottomColor: colorScales.gray[100],
+  },
+  filterPopupTitle: {
+    fontSize: typography.fontSize.base,
+    fontWeight: typography.fontWeight.bold as any,
+    fontFamily: typography.fontFamily,
+    color: colorScales.gray[900],
+  },
+  filterPopupBody: {
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[3],
+    gap: spacing[2],
+  },
+  filterPopupLabel: {
+    fontSize: typography.fontSize.sm,
+    fontWeight: typography.fontWeight.semibold as any,
+    fontFamily: typography.fontFamily,
+    color: colorScales.gray[700],
+  },
+  filterPopupSelect: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: spacing[2.5],
+    paddingHorizontal: spacing[3],
+    borderRadius: borderRadius.lg,
+    borderWidth: 1.5,
     borderColor: colors.primary,
     backgroundColor: colors.background,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 1 },
-    shadowOpacity: 0.04,
-    shadowRadius: 3,
-    elevation: 1,
   },
-  filterDropdown: {
-    backgroundColor: colors.background,
+  filterPopupSelectText: {
+    fontSize: typography.fontSize.sm,
+    fontWeight: typography.fontWeight.semibold as any,
+    fontFamily: typography.fontFamily,
+    color: colorScales.gray[800],
+  },
+  filterPopupOptionsList: {
+    marginTop: spacing[1],
     borderWidth: 1,
     borderColor: colorScales.gray[200],
     borderRadius: borderRadius.lg,
-    marginBottom: spacing[3],
-    ...shadows.md,
+    backgroundColor: colors.background,
+    overflow: 'hidden',
   },
-  filterOption: {
+  filterPopupOption: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: spacing[2],
+    justifyContent: 'space-between',
+    paddingVertical: spacing[2.5],
     paddingHorizontal: spacing[3],
-    paddingVertical: spacing[3],
+    borderBottomWidth: 1,
+    borderBottomColor: colorScales.gray[100],
   },
-  filterOptionActive: {
-    backgroundColor: colorScales.gray[50],
+  filterPopupOptionActive: {
+    backgroundColor: colorScales.green[50],
   },
-  filterOptionText: {
+  filterPopupOptionText: {
     fontSize: typography.fontSize.sm,
-    fontWeight: typography.fontWeight.medium,
-    color: colorScales.gray[800],
+    fontFamily: typography.fontFamily,
+    color: colorScales.gray[700],
+  },
+  filterPopupOptionTextActive: {
+    fontSize: typography.fontSize.sm,
+    fontWeight: typography.fontWeight.bold as any,
+    fontFamily: typography.fontFamily,
+    color: colors.primary,
+  },
+  filterPopupActionsDivider: {
+    height: 1,
+    backgroundColor: colorScales.gray[100],
+  },
+  filterPopupActions: {
+    paddingVertical: spacing[1],
   },
   listContent: {
-    paddingBottom: spacing[24],
+    paddingBottom: spacing[6],
   },
   separator: {
     height: spacing[3],
-  },
-  fab: {
-    position: 'absolute',
-    bottom: spacing[6],
-    right: spacing[6],
-    width: 56,
-    height: 56,
-    borderRadius: borderRadius.full,
-    backgroundColor: colors.primary,
-    alignItems: 'center',
-    justifyContent: 'center',
-    ...shadows.lg,
   },
   pagination: {
     flexDirection: 'row',
@@ -426,7 +1679,7 @@ const styles = StyleSheet.create({
   },
   pageNumText: {
     fontSize: typography.fontSize.sm,
-    fontWeight: typography.fontWeight.medium,
+    fontWeight: typography.fontWeight.medium as any,
     color: colorScales.gray[700],
   },
   pageNumTextActive: {
@@ -437,5 +1690,257 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     fontSize: typography.fontSize.sm,
     color: colorScales.gray[400],
+  },
+
+  /* === Customer card — estilo web: top row (avatar + nombre/email + badge) + grid (4 details) + footer (total + 3 acciones) === */
+  customerCard: {
+    marginHorizontal: spacing[3],
+    marginBottom: spacing[3],
+    backgroundColor: colors.background,
+    borderRadius: borderRadius.lg,
+    borderWidth: 1,
+    borderColor: colorScales.gray[200],
+    overflow: 'hidden',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.05,
+    shadowRadius: 3,
+    elevation: 1,
+  },
+  cardTopRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: spacing[3],
+    padding: spacing[4],
+    paddingBottom: spacing[2],
+  },
+  cardMedia: {
+    width: 44,
+    height: 44,
+    borderRadius: borderRadius.full,
+    backgroundColor: colorScales.gray[50],
+    borderWidth: 1,
+    borderColor: colorScales.gray[200],
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  cardAvatar: {
+    width: 44,
+    height: 44,
+  },
+  cardCenter: {
+    flex: 1,
+    gap: 2,
+    minWidth: 0,
+  },
+  cardTitle: {
+    fontSize: typography.fontSize.base,
+    fontWeight: typography.fontWeight.bold as any,
+    fontFamily: typography.fontFamily,
+    color: colorScales.gray[900],
+  },
+  cardEmail: {
+    fontSize: typography.fontSize.sm,
+    fontFamily: typography.fontFamily,
+    color: colorScales.gray[500],
+  },
+  cardStatusBadge: {
+    paddingHorizontal: spacing[2.5],
+    paddingVertical: 3,
+    borderRadius: borderRadius.full,
+    alignSelf: 'flex-start',
+  },
+  cardStatusBadgeText: {
+    fontSize: 10,
+    fontWeight: typography.fontWeight.bold as any,
+    fontFamily: typography.fontFamily,
+    textTransform: 'uppercase',
+    letterSpacing: 0.3,
+  },
+  cardDetailsGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing[2],
+    paddingHorizontal: spacing[4],
+    paddingBottom: spacing[3],
+  },
+  cardDetailsRow3: {
+    flexDirection: 'row',
+    gap: spacing[2],
+    paddingHorizontal: spacing[4],
+    paddingBottom: spacing[2],
+  },
+  cardDetailsRow2: {
+    flexDirection: 'row',
+    gap: spacing[2],
+    paddingHorizontal: spacing[4],
+    paddingBottom: spacing[3],
+  },
+  cardDetailItemThird: {
+    flex: 1,
+    minWidth: 0,
+    borderRadius: borderRadius.md,
+    backgroundColor: colorScales.gray[50],
+    borderWidth: 1,
+    borderColor: colorScales.gray[100],
+    paddingHorizontal: spacing[2.5],
+    paddingVertical: spacing[2],
+  },
+  cardDetailItemHalf: {
+    flex: 1,
+    minWidth: 0,
+    borderRadius: borderRadius.md,
+    backgroundColor: colorScales.gray[50],
+    borderWidth: 1,
+    borderColor: colorScales.gray[100],
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[2],
+  },
+  cardDetailItem: {
+    flexGrow: 1,
+    flexBasis: '47%',
+    minWidth: 126,
+    borderRadius: borderRadius.md,
+    backgroundColor: colorScales.gray[50],
+    borderWidth: 1,
+    borderColor: colorScales.gray[100],
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[2],
+  },
+  cardDetailLabelRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[1],
+  },
+  cardDetailLabel: {
+    fontSize: 10,
+    fontWeight: typography.fontWeight.bold as any,
+    fontFamily: typography.fontFamily,
+    color: colorScales.gray[500],
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  cardDetailValue: {
+    marginTop: 2,
+    fontSize: typography.fontSize.sm,
+    fontWeight: typography.fontWeight.semibold as any,
+    fontFamily: typography.fontFamily,
+    color: colorScales.gray[800],
+  },
+  cardFooter: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[3],
+    borderTopWidth: 1,
+    borderTopColor: colorScales.gray[100],
+    backgroundColor: colorScales.gray[50],
+  },
+  cardFooterLeft: {
+    gap: 2,
+  },
+  cardFooterLabel: {
+    fontSize: 10,
+    fontWeight: typography.fontWeight.bold as any,
+    fontFamily: typography.fontFamily,
+    color: colorScales.gray[500],
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  cardFooterValue: {
+    fontSize: typography.fontSize.lg,
+    fontWeight: typography.fontWeight.bold as any,
+    fontFamily: typography.fontFamily,
+    color: colorScales.gray[900],
+  },
+  cardActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+  },
+  cardActionView: {
+    width: 36,
+    height: 36,
+    borderRadius: borderRadius.md,
+    backgroundColor: colorScales.gray[100],
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  cardActionEdit: {
+    width: 36,
+    height: 36,
+    borderRadius: borderRadius.md,
+    backgroundColor: colorScales.blue[50],
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  cardActionMore: {
+    width: 36,
+    height: 36,
+    borderRadius: borderRadius.md,
+    backgroundColor: colorScales.gray[200],
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+
+  /* Dropdown de acciones (popup "Eliminar") — mismo estilo que locations.tsx */
+  dropdownBackdrop: { flex: 1 },
+  dropdownPositioner: { position: 'absolute', alignItems: 'flex-end' },
+  dropdownArrow: {
+    width: 0,
+    height: 0,
+    borderLeftWidth: 8,
+    borderRightWidth: 8,
+    borderBottomWidth: 8,
+    borderLeftColor: 'transparent',
+    borderRightColor: 'transparent',
+    borderBottomColor: colors.background,
+    marginRight: 14,
+    marginBottom: -1,
+  },
+  dropdown: {
+    backgroundColor: colors.background,
+    borderRadius: borderRadius.lg,
+    borderWidth: 1,
+    borderColor: colorScales.gray[200],
+    minWidth: 200,
+    ...shadows.lg,
+  },
+  dropdownItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+    paddingVertical: spacing[2.5],
+    paddingHorizontal: spacing[3],
+  },
+  dropdownItemText: {
+    fontSize: typography.fontSize.sm,
+    fontWeight: typography.fontWeight.medium as any,
+    fontFamily: typography.fontFamily,
+    color: colorScales.gray[700],
+  },
+  dropdownItemPrimary: {
+    fontSize: typography.fontSize.sm,
+    fontWeight: typography.fontWeight.bold as any,
+    fontFamily: typography.fontFamily,
+    color: colors.primary,
+  },
+  dropdownIconWrap: {
+    width: 28,
+    height: 28,
+    borderRadius: 6,
+    backgroundColor: colorScales.gray[100],
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  dropdownDivider: {
+    height: 1,
+    backgroundColor: colorScales.gray[100],
+  },
+  dropdownItemDanger: {
+    fontSize: typography.fontSize.sm,
+    fontWeight: typography.fontWeight.bold as any,
+    color: colorScales.red[600],
   },
 });

--- a/apps/mobile/app/(store-admin)/customers/data-collection/_layout.tsx
+++ b/apps/mobile/app/(store-admin)/customers/data-collection/_layout.tsx
@@ -1,7 +1,7 @@
 import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { Slot, useRouter, useSegments } from 'expo-router';
 import { Icon } from '@/shared/components/icon/icon';
-import { borderRadius, colorScales, colors, spacing, typography } from '@/shared/theme';
+import { borderRadius, colorScales, colors, shadows, spacing, typography } from '@/shared/theme';
 
 const TABS = [
   { id: 'fields', label: 'Campos', icon: 'database' },
@@ -25,11 +25,13 @@ export default function DataCollectionLayout() {
 
   return (
     <View style={styles.root}>
-      <View style={styles.tabBar}>
+      {/* Tab bar: sticky + elevation (estilo web sticky top-0 backdrop-blur shadow-sm) */}
+      <View style={styles.tabBarWrap}>
         <ScrollView
           horizontal
           showsHorizontalScrollIndicator={false}
           contentContainerStyle={styles.tabList}
+          style={styles.tabBar}
         >
           {TABS.map((tab) => {
             const isActive = tab.id === activeTab;
@@ -62,10 +64,14 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: colorScales.gray[50],
   },
-  tabBar: {
+  tabBarWrap: {
     backgroundColor: colors.background,
     borderBottomWidth: 1,
     borderBottomColor: colorScales.gray[200],
+    ...shadows.sm,
+  },
+  tabBar: {
+    flexGrow: 0,
   },
   tabList: {
     flexDirection: 'row',

--- a/apps/mobile/app/(store-admin)/customers/data-collection/fields.tsx
+++ b/apps/mobile/app/(store-admin)/customers/data-collection/fields.tsx
@@ -1,88 +1,238 @@
-import { useCallback, useState } from 'react';
-import { FlatList, Pressable, RefreshControl, StyleSheet, Text, View } from 'react-native';
+import { useCallback, useMemo, useState } from 'react';
+import { FlatList, Pressable, RefreshControl, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
 import { useQuery } from '@tanstack/react-query';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Icon } from '@/shared/components/icon/icon';
 import { Spinner } from '@/shared/components/spinner/spinner';
 import { EmptyState } from '@/shared/components/empty-state/empty-state';
+import { ConfirmDialog } from '@/shared/components/confirm-dialog/confirm-dialog';
+import { toastSuccess, toastError } from '@/shared/components/toast/toast.store';
 import { DataCollectionService } from '@/features/store/services/data-collection.service';
 import { borderRadius, colorScales, colors, shadows, spacing, typography } from '@/shared/theme';
-import type { MetadataField } from '@/features/store/types/data-collection.types';
+import type { MetadataField, FieldType, EntityType, DisplayMode } from '@/features/store/types/data-collection.types';
+
+const ENTITY_LABELS: Record<string, string> = {
+  customer: 'Cliente',
+  booking: 'Reserva',
+  order: 'Orden',
+};
+
+const FIELD_TYPES: { value: FieldType; label: string }[] = [
+  { value: 'text', label: 'Texto' },
+  { value: 'number', label: 'Número' },
+  { value: 'date', label: 'Fecha' },
+  { value: 'select', label: 'Selección' },
+  { value: 'checkbox', label: 'Checkbox' },
+  { value: 'textarea', label: 'Área de texto' },
+  { value: 'file', label: 'Archivo' },
+  { value: 'email', label: 'Email' },
+  { value: 'phone', label: 'Teléfono' },
+  { value: 'url', label: 'URL' },
+];
+
+const DISPLAY_MODES: { value: DisplayMode; label: string }[] = [
+  { value: 'detail', label: 'Detalle' },
+  { value: 'summary', label: 'Resumen' },
+];
+
+const ENTITY_OPTIONS = ['customer', 'booking', 'order'] as const;
+
+// Opciones de filtro de entidad (web: [{id:'',label:'Todos'}, ...])
+const ENTITY_FILTER_OPTIONS: { value: string | undefined; label: string }[] = [
+  { value: undefined, label: 'Todos' },
+  ...ENTITY_OPTIONS.map((e) => ({ value: e as string, label: ENTITY_LABELS[e] })),
+];
 
 export default function FieldsScreen() {
+  const insets = useSafeAreaInsets();
   const [entityFilter, setEntityFilter] = useState<string | undefined>();
+  const [search, setSearch] = useState('');
+  const [showModal, setShowModal] = useState(false);
+  const [editingField, setEditingField] = useState<MetadataField | null>(null);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState<MetadataField | null>(null);
+  const [actionLoading, setActionLoading] = useState(false);
+
+  // Form state
+  const [formLabel, setFormLabel] = useState('');
+  const [formKey, setFormKey] = useState('');
+  const [formEntityType, setFormEntityType] = useState<EntityType>('customer');
+  const [formFieldType, setFormFieldType] = useState<FieldType>('text');
+  const [formDescription, setFormDescription] = useState('');
+  const [formDisplayMode, setFormDisplayMode] = useState<DisplayMode>('detail');
+  const [formRequired, setFormRequired] = useState(false);
+  const [formOptionsText, setFormOptionsText] = useState('');
 
   const { data: fields, isLoading, isRefetching, refetch } = useQuery({
     queryKey: ['metadata-fields', entityFilter],
     queryFn: () => DataCollectionService.fields.list(entityFilter),
   });
 
+  const filteredFields = useMemo(() => {
+    if (!fields) return [];
+    const term = search.toLowerCase().trim();
+    if (!term) return fields;
+    return fields.filter(
+      (f) =>
+        f.label.toLowerCase().includes(term) ||
+        f.field_key.toLowerCase().includes(term) ||
+        f.field_type.toLowerCase().includes(term),
+    );
+  }, [fields, search]);
+
   const handleToggle = useCallback(async (field: MetadataField) => {
-    await DataCollectionService.fields.toggle(field.id);
-    refetch();
+    try {
+      await DataCollectionService.fields.toggle(field.id);
+      toastSuccess(field.is_active ? 'Campo desactivado' : 'Campo activado');
+      refetch();
+    } catch (error: any) {
+      const message = error?.response?.data?.message || error?.message || 'Error al cambiar el estado';
+      toastError(typeof message === 'string' ? message : 'Error al cambiar el estado');
+    }
   }, [refetch]);
 
-  const handleDelete = useCallback(async (id: number) => {
-    await DataCollectionService.fields.delete(id);
-    refetch();
-  }, [refetch]);
+  const handleSearch = useCallback((text: string) => {
+    setSearch(text);
+  }, []);
 
-  const ENTITY_LABELS: Record<string, string> = {
-    customer: 'Clientes',
-    booking: 'Reservas',
-    order: 'Órdenes',
-  };
+  const openCreateModal = useCallback(() => {
+    setEditingField(null);
+    setFormLabel('');
+    setFormKey('');
+    setFormEntityType('customer');
+    setFormFieldType('text');
+    setFormDescription('');
+    setFormDisplayMode('detail');
+    setFormRequired(false);
+    setFormOptionsText('');
+    setShowModal(true);
+  }, []);
 
-  const FIELD_TYPE_LABELS: Record<string, string> = {
-    text: 'Texto',
-    number: 'Número',
-    date: 'Fecha',
-    select: 'Selección',
-    checkbox: 'Checkbox',
-    textarea: 'Área de texto',
-    file: 'Archivo',
-    email: 'Email',
-    phone: 'Teléfono',
-    url: 'URL',
-  };
+  const openEditModal = useCallback((field: MetadataField) => {
+    setEditingField(field);
+    setFormLabel(field.label);
+    setFormKey(field.field_key);
+    setFormEntityType(field.entity_type);
+    setFormFieldType(field.field_type);
+    setFormDescription(field.description || '');
+    setFormDisplayMode(field.display_mode);
+    setFormRequired(field.is_required);
+    // Convertir options (array o record) a texto (uno por línea)
+    const opts = field.options;
+    if (Array.isArray(opts)) {
+      setFormOptionsText((opts as string[]).join('\n'));
+    } else if (opts && typeof opts === 'object') {
+      setFormOptionsText(Object.values(opts as Record<string, string>).join('\n'));
+    } else {
+      setFormOptionsText('');
+    }
+    setShowModal(true);
+  }, []);
+
+  const autoGenerateKey = useCallback((label: string) => {
+    if (!editingField) {
+      setFormKey(
+        label
+          .toLowerCase()
+          .replace(/[^a-z0-9\s]/g, '')
+          .replace(/\s+/g, '_')
+          .substring(0, 100),
+      );
+    }
+  }, [editingField]);
+
+  const handleSaveField = useCallback(async () => {
+    if (!formLabel.trim() || !formKey.trim()) return;
+    setActionLoading(true);
+    try {
+      const data: Partial<MetadataField> & { options?: string[] } = {
+        label: formLabel.trim(),
+        field_key: formKey.trim(),
+        entity_type: formEntityType,
+        field_type: formFieldType,
+        description: formDescription.trim() || undefined,
+        display_mode: formDisplayMode,
+        is_required: formRequired,
+      };
+      // Si el tipo es "select", enviar las opciones como array (web field-modal)
+      if (formFieldType === 'select' && formOptionsText.trim()) {
+        data.options = formOptionsText
+          .split('\n')
+          .map((o) => o.trim())
+          .filter(Boolean);
+      }
+      if (editingField) {
+        await DataCollectionService.fields.update(editingField.id, data);
+        toastSuccess('Campo actualizado');
+      } else {
+        await DataCollectionService.fields.create(data);
+        toastSuccess('Campo creado');
+      }
+      setShowModal(false);
+      refetch();
+    } catch (error: any) {
+      const message = error?.response?.data?.message || error?.message || 'Error al guardar el campo';
+      toastError(typeof message === 'string' ? message : 'Error al guardar el campo');
+    } finally {
+      setActionLoading(false);
+    }
+  }, [formLabel, formKey, formEntityType, formFieldType, formDescription, formDisplayMode, formRequired, formOptionsText, editingField, refetch]);
+
+  const handleDeleteField = useCallback(async () => {
+    if (!showDeleteConfirm) return;
+    setActionLoading(true);
+    try {
+      await DataCollectionService.fields.delete(showDeleteConfirm.id);
+      toastSuccess('Campo eliminado');
+      setShowDeleteConfirm(null);
+      refetch();
+    } catch (error: any) {
+      const message = error?.response?.data?.message || error?.message || 'Error al eliminar el campo';
+      toastError(typeof message === 'string' ? message : 'Error al eliminar el campo');
+    } finally {
+      setActionLoading(false);
+    }
+  }, [showDeleteConfirm, refetch]);
 
   const renderField = useCallback(
     ({ item }: { item: MetadataField }) => (
-      <View style={styles.fieldCard}>
-        <View style={styles.fieldHeader}>
-          <View style={styles.fieldInfo}>
-            <Text style={styles.fieldLabel}>{item.label}</Text>
-            <Text style={styles.fieldKey}>@{item.field_key}</Text>
+      <Pressable onPress={() => openEditModal(item)} style={styles.card}>
+        <View style={styles.cardHeader}>
+          <View style={styles.cardHeaderInfo}>
+            <Text style={styles.cardTitle}>{item.label}</Text>
+            <Text style={styles.cardSubtitle}>@{item.field_key}</Text>
           </View>
           <View style={[styles.statusDot, item.is_active ? styles.statusActive : styles.statusInactive]} />
         </View>
-        <View style={styles.fieldMeta}>
-          <View style={styles.fieldMetaTag}>
-            <Text style={styles.fieldMetaText}>{FIELD_TYPE_LABELS[item.field_type] || item.field_type}</Text>
+
+        <View style={styles.cardMetaRow}>
+          <View style={styles.metaTag}>
+            <Text style={styles.metaTagText}>{ENTITY_LABELS[item.entity_type] || item.entity_type}</Text>
           </View>
-          <View style={styles.fieldMetaTag}>
-            <Text style={styles.fieldMetaText}>{ENTITY_LABELS[item.entity_type] || item.entity_type}</Text>
+          <View style={styles.metaTag}>
+            <Text style={styles.metaTagText}>{FIELD_TYPES.find((t) => t.value === item.field_type)?.label || item.field_type}</Text>
           </View>
           {item.is_required && (
-            <View style={styles.fieldMetaTagRequired}>
-              <Text style={styles.fieldMetaTextRequired}>Obligatorio</Text>
+            <View style={styles.metaTagRequired}>
+              <Text style={styles.metaTagTextRequired}>Obligatorio</Text>
             </View>
           )}
         </View>
-        <View style={styles.fieldActions}>
-          <Pressable onPress={() => handleToggle(item)} style={styles.fieldActionBtn}>
+
+        <View style={styles.cardActions}>
+          <Pressable onPress={() => handleToggle(item)} style={styles.actionBtn}>
             <Icon
-              name={item.is_active ? 'toggle-right' : 'toggle-left'}
-              size={18}
+              name={item.is_active ? 'check-circle' : 'circle'}
+              size={20}
               color={item.is_active ? colors.primary : colorScales.gray[400]}
             />
           </Pressable>
-          <Pressable onPress={() => handleDelete(item.id)} style={styles.fieldActionBtn}>
+          <Pressable onPress={() => setShowDeleteConfirm(item)} style={styles.actionBtn}>
             <Icon name="trash-2" size={16} color={colorScales.red[500]} />
           </Pressable>
         </View>
-      </View>
+      </Pressable>
     ),
-    [handleToggle, handleDelete],
+    [handleToggle, openEditModal],
   );
 
   if (isLoading) {
@@ -96,68 +246,248 @@ export default function FieldsScreen() {
   return (
     <View style={styles.root}>
       <FlatList
-        data={fields ?? []}
+        data={filteredFields}
         keyExtractor={(item) => String(item.id)}
         renderItem={renderField}
         ItemSeparatorComponent={() => <View style={styles.separator} />}
         ListHeaderComponent={
-          <View style={styles.filterRow}>
-            {['customer', 'booking', 'order'].map((type) => (
-              <Pressable
-                key={type}
-                onPress={() => setEntityFilter(entityFilter === type ? undefined : type)}
-                style={[
-                  styles.filterChip,
-                  entityFilter === type && styles.filterChipActive,
-                ]}
-              >
-                <Text
-                  style={[
-                    styles.filterChipText,
-                    entityFilter === type && styles.filterChipTextActive,
-                  ]}
-                >
-                  {ENTITY_LABELS[type]}
-                </Text>
+          <View>
+            {/* Entity filter chips (estilo web: incluye "Todos") */}
+            <View style={styles.filterRow}>
+              {ENTITY_FILTER_OPTIONS.map((opt) => {
+                const isActive = entityFilter === opt.value;
+                return (
+                  <Pressable
+                    key={opt.label}
+                    onPress={() => setEntityFilter(opt.value)}
+                    style={[
+                      styles.filterChip,
+                      isActive && styles.filterChipActive,
+                    ]}
+                  >
+                    <Text
+                      style={[
+                        styles.filterChipText,
+                        isActive && styles.filterChipTextActive,
+                      ]}
+                    >
+                      {opt.label}
+                    </Text>
+                  </Pressable>
+                );
+              })}
+            </View>
+            {/* Title */}
+            <View style={styles.headerRow}>
+              <Text style={styles.headerTitle}>Campos Personalizados ({fields?.length ?? 0})</Text>
+            </View>
+            {/* Search + (+) button */}
+            <View style={styles.searchRow}>
+              <View style={styles.searchInputWrapper}>
+                <Icon name="search" size={16} color={colorScales.gray[400]} />
+                <TextInput
+                  value={search}
+                  onChangeText={handleSearch}
+                  placeholder="Buscar campos..."
+                  placeholderTextColor={colorScales.gray[400]}
+                  style={styles.searchInput}
+                />
+              </View>
+              <Pressable onPress={openCreateModal} style={styles.addBtn}>
+                <Icon name="plus" size={18} color={colors.primary} />
               </Pressable>
-            ))}
+            </View>
           </View>
         }
         ListEmptyComponent={
           <EmptyState
-            title="Sin campos"
-            description="No hay campos de metadatos configurados"
+            title="No hay campos"
+            description="Define los campos de datos para clientes, reservas y órdenes"
             icon="database"
+            actionLabel="Nuevo Campo"
+            onAction={openCreateModal}
           />
         }
         refreshControl={<RefreshControl refreshing={isRefetching} onRefresh={refetch} />}
-        contentContainerStyle={styles.listContent}
+        contentContainerStyle={[styles.listContent, { paddingBottom: insets.bottom + spacing[8] }]}
+        keyboardShouldPersistTaps="handled"
+      />
+
+      {/* Create/Edit Modal */}
+      {showModal && (
+        <View style={styles.modalOverlay}>
+          <Pressable style={styles.modalBackdrop} onPress={() => setShowModal(false)} />
+          <ScrollView style={styles.modalSheet} keyboardShouldPersistTaps="handled">
+            <View style={styles.modalHeader}>
+              <Text style={styles.modalTitle}>{editingField ? 'Editar Campo' : 'Nuevo Campo'}</Text>
+              <Pressable onPress={() => setShowModal(false)}>
+                <Icon name="x" size={20} color={colorScales.gray[500]} />
+              </Pressable>
+            </View>
+
+            {/* Label */}
+            <View style={styles.formGroup}>
+              <Text style={styles.formLabel}>Label</Text>
+              <TextInput
+                value={formLabel}
+                onChangeText={(t) => { setFormLabel(t); autoGenerateKey(t); }}
+                placeholder="Ej: Fecha de nacimiento"
+                placeholderTextColor={colorScales.gray[400]}
+                style={styles.formInput}
+              />
+            </View>
+
+            {/* Key */}
+            <View style={styles.formGroup}>
+              <Text style={styles.formLabel}>Key</Text>
+              <TextInput
+                value={formKey}
+                onChangeText={setFormKey}
+                placeholder="fecha_de_nacimiento"
+                placeholderTextColor={colorScales.gray[400]}
+                style={[styles.formInput, !!editingField && styles.formInputDisabled]}
+                editable={!editingField}
+              />
+            </View>
+
+            {/* Entity type */}
+            <View style={styles.formGroup}>
+              <Text style={styles.formLabel}>Tipo de Entidad</Text>
+              <View style={styles.chipRow}>
+                {ENTITY_OPTIONS.map((type) => (
+                  <Pressable
+                    key={type}
+                    onPress={() => setFormEntityType(type)}
+                    style={[styles.chip, formEntityType === type && styles.chipActive]}
+                  >
+                    <Text style={[styles.chipText, formEntityType === type && styles.chipTextActive]}>
+                      {ENTITY_LABELS[type]}
+                    </Text>
+                  </Pressable>
+                ))}
+              </View>
+            </View>
+
+            {/* Field type */}
+            <View style={styles.formGroup}>
+              <Text style={styles.formLabel}>Tipo de Campo</Text>
+              <View style={styles.chipRowWrapped}>
+                {FIELD_TYPES.map((ft) => (
+                  <Pressable
+                    key={ft.value}
+                    onPress={() => setFormFieldType(ft.value)}
+                    style={[styles.chip, formFieldType === ft.value && styles.chipActive]}
+                  >
+                    <Text style={[styles.chipText, formFieldType === ft.value && styles.chipTextActive]}>
+                      {ft.label}
+                    </Text>
+                  </Pressable>
+                ))}
+              </View>
+            </View>
+
+            {/* Description */}
+            <View style={styles.formGroup}>
+              <Text style={styles.formLabel}>Descripción</Text>
+              <TextInput
+                value={formDescription}
+                onChangeText={setFormDescription}
+                placeholder="Descripción opcional..."
+                placeholderTextColor={colorScales.gray[400]}
+                style={styles.formTextarea}
+                multiline
+              />
+            </View>
+
+            {/* Display mode */}
+            <View style={styles.formGroup}>
+              <Text style={styles.formLabel}>Modo de Display</Text>
+              <View style={styles.chipRow}>
+                {DISPLAY_MODES.map((dm) => (
+                  <Pressable
+                    key={dm.value}
+                    onPress={() => setFormDisplayMode(dm.value)}
+                    style={[styles.chip, formDisplayMode === dm.value && styles.chipActive]}
+                  >
+                    <Text style={[styles.chipText, formDisplayMode === dm.value && styles.chipTextActive]}>
+                      {dm.label}
+                    </Text>
+                  </Pressable>
+                ))}
+              </View>
+            </View>
+
+            {/* Opciones (solo cuando field_type === 'select') — estilo web */}
+            {formFieldType === 'select' && (
+              <View style={styles.formGroup}>
+                <Text style={styles.formLabel}>Opciones (una por línea)</Text>
+                <TextInput
+                  value={formOptionsText}
+                  onChangeText={setFormOptionsText}
+                  placeholder={'Opción 1\nOpción 2\nOpción 3'}
+                  placeholderTextColor={colorScales.gray[400]}
+                  style={[styles.formTextarea, { minHeight: 90 }]}
+                  multiline
+                />
+              </View>
+            )}
+
+            {/* Required toggle */}
+            <View style={styles.formGroup}>
+              <Pressable onPress={() => setFormRequired((v) => !v)} style={styles.toggleRow}>
+                <Text style={styles.formLabel}>Obligatorio</Text>
+                <View style={[styles.toggle, formRequired && styles.toggleActive]}>
+                  <View style={[styles.toggleThumb, formRequired && styles.toggleThumbActive]} />
+                </View>
+              </Pressable>
+            </View>
+
+            {/* Actions */}
+            <View style={styles.formActions}>
+              <Pressable onPress={() => setShowModal(false)} style={styles.cancelBtn}>
+                <Text style={styles.cancelBtnText}>Cancelar</Text>
+              </Pressable>
+              <Pressable
+                onPress={handleSaveField}
+                style={[styles.saveBtn, (!formLabel.trim() || !formKey.trim() || actionLoading) && styles.saveBtnDisabled]}
+                disabled={!formLabel.trim() || !formKey.trim() || actionLoading}
+              >
+                <Text style={styles.saveBtnText}>
+                  {actionLoading ? 'Guardando...' : editingField ? 'Guardar' : 'Crear'}
+                </Text>
+              </Pressable>
+            </View>
+          </ScrollView>
+        </View>
+      )}
+
+      <ConfirmDialog
+        visible={!!showDeleteConfirm}
+        onClose={() => setShowDeleteConfirm(null)}
+        onConfirm={handleDeleteField}
+        title="Eliminar campo"
+        message={`¿Estás seguro de eliminar "${showDeleteConfirm?.label}"?`}
+        confirmLabel="Eliminar"
+        cancelLabel="Cancelar"
+        destructive
+        loading={actionLoading}
       />
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  root: {
-    flex: 1,
-    backgroundColor: colorScales.gray[50],
-  },
-  loader: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  listContent: {
-    paddingVertical: spacing[3],
-    paddingBottom: spacing[8],
-  },
-  separator: {
-    height: spacing[3],
-  },
+  root: { flex: 1, backgroundColor: colorScales.gray[50] },
+  loader: { flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: colorScales.gray[50] },
+  listContent: { paddingBottom: spacing[8] },
+  separator: { height: spacing[3] },
+  // Filter chips
   filterRow: {
     flexDirection: 'row',
     gap: spacing[2],
-    marginBottom: spacing[3],
+    paddingHorizontal: spacing[4],
+    paddingTop: spacing[3],
+    paddingBottom: spacing[2],
   },
   filterChip: {
     paddingHorizontal: spacing[3],
@@ -167,91 +497,148 @@ const styles = StyleSheet.create({
     borderColor: colorScales.gray[200],
     backgroundColor: colors.background,
   },
-  filterChipActive: {
-    backgroundColor: colors.primary,
-    borderColor: colors.primary,
+  filterChipActive: { backgroundColor: colorScales.green[50], borderColor: colorScales.green[500] },
+  filterChipText: { fontSize: typography.fontSize.sm, fontWeight: typography.fontWeight.medium, color: colorScales.gray[600] },
+  filterChipTextActive: { color: colorScales.green[600], fontWeight: typography.fontWeight.bold },
+  // Header
+  headerRow: { paddingHorizontal: spacing[4], paddingTop: spacing[1], paddingBottom: spacing[1] },
+  headerTitle: { fontSize: 12, fontWeight: '700', color: colorScales.gray[600], letterSpacing: 0.3 },
+  // Search row
+  searchRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+    paddingHorizontal: spacing[4],
+    paddingBottom: spacing[3],
   },
-  filterChipText: {
+  searchInputWrapper: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: colors.background,
+    borderRadius: borderRadius.xl,
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[2],
+    borderWidth: 1,
+    borderColor: colorScales.gray[200],
+    minHeight: 40,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.05,
+    shadowRadius: 8,
+    elevation: 2,
+  },
+  searchInput: {
+    flex: 1,
     fontSize: typography.fontSize.sm,
-    fontWeight: typography.fontWeight.medium,
-    color: colorScales.gray[600],
+    fontFamily: typography.fontFamily,
+    color: colorScales.gray[900],
+    padding: 0,
+    height: '100%',
   },
-  filterChipTextActive: {
-    color: colors.background,
+  addBtn: {
+    width: 40,
+    height: 40,
+    borderRadius: borderRadius.xl,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1.5,
+    borderColor: colors.primary,
+    backgroundColor: colors.background,
   },
-  fieldCard: {
+  // Card
+  card: {
     marginHorizontal: spacing[4],
     backgroundColor: colors.background,
     borderRadius: borderRadius.lg,
     padding: spacing[3],
     ...shadows.sm,
   },
-  fieldHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    marginBottom: spacing[2],
-  },
-  fieldInfo: {
-    flex: 1,
-  },
-  fieldLabel: {
-    fontSize: typography.fontSize.sm,
-    fontWeight: typography.fontWeight.semibold,
+  cardHeader: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginBottom: spacing[2] },
+  cardHeaderInfo: { flex: 1 },
+  cardTitle: { fontSize: typography.fontSize.sm, fontWeight: '600', color: colorScales.gray[900] },
+  cardSubtitle: { fontSize: typography.fontSize.xs, color: colorScales.gray[400], fontFamily: 'monospace' },
+  statusDot: { width: 10, height: 10, borderRadius: 5 },
+  statusActive: { backgroundColor: colorScales.green[600] },
+  statusInactive: { backgroundColor: colorScales.gray[300] },
+  cardMetaRow: { flexDirection: 'row', gap: spacing[1], marginBottom: spacing[2], flexWrap: 'wrap' },
+  metaTag: { backgroundColor: colorScales.gray[100], paddingHorizontal: spacing[2], paddingVertical: 2, borderRadius: borderRadius.sm },
+  metaTagText: { fontSize: 11, color: colorScales.gray[500] },
+  metaTagRequired: { backgroundColor: colorScales.amber[100], paddingHorizontal: spacing[2], paddingVertical: 2, borderRadius: borderRadius.sm },
+  metaTagTextRequired: { fontSize: 11, color: colorScales.amber[700], fontWeight: typography.fontWeight.medium },
+  cardActions: { flexDirection: 'row', justifyContent: 'flex-end', gap: spacing[2], borderTopWidth: 1, borderTopColor: colorScales.gray[100], paddingTop: spacing[2] },
+  actionBtn: { padding: spacing[1] },
+  // Modal
+  modalOverlay: { ...StyleSheet.absoluteFillObject, justifyContent: 'flex-end', zIndex: 100 },
+  modalBackdrop: { ...StyleSheet.absoluteFillObject, backgroundColor: 'rgba(0,0,0,0.4)' },
+  modalSheet: { maxHeight: '90%', backgroundColor: colors.background, borderTopLeftRadius: borderRadius.xl, borderTopRightRadius: borderRadius.xl, padding: spacing[4] },
+  modalHeader: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginBottom: spacing[4] },
+  modalTitle: { fontSize: typography.fontSize.lg, fontWeight: '700', color: colorScales.gray[900] },
+  // Form
+  formGroup: { marginBottom: spacing[3] },
+  formLabel: { fontSize: typography.fontSize.xs, fontWeight: '600', color: colorScales.gray[500], marginBottom: spacing[1], textTransform: 'uppercase', letterSpacing: 0.5 },
+  formInput: {
+    backgroundColor: colorScales.gray[50],
+    borderRadius: borderRadius.md,
+    borderWidth: 1,
+    borderColor: colorScales.gray[200],
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[2],
     color: colorScales.gray[900],
+    fontSize: typography.fontSize.sm,
   },
-  fieldKey: {
-    fontSize: typography.fontSize.xs,
-    color: colorScales.gray[400],
-    fontFamily: 'monospace',
+  formInputDisabled: { opacity: 0.6, backgroundColor: colorScales.gray[100] },
+  formTextarea: {
+    backgroundColor: colorScales.gray[50],
+    borderRadius: borderRadius.md,
+    borderWidth: 1,
+    borderColor: colorScales.gray[200],
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[2],
+    color: colorScales.gray[900],
+    fontSize: typography.fontSize.sm,
+    minHeight: 60,
+    textAlignVertical: 'top',
   },
-  statusDot: {
-    width: 10,
-    height: 10,
-    borderRadius: 5,
+  chipRow: { flexDirection: 'row', gap: spacing[2] },
+  chipRowWrapped: { flexDirection: 'row', gap: spacing[2], flexWrap: 'wrap' },
+  chip: {
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[1.5],
+    borderRadius: borderRadius.full,
+    borderWidth: 1,
+    borderColor: colorScales.gray[200],
+    backgroundColor: colors.background,
   },
-  statusActive: {
-    backgroundColor: '#059669',
-  },
-  statusInactive: {
+  chipActive: { backgroundColor: colorScales.green[50], borderColor: colorScales.green[500] },
+  chipText: { fontSize: typography.fontSize.sm, fontWeight: typography.fontWeight.medium, color: colorScales.gray[600] },
+  chipTextActive: { color: colorScales.green[600], fontWeight: typography.fontWeight.bold },
+  toggleRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
+  toggle: {
+    width: 44,
+    height: 24,
+    borderRadius: 12,
     backgroundColor: colorScales.gray[300],
+    justifyContent: 'center',
+    padding: 2,
   },
-  fieldMeta: {
-    flexDirection: 'row',
-    gap: spacing[1],
-    marginBottom: spacing[2],
-    flexWrap: 'wrap',
+  toggleActive: { backgroundColor: colors.primary },
+  toggleThumb: {
+    width: 20,
+    height: 20,
+    borderRadius: 10,
+    backgroundColor: colors.background,
   },
-  fieldMetaTag: {
-    backgroundColor: colorScales.gray[100],
-    paddingHorizontal: spacing[2],
-    paddingVertical: 2,
-    borderRadius: borderRadius.sm,
+  toggleThumbActive: { marginLeft: 20 },
+  formActions: { flexDirection: 'row', justifyContent: 'flex-end', gap: spacing[2], marginTop: spacing[2] },
+  cancelBtn: { paddingHorizontal: spacing[4], paddingVertical: spacing[2] },
+  cancelBtnText: { fontSize: typography.fontSize.sm, color: colorScales.gray[600], fontWeight: typography.fontWeight.medium },
+  saveBtn: {
+    backgroundColor: colors.primary,
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[2],
+    borderRadius: borderRadius.md,
   },
-  fieldMetaTagRequired: {
-    backgroundColor: '#fef3c7',
-    paddingHorizontal: spacing[2],
-    paddingVertical: 2,
-    borderRadius: borderRadius.sm,
-  },
-  fieldMetaText: {
-    fontSize: 11,
-    color: colorScales.gray[500],
-  },
-  fieldMetaTextRequired: {
-    fontSize: 11,
-    color: '#d97706',
-    fontWeight: typography.fontWeight.medium,
-  },
-  fieldActions: {
-    flexDirection: 'row',
-    justifyContent: 'flex-end',
-    gap: spacing[2],
-    borderTopWidth: 1,
-    borderTopColor: colorScales.gray[100],
-    paddingTop: spacing[2],
-  },
-  fieldActionBtn: {
-    padding: spacing[1],
-  },
+  saveBtnDisabled: { opacity: 0.5 },
+  saveBtnText: { fontSize: typography.fontSize.sm, fontWeight: typography.fontWeight.semibold, color: colors.background },
 });

--- a/apps/mobile/app/(store-admin)/customers/data-collection/submissions.tsx
+++ b/apps/mobile/app/(store-admin)/customers/data-collection/submissions.tsx
@@ -1,32 +1,50 @@
-import { useCallback, useState } from 'react';
-import { FlatList, Pressable, RefreshControl, StyleSheet, Text, View } from 'react-native';
+import { useCallback, useMemo, useState } from 'react';
+import { FlatList, Modal, Pressable, RefreshControl, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
 import { useQuery } from '@tanstack/react-query';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Ionicons } from '@expo/vector-icons';
 import { Icon } from '@/shared/components/icon/icon';
 import { Spinner } from '@/shared/components/spinner/spinner';
 import { EmptyState } from '@/shared/components/empty-state/empty-state';
+import { toastSuccess } from '@/shared/components/toast/toast.store';
 import { DataCollectionService } from '@/features/store/services/data-collection.service';
-import { formatRelative } from '@/shared/utils/date';
+import { formatRelative, formatDate } from '@/shared/utils/date';
 import { borderRadius, colorScales, colors, shadows, spacing, typography } from '@/shared/theme';
-import type { DataCollectionSubmission } from '@/features/store/types/data-collection.types';
+import type { DataCollectionSubmission, SubmissionStatus } from '@/features/store/types/data-collection.types';
+
+// Purple no existe en colorScales; usamos constantes locales para IA y Procesando
+const PURPLE_BG = '#f3e8ff';
+const PURPLE_TEXT = '#7c3aed';
+const PURPLE_BORDER = '#c084fc';
 
 const STATUS_STYLE: Record<string, { label: string; bg: string; text: string }> = {
-  pending: { label: 'Pendiente', bg: '#fef3c7', text: '#d97706' },
-  in_progress: { label: 'En progreso', bg: '#dbeafe', text: '#2563eb' },
-  submitted: { label: 'Enviado', bg: '#d1fae5', text: '#059669' },
-  processing: { label: 'Procesando', bg: '#f3e8ff', text: '#7c3aed' },
-  completed: { label: 'Completado', bg: '#d1fae5', text: '#059669' },
-  expired: { label: 'Expirado', bg: '#f3f4f6', text: '#6b7280' },
+  pending: { label: 'Pendiente', bg: colorScales.amber[100], text: colorScales.amber[700] },
+  in_progress: { label: 'En progreso', bg: colorScales.blue[100], text: colorScales.blue[700] },
+  submitted: { label: 'Enviado', bg: colorScales.green[100], text: colorScales.green[700] },
+  processing: { label: 'Procesando', bg: PURPLE_BG, text: PURPLE_TEXT },
+  completed: { label: 'Completado', bg: colorScales.green[100], text: colorScales.green[700] },
+  expired: { label: 'Expirado', bg: colorScales.gray[100], text: colorScales.gray[600] },
 };
 
+const STATUS_FILTERS: { id: SubmissionStatus | ''; label: string }[] = [
+  { id: '', label: 'Todos' },
+  { id: 'pending', label: 'Pendientes' },
+  { id: 'submitted', label: 'Enviados' },
+  { id: 'completed', label: 'Completados' },
+];
+
 export default function SubmissionsScreen() {
+  const insets = useSafeAreaInsets();
   const [selectedSubmission, setSelectedSubmission] = useState<DataCollectionSubmission | null>(null);
+  const [statusFilter, setStatusFilter] = useState<SubmissionStatus | ''>('');
+  const [search, setSearch] = useState('');
 
   const { data: submissionsData, isLoading, isRefetching, refetch } = useQuery({
-    queryKey: ['data-collection-submissions'],
+    queryKey: ['data-collection-submissions', statusFilter],
     queryFn: () => DataCollectionService.submissions.list(),
   });
 
-  const { data: submissionDetail, refetch: refetchDetail } = useQuery({
+  const detailQuery = useQuery({
     queryKey: ['submission-detail', selectedSubmission?.id],
     queryFn: () => DataCollectionService.submissions.getOne(selectedSubmission!.id),
     enabled: !!selectedSubmission,
@@ -34,59 +52,63 @@ export default function SubmissionsScreen() {
 
   const submissions = submissionsData?.data ?? [];
 
+  const filteredSubmissions = useMemo(() => {
+    let result = submissions;
+    if (statusFilter) {
+      result = result.filter((s) => s.status === statusFilter);
+    }
+    const term = search.toLowerCase().trim();
+    if (term) {
+      result = result.filter((s) => {
+        const name = `${s.customer?.first_name ?? ''} ${s.customer?.last_name ?? ''}`.toLowerCase();
+        const template = (s.template?.name ?? '').toLowerCase();
+        return name.includes(term) || template.includes(term);
+      });
+    }
+    return result;
+  }, [submissions, statusFilter, search]);
+
+  const customerName = useCallback((item: DataCollectionSubmission): string => {
+    if (item.customer) return `${item.customer.first_name} ${item.customer.last_name}`;
+    if (item.booking?.customer) return `${item.booking.customer.first_name} ${item.booking.customer.last_name}`;
+    return 'Sin cliente';
+  }, []);
+
   const renderSubmission = useCallback(
     ({ item }: { item: DataCollectionSubmission }) => {
       const status = STATUS_STYLE[item.status] || STATUS_STYLE.pending;
-      const customerName = item.customer
-        ? `${item.customer.first_name} ${item.customer.last_name}`
-        : item.booking?.customer
-          ? `${item.booking.customer.first_name} ${item.booking.customer.last_name}`
-          : 'Sin cliente';
-
       return (
         <Pressable
-          onPress={() => setSelectedSubmission(item)}
-          style={styles.submissionCard}
+          onPress={() => {
+            setSelectedSubmission(item);
+            detailQuery.refetch();
+          }}
+          style={styles.card}
         >
-          <View style={styles.submissionHeader}>
-            <View style={styles.submissionInfo}>
-              <Text style={styles.submissionTemplate}>
+          <View style={styles.cardHeader}>
+            <View style={styles.cardHeaderInfo}>
+              <View style={styles.cardTitleRow}>
+                <Text style={styles.cardTitle}>{customerName(item)}</Text>
+                <View style={[styles.statusBadge, { backgroundColor: status.bg }]}>
+                  <Text style={[styles.statusBadgeText, { color: status.text }]}>{status.label}</Text>
+                </View>
+                {item.ai_prediagnosis && (
+                  <View style={styles.aiBadge}>
+                    <Text style={styles.aiBadgeText}>IA</Text>
+                  </View>
+                )}
+              </View>
+              <Text style={styles.cardSubtitle} numberOfLines={1}>
                 {item.template?.name || `Plantilla #${item.template_id}`}
-              </Text>
-              <Text style={styles.submissionCustomer} numberOfLines={1}>
-                {customerName}
-              </Text>
-            </View>
-            <View style={[styles.statusBadge, { backgroundColor: status.bg }]}>
-              <Text style={[styles.statusBadgeText, { color: status.text }]}>
-                {status.label}
+                {item.booking?.booking_number ? ` · #${item.booking.booking_number}` : ''}
               </Text>
             </View>
           </View>
-          <View style={styles.submissionMeta}>
-            <Icon name="calendar" size={12} color={colorScales.gray[400]} />
-            <Text style={styles.submissionMetaText}>
-              {formatRelative(item.created_at)}
-            </Text>
-            {item.booking?.booking_number && (
-              <>
-                <Icon name="shopping-bag" size={12} color={colorScales.gray[400]} />
-                <Text style={styles.submissionMetaText}>
-                  #{item.booking.booking_number}
-                </Text>
-              </>
-            )}
-          </View>
-          {item.ai_prediagnosis && (
-            <View style={styles.aiBadge}>
-              <Icon name="brain" size={12} color="#7c3aed" />
-              <Text style={styles.aiBadgeText}>Con prediagnóstico</Text>
-            </View>
-          )}
+          <Text style={styles.cardDate}>{formatRelative(item.created_at)}</Text>
         </Pressable>
       );
     },
-    [],
+    [customerName, detailQuery],
   );
 
   if (isLoading) {
@@ -100,194 +122,340 @@ export default function SubmissionsScreen() {
   return (
     <View style={styles.root}>
       <FlatList
-        data={submissions}
+        data={filteredSubmissions}
         keyExtractor={(item) => String(item.id)}
         renderItem={renderSubmission}
         ItemSeparatorComponent={() => <View style={styles.separator} />}
+        ListHeaderComponent={
+          <View>
+            {/* Status filters */}
+            <View style={styles.filterRow}>
+              {STATUS_FILTERS.map((s) => (
+                <Pressable
+                  key={s.id}
+                  onPress={() => setStatusFilter(s.id)}
+                  style={[
+                    styles.filterChip,
+                    statusFilter === s.id && styles.filterChipActive,
+                  ]}
+                >
+                  <Text
+                    style={[
+                      styles.filterChipText,
+                      statusFilter === s.id && styles.filterChipTextActive,
+                    ]}
+                  >
+                    {s.label}
+                  </Text>
+                </Pressable>
+              ))}
+            </View>
+            {/* Title */}
+            <View style={styles.headerRow}>
+              <Text style={styles.headerTitle}>Formularios Enviados ({filteredSubmissions.length})</Text>
+            </View>
+            {/* Search */}
+            <View style={styles.searchRow}>
+              <View style={styles.searchInputWrapper}>
+                <Icon name="search" size={16} color={colorScales.gray[400]} />
+                <TextInput
+                  value={search}
+                  onChangeText={setSearch}
+                  placeholder="Buscar por cliente..."
+                  placeholderTextColor={colorScales.gray[400]}
+                  style={styles.searchInput}
+                />
+              </View>
+            </View>
+          </View>
+        }
         ListEmptyComponent={
           <EmptyState
             title="Sin formularios"
-            description="No hay formularios de recolección de datos"
+            description="Cuando los clientes completen formularios de preconsulta, aparecerán aquí."
             icon="inbox"
           />
         }
         refreshControl={<RefreshControl refreshing={isRefetching} onRefresh={refetch} />}
-        contentContainerStyle={styles.listContent}
+        contentContainerStyle={[styles.listContent, { paddingBottom: insets.bottom + spacing[8] }]}
       />
 
-      {selectedSubmission && submissionDetail && (
-        <View style={styles.modalOverlay}>
-          <Pressable style={styles.modalBackdrop} onPress={() => setSelectedSubmission(null)} />
-          <View style={styles.modalSheet}>
+      {/* Detail modal — estilo web (status badge en header, banners, caja IA, metadata footer) */}
+      <Modal visible={!!selectedSubmission} transparent animationType="fade" onRequestClose={() => setSelectedSubmission(null)}>
+        <View style={styles.detailOverlay}>
+          <View style={styles.detailModal}>
             <View style={styles.modalHeader}>
-              <Text style={styles.modalTitle}>Detalle del Formulario</Text>
-              <Pressable onPress={() => setSelectedSubmission(null)}>
-                <Icon name="x" size={20} color={colorScales.gray[500]} />
+              <View style={styles.modalHeaderText}>
+                <Text style={styles.modalTitle}>Detalle del Formulario</Text>
+                <Text style={styles.modalSubtitle}>Información completa del envío</Text>
+              </View>
+              <Pressable onPress={() => setSelectedSubmission(null)} hitSlop={8} style={styles.modalCloseBtn}>
+                <Ionicons name="close" size={22} color={colorScales.gray[500]} />
               </Pressable>
             </View>
 
-            <View style={styles.detailSection}>
-              <Text style={styles.detailLabel}>Plantilla</Text>
-              <Text style={styles.detailValue}>{submissionDetail.template?.name || `#${submissionDetail.template_id}`}</Text>
+            {detailQuery.isLoading ? (
+              <View style={styles.detailLoadingContainer}>
+                <Spinner />
+                <Text style={styles.detailLoadingText}>Cargando detalle...</Text>
+              </View>
+            ) : detailQuery.error ? (
+              <View style={styles.detailErrorContainer}>
+                <Text style={styles.detailErrorText}>No se pudo cargar el detalle del formulario.</Text>
+                <Pressable onPress={() => detailQuery.refetch()} style={styles.retryBtn}>
+                  <Text style={styles.retryBtnText}>Reintentar</Text>
+                </Pressable>
+              </View>
+            ) : detailQuery.data ? (
+              <ScrollView style={styles.detailBody} contentContainerStyle={styles.detailBodyContent} showsVerticalScrollIndicator={false}>
+                {/* Status badge (estilo web: header-end) */}
+                {(() => {
+                  const status = STATUS_STYLE[detailQuery.data.status] || STATUS_STYLE.pending;
+                  return (
+                    <View style={styles.statusHeaderRow}>
+                      <View style={[styles.statusBadge, styles.statusBadgeLg, { backgroundColor: status.bg }]}>
+                        <Text style={[styles.statusBadgeText, { color: status.text }]}>
+                          {status.label}
+                        </Text>
+                      </View>
+                    </View>
+                  );
+                })()}
+
+                {/* Banner Cliente (estilo web: surface-secondary con icono) */}
+                {(() => {
+                  const cust = detailQuery.data.customer || detailQuery.data.booking?.customer;
+                  if (!cust) return null;
+                  return (
+                    <View style={styles.infoBanner}>
+                      <Icon name="user" size={14} color={colorScales.gray[500]} />
+                      <Text style={styles.infoBannerPrimary}>
+                        {cust.first_name} {cust.last_name}
+                      </Text>
+                    </View>
+                  );
+                })()}
+
+                {/* Banner Reserva (estilo web: surface-secondary con icono + booking_number + fecha + producto) */}
+                {detailQuery.data.booking && (
+                  <View style={styles.infoBanner}>
+                    <Icon name="calendar" size={14} color={colorScales.gray[500]} />
+                    <Text style={styles.infoBannerPrimary}>
+                      #{detailQuery.data.booking.booking_number}
+                    </Text>
+                    {detailQuery.data.booking.date ? (
+                      <Text style={styles.infoBannerMuted}>{formatDate(detailQuery.data.booking.date)}</Text>
+                    ) : null}
+                    {detailQuery.data.booking.product?.name ? (
+                      <Text style={styles.infoBannerMuted}>· {detailQuery.data.booking.product.name}</Text>
+                    ) : null}
+                  </View>
+                )}
+
+                {/* Plantilla */}
+                <View style={styles.detailSection}>
+                  <Text style={styles.detailLabel}>Plantilla</Text>
+                  <Text style={styles.detailValue}>
+                    {detailQuery.data.template?.name || `#${detailQuery.data.template_id}`}
+                  </Text>
+                </View>
+
+                {/* Pre-diagnóstico IA (estilo web: caja con borde morado) */}
+                {detailQuery.data.ai_prediagnosis ? (
+                  <View style={styles.aiBox}>
+                    <View style={styles.aiBoxHeader}>
+                      <Icon name="info" size={16} color={PURPLE_TEXT} />
+                      <Text style={styles.aiBoxTitle}>Pre-diagnóstico IA</Text>
+                    </View>
+                    <Text style={styles.aiBoxBody}>{detailQuery.data.ai_prediagnosis}</Text>
+                  </View>
+                ) : null}
+
+                {/* Metadata footer (estilo web: Creado / Enviado / Procesado) */}
+                <View style={styles.metadataFooter}>
+                  {detailQuery.data.template?.name ? (
+                    <Text style={styles.metadataText}>
+                      Plantilla: {detailQuery.data.template.name}
+                    </Text>
+                  ) : null}
+                  <Text style={styles.metadataText}>
+                    Creado: {formatDate(detailQuery.data.created_at)}
+                  </Text>
+                  {detailQuery.data.submitted_at ? (
+                    <Text style={styles.metadataText}>
+                      Enviado: {formatDate(detailQuery.data.submitted_at)}
+                    </Text>
+                  ) : null}
+                  {detailQuery.data.processed_at ? (
+                    <Text style={styles.metadataText}>
+                      Procesado: {formatDate(detailQuery.data.processed_at)}
+                    </Text>
+                  ) : null}
+                </View>
+              </ScrollView>
+            ) : null}
+
+            {/* Footer: Cerrar (estilo web) */}
+            <View style={styles.detailFooter}>
+              <Pressable style={styles.cancelBtn} onPress={() => setSelectedSubmission(null)}>
+                <Text style={styles.cancelBtnText}>Cerrar</Text>
+              </Pressable>
             </View>
-
-            <View style={styles.detailSection}>
-              <Text style={styles.detailLabel}>Estado</Text>
-              <View style={[styles.statusBadge, { backgroundColor: STATUS_STYLE[submissionDetail.status]?.bg || '#f3f4f6', alignSelf: 'flex-start' }]}>
-                <Text style={[styles.statusBadgeText, { color: STATUS_STYLE[submissionDetail.status]?.text || '#6b7280' }]}>
-                  {STATUS_STYLE[submissionDetail.status]?.label || submissionDetail.status}
-                </Text>
-              </View>
-            </View>
-
-            {submissionDetail.customer && (
-              <View style={styles.detailSection}>
-                <Text style={styles.detailLabel}>Cliente</Text>
-                <Text style={styles.detailValue}>
-                  {submissionDetail.customer.first_name} {submissionDetail.customer.last_name}
-                </Text>
-              </View>
-            )}
-
-            {submissionDetail.booking && (
-              <View style={styles.detailSection}>
-                <Text style={styles.detailLabel}>Reserva</Text>
-                <Text style={styles.detailValue}>
-                  #{submissionDetail.booking.booking_number} — {submissionDetail.booking.product?.name}
-                </Text>
-              </View>
-            )}
-
-            {submissionDetail.ai_prediagnosis && (
-              <View style={styles.detailSection}>
-                <Text style={styles.detailLabel}>Prediagnóstico IA</Text>
-                <Text style={styles.detailValue}>{submissionDetail.ai_prediagnosis}</Text>
-              </View>
-            )}
           </View>
         </View>
-      )}
+      </Modal>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  root: {
-    flex: 1,
-    backgroundColor: colorScales.gray[50],
+  root: { flex: 1, backgroundColor: colorScales.gray[50] },
+  loader: { flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: colorScales.gray[50] },
+  listContent: { paddingBottom: spacing[8] },
+  separator: { height: spacing[3] },
+  filterRow: {
+    flexDirection: 'row', gap: spacing[2], paddingHorizontal: spacing[4], paddingTop: spacing[3], paddingBottom: spacing[2],
   },
-  loader: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
+  filterChip: {
+    paddingHorizontal: spacing[3], paddingVertical: spacing[1.5], borderRadius: borderRadius.full,
+    borderWidth: 1, borderColor: colorScales.gray[200], backgroundColor: colors.background,
   },
-  listContent: {
-    paddingVertical: spacing[3],
-    paddingBottom: spacing[8],
+  filterChipActive: { backgroundColor: colorScales.green[50], borderColor: colorScales.green[500] },
+  filterChipText: { fontSize: typography.fontSize.sm, fontWeight: typography.fontWeight.medium, color: colorScales.gray[600] },
+  filterChipTextActive: { color: colorScales.green[600], fontWeight: typography.fontWeight.bold },
+  headerRow: { paddingHorizontal: spacing[4], paddingTop: spacing[1], paddingBottom: spacing[1] },
+  headerTitle: { fontSize: 12, fontWeight: typography.fontWeight.bold, color: colorScales.gray[600], letterSpacing: 0.3 },
+  searchRow: {
+    flexDirection: 'row', alignItems: 'center', gap: spacing[2],
+    paddingHorizontal: spacing[4], paddingBottom: spacing[3],
   },
-  separator: {
-    height: spacing[3],
+  searchInputWrapper: {
+    flex: 1, flexDirection: 'row', alignItems: 'center', backgroundColor: colors.background,
+    borderRadius: borderRadius.xl, paddingHorizontal: spacing[3], paddingVertical: spacing[2],
+    borderWidth: 1, borderColor: colorScales.gray[200], minHeight: 40,
+    shadowColor: '#000', shadowOffset: { width: 0, height: 2 }, shadowOpacity: 0.05, shadowRadius: 8, elevation: 2,
   },
-  submissionCard: {
-    marginHorizontal: spacing[4],
-    backgroundColor: colors.background,
-    borderRadius: borderRadius.lg,
-    padding: spacing[3],
-    ...shadows.sm,
+  searchInput: {
+    flex: 1, fontSize: typography.fontSize.sm, fontFamily: typography.fontFamily,
+    color: colorScales.gray[900], padding: 0, height: '100%',
   },
-  submissionHeader: {
-    flexDirection: 'row',
-    alignItems: 'flex-start',
-    justifyContent: 'space-between',
-    marginBottom: spacing[2],
+  card: {
+    marginHorizontal: spacing[4], backgroundColor: colors.background, borderRadius: borderRadius.lg,
+    padding: spacing[3], ...shadows.sm,
   },
-  submissionInfo: {
-    flex: 1,
-    marginRight: spacing[2],
-  },
-  submissionTemplate: {
-    fontSize: typography.fontSize.sm,
-    fontWeight: typography.fontWeight.semibold,
-    color: colorScales.gray[900],
-  },
-  submissionCustomer: {
-    fontSize: typography.fontSize.xs,
-    color: colorScales.gray[500],
-    marginTop: 2,
-  },
-  statusBadge: {
-    paddingHorizontal: spacing[2],
-    paddingVertical: 2,
+  cardHeader: { marginBottom: spacing[2] },
+  cardHeaderInfo: { flex: 1 },
+  cardTitleRow: { flexDirection: 'row', alignItems: 'center', gap: spacing[1], marginBottom: 2 },
+  cardTitle: { fontSize: typography.fontSize.sm, fontWeight: typography.fontWeight.semibold, color: colorScales.gray[900] },
+  cardSubtitle: { fontSize: typography.fontSize.xs, color: colorScales.gray[500] },
+  statusBadge: { paddingHorizontal: spacing[2], paddingVertical: 2, borderRadius: borderRadius.full },
+  statusBadgeText: { fontSize: 11, fontWeight: typography.fontWeight.semibold },
+  aiBadge: {
+    backgroundColor: PURPLE_BG, paddingHorizontal: spacing[1.5], paddingVertical: 1,
     borderRadius: borderRadius.full,
   },
-  statusBadgeText: {
-    fontSize: 11,
+  aiBadgeText: { fontSize: 10, fontWeight: typography.fontWeight.bold, color: PURPLE_TEXT },
+  cardDate: { fontSize: typography.fontSize.xs, color: colorScales.gray[400] },
+
+  /* === Modal Detalle (estilo web submission-detail-modal) === */
+  detailOverlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.4)', justifyContent: 'center', alignItems: 'center', padding: spacing[4] },
+  detailModal: {
+    backgroundColor: colors.background, borderRadius: borderRadius.lg, borderWidth: 1, borderColor: colorScales.gray[200],
+    width: '100%', maxWidth: 560, maxHeight: '90%',
+    shadowColor: '#000', shadowOffset: { width: 0, height: 8 }, shadowOpacity: 0.15, shadowRadius: 24, elevation: 8,
+  },
+  detailBody: { flexGrow: 0, flexShrink: 1, maxHeight: 520 },
+  detailBodyContent: { padding: spacing[4], gap: spacing[3] },
+  detailFooter: {
+    paddingHorizontal: spacing[4], paddingTop: spacing[3], paddingBottom: spacing[4],
+    borderTopWidth: 1, borderTopColor: colorScales.gray[200],
+    backgroundColor: colors.background,
+  },
+  modalHeader: { flexDirection: 'row', alignItems: 'flex-start', gap: spacing[3], paddingHorizontal: spacing[4], paddingTop: spacing[4], paddingBottom: spacing[3], borderBottomWidth: 1, borderBottomColor: colorScales.gray[100] },
+  modalHeaderText: { flex: 1 },
+  modalTitle: { fontSize: typography.fontSize.lg, fontWeight: typography.fontWeight.bold, color: colorScales.gray[900] },
+  modalSubtitle: { fontSize: typography.fontSize.xs, color: colorScales.gray[500], marginTop: 2 },
+  modalCloseBtn: { padding: spacing[1] },
+  statusHeaderRow: { alignItems: 'flex-start' },
+  statusBadgeLg: { paddingHorizontal: spacing[3], paddingVertical: spacing[1] },
+  /* Banners estilo web (surface-secondary con icono + texto) */
+  infoBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[2.5],
+    backgroundColor: colorScales.gray[50],
+    borderRadius: borderRadius.md,
+    borderWidth: 1,
+    borderColor: colorScales.gray[100],
+    flexWrap: 'wrap',
+  },
+  infoBannerPrimary: {
+    fontSize: typography.fontSize.sm,
     fontWeight: typography.fontWeight.semibold,
+    fontFamily: typography.fontFamily,
+    color: colorScales.gray[900],
   },
-  submissionMeta: {
+  infoBannerMuted: {
+    fontSize: typography.fontSize.sm,
+    fontFamily: typography.fontFamily,
+    color: colorScales.gray[500],
+  },
+  /* Caja de Pre-diagnóstico IA (estilo web: borde + fondo morado) */
+  aiBox: {
+    borderRadius: borderRadius.lg,
+    overflow: 'hidden',
+    borderWidth: 1,
+    borderColor: PURPLE_BORDER,
+  },
+  aiBoxHeader: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: spacing[1],
+    gap: spacing[2],
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[2.5],
+    backgroundColor: PURPLE_BG,
   },
-  submissionMetaText: {
-    fontSize: typography.fontSize.xs,
-    color: colorScales.gray[400],
-    marginRight: spacing[2],
+  aiBoxTitle: {
+    fontSize: typography.fontSize.sm,
+    fontWeight: typography.fontWeight.semibold,
+    color: PURPLE_TEXT,
   },
-  aiBadge: {
+  aiBoxBody: {
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[3],
+    fontSize: typography.fontSize.sm,
+    fontFamily: typography.fontFamily,
+    color: colorScales.gray[800],
+    lineHeight: 20,
+  },
+  /* Metadata footer estilo web (Creado / Enviado / Procesado) */
+  metadataFooter: {
     flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing[1],
-    marginTop: spacing[2],
+    flexWrap: 'wrap',
+    gap: spacing[3],
     paddingTop: spacing[2],
     borderTopWidth: 1,
     borderTopColor: colorScales.gray[100],
   },
-  aiBadgeText: {
+  metadataText: {
     fontSize: typography.fontSize.xs,
-    color: '#7c3aed',
-    fontWeight: typography.fontWeight.medium,
-  },
-  modalOverlay: {
-    ...StyleSheet.absoluteFillObject,
-    justifyContent: 'flex-end',
-    zIndex: 100,
-  },
-  modalBackdrop: {
-    ...StyleSheet.absoluteFillObject,
-    backgroundColor: 'rgba(0,0,0,0.4)',
-  },
-  modalSheet: {
-    maxHeight: '70%',
-    backgroundColor: colors.background,
-    borderTopLeftRadius: borderRadius.xl,
-    borderTopRightRadius: borderRadius.xl,
-    padding: spacing[4],
-  },
-  modalHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    marginBottom: spacing[4],
-  },
-  modalTitle: {
-    fontSize: typography.fontSize.lg,
-    fontWeight: typography.fontWeight.bold,
-    color: colorScales.gray[900],
-  },
-  detailSection: {
-    marginBottom: spacing[3],
-  },
-  detailLabel: {
-    fontSize: typography.fontSize.xs,
-    fontWeight: typography.fontWeight.medium,
+    fontFamily: typography.fontFamily,
     color: colorScales.gray[500],
-    marginBottom: spacing[1],
-    textTransform: 'uppercase',
-    letterSpacing: 0.5,
   },
-  detailValue: {
-    fontSize: typography.fontSize.sm,
-    color: colorScales.gray[800],
-  },
+  /* Estados loading/error */
+  detailLoadingContainer: { alignItems: 'center', justifyContent: 'center', paddingVertical: spacing[10] },
+  detailLoadingText: { marginTop: spacing[3], fontSize: typography.fontSize.sm, color: colorScales.gray[500] },
+  detailErrorContainer: { alignItems: 'center', justifyContent: 'center', paddingVertical: spacing[10] },
+  detailErrorText: { fontSize: typography.fontSize.sm, color: colorScales.red[600], marginBottom: spacing[3], textAlign: 'center' },
+  retryBtn: { paddingHorizontal: spacing[4], paddingVertical: spacing[2], backgroundColor: colors.primary, borderRadius: borderRadius.md },
+  retryBtnText: { fontSize: typography.fontSize.sm, fontWeight: typography.fontWeight.semibold, color: colors.background },
+  /* Footer botón Cerrar */
+  cancelBtn: { paddingVertical: 10, borderRadius: borderRadius.full, backgroundColor: colorScales.gray[900], alignItems: 'center', justifyContent: 'center' },
+  cancelBtnText: { fontSize: 13, fontWeight: typography.fontWeight.bold, color: colors.background },
+  /* Secciones detalle (Plantilla, etc.) */
+  detailSection: { marginBottom: spacing[3] },
+  detailLabel: { fontSize: typography.fontSize.xs, fontWeight: typography.fontWeight.medium, color: colorScales.gray[500], marginBottom: spacing[1], textTransform: 'uppercase', letterSpacing: 0.5 },
+  detailValue: { fontSize: typography.fontSize.sm, color: colorScales.gray[800] },
 });

--- a/apps/mobile/app/(store-admin)/customers/data-collection/templates.tsx
+++ b/apps/mobile/app/(store-admin)/customers/data-collection/templates.tsx
@@ -1,21 +1,54 @@
 import { useCallback, useState } from 'react';
-import { FlatList, Pressable, RefreshControl, StyleSheet, Text, View } from 'react-native';
+import { FlatList, Modal, Pressable, RefreshControl, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
 import { useQuery } from '@tanstack/react-query';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Ionicons } from '@expo/vector-icons';
 import { Icon } from '@/shared/components/icon/icon';
 import { Spinner } from '@/shared/components/spinner/spinner';
 import { EmptyState } from '@/shared/components/empty-state/empty-state';
+import { ConfirmDialog } from '@/shared/components/confirm-dialog/confirm-dialog';
+import { toastSuccess, toastError } from '@/shared/components/toast/toast.store';
 import { DataCollectionService } from '@/features/store/services/data-collection.service';
 import { borderRadius, colorScales, colors, shadows, spacing, typography } from '@/shared/theme';
-import type { DataCollectionTemplate } from '@/features/store/types/data-collection.types';
+import type { DataCollectionTemplate, EntityType, TemplateStatus } from '@/features/store/types/data-collection.types';
 
-const STATUS_LABELS: Record<string, { label: string; color: string; bg: string }> = {
-  active: { label: 'Activa', color: '#059669', bg: '#d1fae5' },
-  inactive: { label: 'Inactiva', color: '#6b7280', bg: '#f3f4f6' },
-  archived: { label: 'Archivada', color: '#dc2626', bg: '#fee2e2' },
+const STATUS_STYLE: Record<string, { label: string; color: string; bg: string }> = {
+  active: { label: 'Activo', color: colorScales.green[700], bg: colorScales.green[100] },
+  inactive: { label: 'Inactivo', color: colorScales.gray[600], bg: colorScales.gray[100] },
+  archived: { label: 'Archivado', color: colorScales.red[600], bg: colorScales.red[50] },
 };
 
+const STATUS_OPTIONS = ['active', 'inactive', 'archived'];
+const STATUS_LABEL_MAP: Record<string, string> = {
+  active: 'Activas',
+  inactive: 'Inactivas',
+  archived: 'Archivadas',
+};
+
+const ENTITY_LABELS: Record<EntityType, string> = {
+  customer: 'Cliente',
+  booking: 'Reserva',
+  order: 'Orden',
+};
+
+const TEMPLATE_ENTITY_OPTIONS: EntityType[] = ['customer', 'booking', 'order'];
+const TEMPLATE_STATUS_OPTIONS: TemplateStatus[] = ['active', 'inactive', 'archived'];
+
 export default function TemplatesScreen() {
+  const insets = useSafeAreaInsets();
   const [statusFilter, setStatusFilter] = useState<string | undefined>();
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState<DataCollectionTemplate | null>(null);
+  const [actionLoading, setActionLoading] = useState(false);
+
+  // Modal crear/editar plantilla
+  const [showTemplateModal, setShowTemplateModal] = useState(false);
+  const [editingTemplate, setEditingTemplate] = useState<DataCollectionTemplate | null>(null);
+  const [tplName, setTplName] = useState('');
+  const [tplDescription, setTplDescription] = useState('');
+  const [tplEntityType, setTplEntityType] = useState<EntityType>('booking');
+  const [tplStatus, setTplStatus] = useState<TemplateStatus>('active');
+  const [tplIsDefault, setTplIsDefault] = useState(false);
+  const [tplErrors, setTplErrors] = useState<Record<string, string>>({});
 
   const { data: templates, isLoading, isRefetching, refetch } = useQuery({
     queryKey: ['data-collection-templates', statusFilter],
@@ -23,68 +56,155 @@ export default function TemplatesScreen() {
   });
 
   const handleDuplicate = useCallback(async (id: number) => {
-    await DataCollectionService.templates.duplicate(id);
-    refetch();
+    try {
+      await DataCollectionService.templates.duplicate(id);
+      toastSuccess('Plantilla duplicada');
+      refetch();
+    } catch (error: any) {
+      const message = error?.response?.data?.message || error?.message || 'Error al duplicar';
+      toastError(typeof message === 'string' ? message : 'Error al duplicar la plantilla');
+    }
   }, [refetch]);
 
-  const handleDelete = useCallback(async (id: number) => {
-    await DataCollectionService.templates.delete(id);
-    refetch();
-  }, [refetch]);
+  const handleDelete = useCallback(async () => {
+    if (!showDeleteConfirm) return;
+    setActionLoading(true);
+    try {
+      await DataCollectionService.templates.delete(showDeleteConfirm.id);
+      toastSuccess('Plantilla eliminada');
+      setShowDeleteConfirm(null);
+      refetch();
+    } catch (error: any) {
+      const message = error?.response?.data?.message || error?.message || 'Error al eliminar';
+      toastError(typeof message === 'string' ? message : 'Error al eliminar la plantilla');
+    } finally {
+      setActionLoading(false);
+    }
+  }, [showDeleteConfirm, refetch]);
 
-  const STATUS_OPTIONS = ['active', 'inactive', 'archived'];
-  const STATUS_LABEL_MAP: Record<string, string> = {
-    active: 'Activas',
-    inactive: 'Inactivas',
-    archived: 'Archivadas',
-  };
+  // Abrir modal de edición con datos pre-rellenados
+  const openEditTemplate = useCallback((template: DataCollectionTemplate) => {
+    setEditingTemplate(template);
+    setTplName(template.name);
+    setTplDescription(template.description || '');
+    setTplEntityType(template.entity_type);
+    setTplStatus(template.status);
+    setTplIsDefault(!!template.is_default);
+    setTplErrors({});
+    setShowTemplateModal(true);
+  }, []);
+
+  // Abrir modal de creación (vacío)
+  const openNewTemplate = useCallback(() => {
+    setEditingTemplate(null);
+    setTplName('');
+    setTplDescription('');
+    setTplEntityType('booking');
+    setTplStatus('active');
+    setTplIsDefault(false);
+    setTplErrors({});
+    setShowTemplateModal(true);
+  }, []);
+
+  const closeTemplateModal = useCallback(() => {
+    setShowTemplateModal(false);
+    setEditingTemplate(null);
+    setTplErrors({});
+  }, []);
+
+  const handleSaveTemplate = useCallback(async () => {
+    setTplErrors({});
+    const newErrors: Record<string, string> = {};
+    if (!tplName.trim()) newErrors.name = 'El nombre es requerido';
+    if (Object.keys(newErrors).length > 0) {
+      setTplErrors(newErrors);
+      toastError('Revisa los campos marcados');
+      return;
+    }
+    setActionLoading(true);
+    try {
+      const data = {
+        name: tplName.trim(),
+        description: tplDescription.trim() || undefined,
+        entity_type: tplEntityType,
+        status: tplStatus,
+        is_default: tplIsDefault,
+      };
+      if (editingTemplate) {
+        await DataCollectionService.templates.update(editingTemplate.id, data);
+        toastSuccess('Plantilla actualizada');
+      } else {
+        await DataCollectionService.templates.create(data);
+        toastSuccess('Plantilla creada');
+      }
+      closeTemplateModal();
+      refetch();
+    } catch (error: any) {
+      const message = error?.response?.data?.message || error?.message || 'Error al guardar';
+      toastError(typeof message === 'string' ? message : 'Error al guardar la plantilla');
+    } finally {
+      setActionLoading(false);
+    }
+  }, [tplName, tplDescription, tplEntityType, tplStatus, tplIsDefault, editingTemplate, refetch, closeTemplateModal]);
 
   const renderTemplate = useCallback(
     ({ item }: { item: DataCollectionTemplate }) => {
-      const status = STATUS_LABELS[item.status] || STATUS_LABELS.active;
+      const status = STATUS_STYLE[item.status] || STATUS_STYLE.active;
+      const sectionCount = item.sections?.length ?? 0;
       const productCount = item.products?.length ?? 0;
       return (
-        <View style={styles.templateCard}>
-          <View style={styles.templateInfo}>
-            <Icon name={item.icon || 'layout-template'} size={20} color={colors.primary} />
-            <View style={styles.templateTextInfo}>
-              <Text style={styles.templateName}>{item.name}</Text>
-              <Text style={styles.templateDescription} numberOfLines={1}>
-                {item.description || 'Sin descripción'}
-              </Text>
+        <View style={styles.card}>
+          <View style={styles.cardHeader}>
+            <View style={styles.cardHeaderLeft}>
+              <Icon name={item.icon || 'layout-template'} size={20} color={colors.primary} />
+              <View style={styles.cardHeaderInfo}>
+                <Text style={styles.cardTitle}>{item.name}</Text>
+                {item.description && (
+                  <Text style={styles.cardSubtitle} numberOfLines={2}>{item.description}</Text>
+                )}
+              </View>
+            </View>
+            <View style={[styles.statusBadge, { backgroundColor: status.bg }]}>
+              <Text style={[styles.statusBadgeText, { color: status.color }]}>{status.label}</Text>
             </View>
           </View>
-          <View style={styles.templateMeta}>
-            <View style={[styles.statusBadge, { backgroundColor: status.bg }]}>
-              <Text style={[styles.statusBadgeText, { color: status.color }]}>
-                {status.label}
-              </Text>
-            </View>
+
+          <View style={styles.cardMetaRow}>
+            <Icon name="layers" size={12} color={colorScales.gray[400]} />
+            <Text style={styles.metaText}>{sectionCount} secciones</Text>
+            <Icon name="tag" size={12} color={colorScales.gray[400]} />
+            <Text style={styles.metaText}>{ENTITY_LABELS[item.entity_type] || item.entity_type}</Text>
             {item.is_default && (
-              <View style={styles.defaultBadge}>
-                <Icon name="star" size={12} color="#d97706" />
-                <Text style={styles.defaultBadgeText}>Default</Text>
-              </View>
+              <>
+                <Icon name="star" size={12} color={colorScales.amber[600]} />
+                <Text style={[styles.metaText, { color: colorScales.amber[600] }]}>Default</Text>
+              </>
             )}
             {productCount > 0 && (
-              <View style={styles.productBadge}>
-                <Icon name="package" size={12} color={colorScales.gray[500]} />
-                <Text style={styles.productBadgeText}>{productCount}</Text>
-              </View>
+              <>
+                <Icon name="package" size={12} color={colorScales.gray[400]} />
+                <Text style={styles.metaText}>{productCount} producto(s)</Text>
+              </>
             )}
           </View>
-          <View style={styles.templateActions}>
-            <Pressable onPress={() => handleDuplicate(item.id)} style={styles.templateActionBtn}>
-              <Icon name="copy" size={16} color={colorScales.gray[500]} />
+
+          <View style={styles.cardActions}>
+            <Pressable onPress={() => openEditTemplate(item)} style={styles.actionBtn}>
+              <Icon name="pencil" size={14} color={colorScales.gray[600]} />
+              <Text style={styles.actionBtnText}>Editar</Text>
             </Pressable>
-            <Pressable onPress={() => handleDelete(item.id)} style={styles.templateActionBtn}>
-              <Icon name="trash-2" size={16} color={colorScales.red[500]} />
+            <Pressable onPress={() => handleDuplicate(item.id)} style={styles.actionBtn}>
+              <Icon name="copy" size={14} color={colorScales.gray[600]} />
+              <Text style={styles.actionBtnText}>Duplicar</Text>
+            </Pressable>
+            <Pressable onPress={() => setShowDeleteConfirm(item)} style={styles.actionBtn}>
+              <Icon name="trash-2" size={14} color={colorScales.red[500]} />
             </Pressable>
           </View>
         </View>
       );
     },
-    [handleDuplicate, handleDelete],
+    [handleDuplicate, openEditTemplate],
   );
 
   if (isLoading) {
@@ -97,163 +217,335 @@ export default function TemplatesScreen() {
 
   return (
     <View style={styles.root}>
+      {/* Sticky header estilo web (app-sticky-header simplificado para mobile) */}
+      <View style={styles.stickyHeader}>
+        <View style={styles.stickyHeaderIcon}>
+          <Icon name="layout-template" size={20} color={colors.primary} />
+        </View>
+        <View style={styles.stickyHeaderText}>
+          <Text style={styles.stickyHeaderTitle}>Plantillas de Formulario</Text>
+          <Text style={styles.stickyHeaderSubtitle}>Configura los formularios de recolección de datos</Text>
+        </View>
+        <Pressable style={styles.stickyHeaderAction} onPress={openNewTemplate} hitSlop={6}>
+          <Icon name="plus" size={16} color={colors.background} />
+          <Text style={styles.stickyHeaderActionText}>Nueva</Text>
+        </Pressable>
+      </View>
+
       <FlatList
         data={templates ?? []}
         keyExtractor={(item) => String(item.id)}
         renderItem={renderTemplate}
         ItemSeparatorComponent={() => <View style={styles.separator} />}
         ListHeaderComponent={
-          <View style={styles.filterRow}>
-            {STATUS_OPTIONS.map((s) => (
-              <Pressable
-                key={s}
-                onPress={() => setStatusFilter(statusFilter === s ? undefined : s)}
-                style={[styles.filterChip, statusFilter === s && styles.filterChipActive]}
-              >
-                <Text
+          <View>
+            <View style={styles.headerRow}>
+              <Text style={styles.headerTitle}>Plantillas ({templates?.length ?? 0})</Text>
+            </View>
+            <View style={styles.filterRow}>
+              {STATUS_OPTIONS.map((s) => (
+                <Pressable
+                  key={s}
+                  onPress={() => setStatusFilter(statusFilter === s ? undefined : s)}
                   style={[
-                    styles.filterChipText,
-                    statusFilter === s && styles.filterChipTextActive,
+                    styles.filterChip,
+                    statusFilter === s && styles.filterChipActive,
                   ]}
                 >
-                  {STATUS_LABEL_MAP[s]}
-                </Text>
-              </Pressable>
-            ))}
+                  <Text
+                    style={[
+                      styles.filterChipText,
+                      statusFilter === s && styles.filterChipTextActive,
+                    ]}
+                  >
+                    {STATUS_LABEL_MAP[s]}
+                  </Text>
+                </Pressable>
+              ))}
+            </View>
           </View>
         }
         ListEmptyComponent={
           <EmptyState
-            title="Sin plantillas"
-            description="No hay plantillas de recolección de datos"
+            title="No hay plantillas"
+            description="Crea tu primera plantilla para comenzar a recolectar datos de clientes."
             icon="layout-template"
+            actionLabel="Nueva Plantilla"
+            onAction={openNewTemplate}
           />
         }
         refreshControl={<RefreshControl refreshing={isRefetching} onRefresh={refetch} />}
-        contentContainerStyle={styles.listContent}
+        contentContainerStyle={[styles.listContent, { paddingBottom: insets.bottom + spacing[8] }]}
       />
+
+      <ConfirmDialog
+        visible={!!showDeleteConfirm}
+        onClose={() => setShowDeleteConfirm(null)}
+        onConfirm={handleDelete}
+        title="Eliminar plantilla"
+        message={`¿Estás seguro de eliminar "${showDeleteConfirm?.name}"?`}
+        confirmLabel="Eliminar"
+        cancelLabel="Cancelar"
+        destructive
+        loading={actionLoading}
+      />
+
+      {/* Modal crear/editar plantilla (estilo web: name, description, entity_type, status, is_default) */}
+      <Modal visible={showTemplateModal} transparent animationType="fade" onRequestClose={closeTemplateModal}>
+        <View style={styles.modalOverlay}>
+          <View style={styles.modalSheet}>
+            <View style={styles.modalHeader}>
+              <View style={styles.modalHeaderText}>
+                <Text style={styles.modalTitle}>{editingTemplate ? 'Editar plantilla' : 'Nueva plantilla'}</Text>
+                <Text style={styles.modalSubtitle}>
+                  {editingTemplate ? 'Modifica los datos de la plantilla' : 'Crea una nueva plantilla para tu tienda'}
+                </Text>
+              </View>
+              <Pressable onPress={closeTemplateModal} hitSlop={8} style={styles.modalCloseBtn}>
+                <Ionicons name="close" size={22} color={colorScales.gray[500]} />
+              </Pressable>
+            </View>
+
+            <ScrollView style={styles.modalBody} contentContainerStyle={styles.modalBodyContent} showsVerticalScrollIndicator={false} keyboardShouldPersistTaps="handled">
+              {/* Nombre */}
+              <View>
+                <Text style={styles.formLabel}>NOMBRE <Text style={styles.requiredStar}>*</Text></Text>
+                <TextInput
+                  style={[styles.formInput, !!tplErrors.name && styles.formInputError]}
+                  value={tplName}
+                  onChangeText={(v) => { setTplName(v); setTplErrors((p) => { const n = { ...p }; delete n.name; return n; }); }}
+                  placeholder="Ej: Ficha de cliente"
+                  placeholderTextColor={colorScales.gray[400]}
+                />
+                {!!tplErrors.name && <Text style={styles.formErrorText}>{tplErrors.name}</Text>}
+              </View>
+
+              {/* Descripción */}
+              <View>
+                <Text style={styles.formLabel}>DESCRIPCIÓN</Text>
+                <TextInput
+                  value={tplDescription}
+                  onChangeText={setTplDescription}
+                  placeholder="Descripción opcional de la plantilla"
+                  placeholderTextColor={colorScales.gray[400]}
+                  style={styles.formTextarea}
+                  multiline
+                />
+              </View>
+
+              {/* Tipo de Entidad + Estado (row) */}
+              <View style={styles.formRow}>
+                <View style={{ flex: 1 }}>
+                  <Text style={styles.formLabel}>TIPO DE ENTIDAD <Text style={styles.requiredStar}>*</Text></Text>
+                  <View style={styles.chipRow}>
+                    {TEMPLATE_ENTITY_OPTIONS.map((e) => (
+                      <Pressable
+                        key={e}
+                        onPress={() => setTplEntityType(e)}
+                        style={[styles.chip, tplEntityType === e && styles.chipActive]}
+                      >
+                        <Text style={[styles.chipText, tplEntityType === e && styles.chipTextActive]}>
+                          {ENTITY_LABELS[e]}
+                        </Text>
+                      </Pressable>
+                    ))}
+                  </View>
+                </View>
+              </View>
+
+              <View>
+                <Text style={styles.formLabel}>ESTADO</Text>
+                <View style={styles.chipRow}>
+                  {TEMPLATE_STATUS_OPTIONS.map((s) => (
+                    <Pressable
+                      key={s}
+                      onPress={() => setTplStatus(s)}
+                      style={[styles.chip, tplStatus === s && styles.chipActive]}
+                    >
+                      <Text style={[styles.chipText, tplStatus === s && styles.chipTextActive]}>
+                        {STATUS_STYLE[s]?.label || s}
+                      </Text>
+                    </Pressable>
+                  ))}
+                </View>
+              </View>
+
+              {/* Plantilla por defecto — toggle */}
+              <Pressable onPress={() => setTplIsDefault((v) => !v)} style={styles.toggleRow}>
+                <View style={{ flex: 1 }}>
+                  <Text style={styles.toggleLabel}>Plantilla por defecto</Text>
+                  <Text style={styles.toggleDesc}>Define esta plantilla como la predeterminada para la entidad seleccionada</Text>
+                </View>
+                <View style={[styles.toggle, tplIsDefault && styles.toggleActive]}>
+                  <View style={[styles.toggleThumb, tplIsDefault && styles.toggleThumbActive]} />
+                </View>
+              </Pressable>
+            </ScrollView>
+
+            {/* Footer: Cancelar + Guardar/Crear — estilo web */}
+            <View style={styles.modalFooter}>
+              <Pressable style={styles.cancelBtn} onPress={closeTemplateModal}>
+                <Text style={styles.cancelBtnText}>Cancelar</Text>
+              </Pressable>
+              <View style={styles.actionSpacer} />
+              <Pressable
+                style={[styles.confirmBtn, (!tplName.trim() || actionLoading) && styles.confirmBtnDisabled]}
+                onPress={handleSaveTemplate}
+                disabled={!tplName.trim() || actionLoading}
+              >
+                <Text style={styles.confirmBtnText}>
+                  {actionLoading ? 'Guardando...' : editingTemplate ? 'Guardar' : 'Crear'}
+                </Text>
+              </Pressable>
+            </View>
+          </View>
+        </View>
+      </Modal>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  root: {
-    flex: 1,
-    backgroundColor: colorScales.gray[50],
+  root: { flex: 1, backgroundColor: colorScales.gray[50] },
+  loader: { flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: colorScales.gray[50] },
+  listContent: { paddingBottom: spacing[8] },
+  separator: { height: spacing[3] },
+  /* === Sticky header (estilo web app-sticky-header) === */
+  stickyHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[3],
+    backgroundColor: colors.background,
+    borderBottomWidth: 1,
+    borderBottomColor: colorScales.gray[200],
+    ...shadows.sm,
   },
-  loader: {
-    flex: 1,
+  stickyHeaderIcon: {
+    width: 40,
+    height: 40,
+    borderRadius: borderRadius.md,
+    backgroundColor: colorScales.green[50],
+    borderWidth: 1,
+    borderColor: colorScales.green[100],
     alignItems: 'center',
     justifyContent: 'center',
   },
-  listContent: {
-    paddingVertical: spacing[3],
-    paddingBottom: spacing[8],
-  },
-  separator: {
-    height: spacing[3],
-  },
-  filterRow: {
-    flexDirection: 'row',
-    gap: spacing[2],
-    marginBottom: spacing[3],
-  },
-  filterChip: {
-    paddingHorizontal: spacing[3],
-    paddingVertical: spacing[1.5],
-    borderRadius: borderRadius.full,
-    borderWidth: 1,
-    borderColor: colorScales.gray[200],
-    backgroundColor: colors.background,
-  },
-  filterChipActive: {
-    backgroundColor: colors.primary,
-    borderColor: colors.primary,
-  },
-  filterChipText: {
-    fontSize: typography.fontSize.sm,
-    fontWeight: typography.fontWeight.medium,
-    color: colorScales.gray[600],
-  },
-  filterChipTextActive: {
-    color: colors.background,
-  },
-  templateCard: {
-    marginHorizontal: spacing[4],
-    backgroundColor: colors.background,
-    borderRadius: borderRadius.lg,
-    padding: spacing[3],
-    ...shadows.sm,
-  },
-  templateInfo: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing[2],
-    marginBottom: spacing[2],
-  },
-  templateTextInfo: {
-    flex: 1,
-  },
-  templateName: {
-    fontSize: typography.fontSize.sm,
-    fontWeight: typography.fontWeight.semibold,
+  stickyHeaderText: { flex: 1 },
+  stickyHeaderTitle: {
+    fontSize: typography.fontSize.base,
+    fontWeight: typography.fontWeight.bold as any,
+    fontFamily: typography.fontFamily,
     color: colorScales.gray[900],
   },
-  templateDescription: {
+  stickyHeaderSubtitle: {
     fontSize: typography.fontSize.xs,
+    fontFamily: typography.fontFamily,
     color: colorScales.gray[500],
+    marginTop: 1,
   },
-  templateMeta: {
-    flexDirection: 'row',
-    gap: spacing[1],
-    marginBottom: spacing[2],
-    flexWrap: 'wrap',
-  },
-  statusBadge: {
-    paddingHorizontal: spacing[2],
-    paddingVertical: 2,
-    borderRadius: borderRadius.full,
-  },
-  statusBadgeText: {
-    fontSize: 11,
-    fontWeight: typography.fontWeight.semibold,
-  },
-  defaultBadge: {
+  stickyHeaderAction: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: 3,
-    backgroundColor: '#fef3c7',
-    paddingHorizontal: spacing[2],
-    paddingVertical: 2,
+    gap: 4,
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[2],
     borderRadius: borderRadius.full,
+    backgroundColor: colors.primary,
   },
-  defaultBadgeText: {
-    fontSize: 11,
-    fontWeight: typography.fontWeight.semibold,
-    color: '#d97706',
+  stickyHeaderActionText: {
+    fontSize: 13,
+    fontWeight: typography.fontWeight.bold as any,
+    color: colors.background,
   },
-  productBadge: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 3,
-    backgroundColor: colorScales.gray[100],
-    paddingHorizontal: spacing[2],
-    paddingVertical: 2,
-    borderRadius: borderRadius.full,
+  /* === List header (legacy) === */
+  headerRow: { paddingHorizontal: spacing[4], paddingTop: spacing[3], paddingBottom: spacing[2] },
+  headerTitle: { fontSize: 12, fontWeight: typography.fontWeight.bold, color: colorScales.gray[600], letterSpacing: 0.3 },
+  filterRow: {
+    flexDirection: 'row', gap: spacing[2], paddingHorizontal: spacing[4], paddingBottom: spacing[3],
   },
-  productBadgeText: {
-    fontSize: 11,
-    color: colorScales.gray[500],
+  filterChip: {
+    paddingHorizontal: spacing[3], paddingVertical: spacing[1.5], borderRadius: borderRadius.full,
+    borderWidth: 1, borderColor: colorScales.gray[200], backgroundColor: colors.background,
   },
-  templateActions: {
-    flexDirection: 'row',
-    justifyContent: 'flex-end',
-    gap: spacing[2],
-    borderTopWidth: 1,
-    borderTopColor: colorScales.gray[100],
+  filterChipActive: { backgroundColor: colorScales.green[50], borderColor: colorScales.green[500] },
+  filterChipText: { fontSize: typography.fontSize.sm, fontWeight: typography.fontWeight.medium, color: colorScales.gray[600] },
+  filterChipTextActive: { color: colorScales.green[600], fontWeight: typography.fontWeight.bold },
+  card: {
+    marginHorizontal: spacing[4], backgroundColor: colors.background, borderRadius: borderRadius.lg,
+    padding: spacing[3], ...shadows.sm,
+  },
+  cardHeader: {
+    flexDirection: 'row', alignItems: 'flex-start', justifyContent: 'space-between', marginBottom: spacing[2],
+  },
+  cardHeaderLeft: { flexDirection: 'row', alignItems: 'center', gap: spacing[2], flex: 1, marginRight: spacing[2] },
+  cardHeaderInfo: { flex: 1 },
+  cardTitle: { fontSize: typography.fontSize.sm, fontWeight: typography.fontWeight.semibold, color: colorScales.gray[900] },
+  cardSubtitle: { fontSize: typography.fontSize.xs, color: colorScales.gray[500], marginTop: 1 },
+  statusBadge: { paddingHorizontal: spacing[2], paddingVertical: 2, borderRadius: borderRadius.full },
+  statusBadgeText: { fontSize: 11, fontWeight: typography.fontWeight.semibold },
+  cardMetaRow: {
+    flexDirection: 'row', alignItems: 'center', gap: spacing[1], marginBottom: spacing[2], flexWrap: 'wrap',
+  },
+  metaText: { fontSize: typography.fontSize.xs, color: colorScales.gray[500], marginRight: spacing[1] },
+  cardActions: {
+    flexDirection: 'row', gap: spacing[1], borderTopWidth: 1, borderTopColor: colorScales.gray[100],
     paddingTop: spacing[2],
   },
-  templateActionBtn: {
-    padding: spacing[1],
+  actionBtn: {
+    flexDirection: 'row', alignItems: 'center', gap: 3,
+    paddingHorizontal: spacing[2], paddingVertical: spacing[1],
+    borderRadius: borderRadius.md, backgroundColor: colorScales.gray[50],
   },
+  actionBtnText: { fontSize: 11, fontWeight: typography.fontWeight.medium, color: colorScales.gray[600] },
+
+  /* === Modal (estilo web, mismo patrón que locations.tsx createModal) === */
+  modalOverlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.4)', justifyContent: 'center', alignItems: 'center', padding: spacing[4] },
+  modalSheet: {
+    backgroundColor: colors.background, borderRadius: borderRadius.lg, borderWidth: 1, borderColor: colorScales.gray[200],
+    width: '100%', maxWidth: 520, maxHeight: '90%',
+    shadowColor: '#000', shadowOffset: { width: 0, height: 8 }, shadowOpacity: 0.15, shadowRadius: 24, elevation: 8,
+  },
+  modalHeader: { flexDirection: 'row', alignItems: 'flex-start', gap: spacing[3], paddingHorizontal: spacing[4], paddingTop: spacing[4], paddingBottom: spacing[3], borderBottomWidth: 1, borderBottomColor: colorScales.gray[100] },
+  modalHeaderText: { flex: 1 },
+  modalTitle: { fontSize: typography.fontSize.lg, fontWeight: typography.fontWeight.bold as any, color: colorScales.gray[900] },
+  modalSubtitle: { fontSize: typography.fontSize.xs, color: colorScales.gray[500], marginTop: 2 },
+  modalCloseBtn: { padding: spacing[1] },
+  modalBody: { flexGrow: 0, flexShrink: 1, maxHeight: 480 },
+  modalBodyContent: { padding: spacing[4], gap: spacing[3] },
+  modalFooter: { flexDirection: 'row', paddingHorizontal: spacing[4], paddingTop: spacing[3], paddingBottom: spacing[4], borderTopWidth: 1, borderTopColor: colorScales.gray[200], backgroundColor: colors.background, gap: spacing[2] },
+  cancelBtn: { flex: 1, paddingVertical: 10, borderRadius: borderRadius.full, backgroundColor: colorScales.gray[900], alignItems: 'center', justifyContent: 'center' },
+  cancelBtnText: { fontSize: 13, fontWeight: typography.fontWeight.bold as any, color: colors.background },
+  actionSpacer: { width: spacing[3] },
+  confirmBtn: { flex: 1, paddingVertical: 10, borderRadius: borderRadius.full, backgroundColor: colorScales.green[100], alignItems: 'center', justifyContent: 'center' },
+  confirmBtnDisabled: { backgroundColor: colorScales.gray[100] },
+  confirmBtnText: { fontSize: 13, fontWeight: typography.fontWeight.bold as any, color: colorScales.green[800] },
+  formRow: { flexDirection: 'row', gap: spacing[3] },
+  formLabel: { fontSize: 10, fontWeight: typography.fontWeight.bold as any, fontFamily: typography.fontFamily, color: colorScales.gray[500], marginBottom: spacing[1.5], textTransform: 'uppercase', letterSpacing: 0.5 },
+  formInput: {
+    borderWidth: 1, borderColor: colorScales.gray[200], borderRadius: borderRadius.md,
+    paddingHorizontal: spacing[3], paddingVertical: spacing[2.5], fontSize: 14, color: colorScales.gray[900], backgroundColor: colors.background, fontFamily: typography.fontFamily,
+  },
+  formInputError: { borderColor: colorScales.red[500] },
+  formErrorText: { fontSize: 11, color: colorScales.red[600], marginTop: spacing[1] },
+  formTextarea: {
+    borderWidth: 1, borderColor: colorScales.gray[200], borderRadius: borderRadius.md,
+    paddingHorizontal: spacing[3], paddingVertical: spacing[2.5], fontSize: 14, color: colorScales.gray[900], backgroundColor: colors.background,
+    fontFamily: typography.fontFamily, minHeight: 70, textAlignVertical: 'top',
+  },
+  requiredStar: { color: colorScales.red[500] },
+  chipRow: { flexDirection: 'row', gap: spacing[2], flexWrap: 'wrap' },
+  chip: { paddingHorizontal: spacing[3], paddingVertical: spacing[1.5], borderRadius: borderRadius.full, borderWidth: 1, borderColor: colorScales.gray[200], backgroundColor: colors.background },
+  chipActive: { backgroundColor: colorScales.green[50], borderColor: colorScales.green[500] },
+  chipText: { fontSize: typography.fontSize.sm, fontWeight: typography.fontWeight.medium, color: colorScales.gray[600] },
+  chipTextActive: { color: colorScales.green[600], fontWeight: typography.fontWeight.bold },
+  /* Toggle (estilo iOS) */
+  toggleRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', gap: spacing[3], paddingVertical: spacing[2] },
+  toggleLabel: { fontSize: 14, fontWeight: typography.fontWeight.bold as any, color: colorScales.gray[900] },
+  toggleDesc: { fontSize: 11, color: colorScales.gray[500], marginTop: 2 },
+  toggle: { width: 44, height: 26, borderRadius: 13, backgroundColor: colorScales.gray[300], padding: 2, justifyContent: 'center' },
+  toggleActive: { backgroundColor: colors.primary },
+  toggleThumb: { width: 22, height: 22, borderRadius: 11, backgroundColor: colors.background, ...shadows.sm },
+  toggleThumbActive: { transform: [{ translateX: 18 }] },
 });

--- a/apps/mobile/app/(store-admin)/inventory/locations.tsx
+++ b/apps/mobile/app/(store-admin)/inventory/locations.tsx
@@ -15,6 +15,7 @@ import { EmptyState } from '@/shared/components/empty-state/empty-state';
 import { Spinner } from '@/shared/components/spinner/spinner';
 import { StatsGrid } from '@/shared/components/stats-card/stats-grid';
 import { toastSuccess, toastError } from '@/shared/components/toast/toast.store';
+import { ConfirmDialog } from '@/shared/components/confirm-dialog/confirm-dialog';
 import { borderRadius, colorScales, colors, shadows, spacing, typography } from '@/shared/theme';
 
 const TYPE_VARIANT: Record<LocationType, 'info' | 'warning' | 'default'> = {
@@ -253,6 +254,8 @@ export default function LocationsScreen() {
 
   // Estado del popup "más opciones" por card
   const [cardMoreAnchor, setCardMoreAnchor] = useState<{ top: number; right: number; item: Location } | null>(null);
+  // Estado del confirm dialog de eliminación
+  const [deleteTarget, setDeleteTarget] = useState<Location | null>(null);
 
   // Toggle estado desde la card
   const handleToggleActive = useCallback((item: Location) => {
@@ -266,11 +269,19 @@ export default function LocationsScreen() {
     });
   }, [screenW]);
 
-  // Confirmar eliminar
-  const handleDelete = useCallback((item: Location) => {
+  // Abrir confirm dialog de eliminar (cierra el popup "más opciones" primero)
+  const handleAskDelete = useCallback((item: Location) => {
     setCardMoreAnchor(null);
-    deleteMutation.mutate(item.id);
-  }, [deleteMutation]);
+    setDeleteTarget(item);
+  }, []);
+
+  // Confirmar eliminar
+  const handleConfirmDelete = useCallback(() => {
+    if (!deleteTarget) return;
+    const id = deleteTarget.id;
+    setDeleteTarget(null);
+    deleteMutation.mutate(id);
+  }, [deleteTarget, deleteMutation]);
 
   const allLocations = data?.pages.flatMap((p) => p.data) ?? [];
 
@@ -475,7 +486,7 @@ export default function LocationsScreen() {
             <View style={styles.dropdown}>
               <Pressable
                 style={styles.dropdownItem}
-                onPress={() => handleDelete(cardMoreAnchor.item)}
+                onPress={() => handleAskDelete(cardMoreAnchor.item)}
               >
                 <View style={[styles.dropdownIconWrap, { backgroundColor: colorScales.red[50] }]}>
                   <Ionicons name="trash" size={18} color={colorScales.red[600]} />
@@ -765,6 +776,23 @@ export default function LocationsScreen() {
           </View>
         </View>
       </Modal>
+
+      {/* Confirm dialog de eliminación */}
+      <ConfirmDialog
+        visible={!!deleteTarget}
+        onClose={() => setDeleteTarget(null)}
+        onConfirm={handleConfirmDelete}
+        title="Eliminar ubicación"
+        message={
+          deleteTarget
+            ? `¿Estás seguro de eliminar "${deleteTarget.name}"? Esta acción no se puede deshacer.`
+            : ''
+        }
+        confirmLabel="Eliminar"
+        cancelLabel="Cancelar"
+        destructive
+        loading={deleteMutation.isPending}
+      />
     </View>
   );
 }

--- a/apps/mobile/app/(store-admin)/inventory/locations.tsx
+++ b/apps/mobile/app/(store-admin)/inventory/locations.tsx
@@ -244,7 +244,7 @@ export default function LocationsScreen() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['locations'] });
       queryClient.invalidateQueries({ queryKey: ['inventory-stats'] });
-      toastSuccess('Ubicación eliminada correctamente');
+      toastSuccess('Ubicación desactivada correctamente');
     },
     onError: (error: any) => {
       const message = error?.response?.data?.message || error?.message || 'Error al eliminar la ubicación';

--- a/apps/mobile/app/(store-admin)/inventory/pop.tsx
+++ b/apps/mobile/app/(store-admin)/inventory/pop.tsx
@@ -123,8 +123,8 @@ export default function PopScreen() {
         InventoryService.getLocations({ page: 1, limit: 200 }),
         ProductService.list({ page: 1, limit: 200, include_variants: true }),
       ]);
-      setSuppliers((suppliersRes.data || []).map((s: any) => ({ id: Number(s.id), name: s.name, code: s.code, email: s.email, phone: s.phone, tax_id: s.tax_id, is_active: s.state === 'active' })));
-      setLocations((locationsRes.data || []).map((l: any) => ({ id: Number(l.id), name: l.name, code: l.code, type: l.type, is_active: l.state === 'active' })));
+      setSuppliers((suppliersRes.data || []).map((s: any) => ({ id: Number(s.id), name: s.name, code: s.code, email: s.email, phone: s.phone, tax_id: s.tax_id, is_active: !!s.is_active })));
+      setLocations((locationsRes.data || []).map((l: any) => ({ id: Number(l.id), name: l.name, code: l.code, type: l.type, is_active: !!l.is_active })));
       setProducts((productsRes.data || []) as PopProduct[]);
     } catch (err) {
       console.error('Error loading POP data:', err);
@@ -152,7 +152,7 @@ export default function PopScreen() {
         code: res.code,
         email: res.email,
         phone: res.phone,
-        is_active: (res as any).state === 'active',
+        is_active: !!res.is_active,
       };
       setSuppliers((prev) => [...prev, newSupplier]);
       cart.setSupplier(newSupplier.id, newSupplier.name);
@@ -182,7 +182,7 @@ export default function PopScreen() {
         name: res.name,
         code: res.code,
         type: res.type,
-        is_active: (res as any).state === 'active',
+        is_active: !!res.is_active,
       };
       setLocations((prev) => [...prev, newLocation]);
       cart.setLocation(newLocation.id, newLocation.name);

--- a/apps/mobile/app/(store-admin)/inventory/suppliers.tsx
+++ b/apps/mobile/app/(store-admin)/inventory/suppliers.tsx
@@ -213,7 +213,7 @@ export default function SuppliersScreen() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['suppliers'] });
       queryClient.invalidateQueries({ queryKey: ['inventory-stats'] });
-      toastSuccess('Proveedor eliminado');
+      toastSuccess('Proveedor desactivado');
     },
     onError: (error: any) => {
       const message = error?.response?.data?.message || error?.message || 'Error al eliminar el proveedor';

--- a/apps/mobile/app/(store-admin)/inventory/suppliers.tsx
+++ b/apps/mobile/app/(store-admin)/inventory/suppliers.tsx
@@ -14,6 +14,7 @@ import { Spinner } from '@/shared/components/spinner/spinner';
 import { StatsGrid } from '@/shared/components/stats-card/stats-grid';
 import { EmptyState } from '@/shared/components/empty-state/empty-state';
 import { toastSuccess, toastError } from '@/shared/components/toast/toast.store';
+import { ConfirmDialog } from '@/shared/components/confirm-dialog/confirm-dialog';
 import { borderRadius, colorScales, colors, shadows, spacing, typography } from '@/shared/theme';
 
 const STATE_LABELS = {
@@ -112,6 +113,7 @@ export default function SuppliersScreen() {
   const [modalVisible, setModalVisible] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [form, setForm] = useState<CreateSupplierDto & { is_active?: boolean }>({ ...emptyForm });
+  const [deleteTarget, setDeleteTarget] = useState<Supplier | null>(null);
 
   const FILTER_OPTIONS: { label: string; value: 'all' | 'active' | 'inactive' }[] = [
     { label: 'Todos los estados', value: 'all' },
@@ -266,6 +268,7 @@ export default function SuppliersScreen() {
       lead_time_days: form.lead_time_days ?? null,
       notes: form.notes?.trim() || undefined,
       address: form.address?.trim() || undefined,
+      is_active: !!form.is_active,
     };
     if (editingId) {
       updateMutation.mutate({ id: editingId, dto });
@@ -297,8 +300,15 @@ export default function SuppliersScreen() {
   }, [screenW]);
 
   const handleDelete = useCallback((item: Supplier) => {
-    deleteMutation.mutate(item.id);
-  }, [deleteMutation]);
+    setDeleteTarget(item);
+  }, []);
+
+  const handleConfirmDelete = useCallback(() => {
+    if (!deleteTarget) return;
+    const id = deleteTarget.id;
+    setDeleteTarget(null);
+    deleteMutation.mutate(id);
+  }, [deleteTarget, deleteMutation]);
 
   const isSubmitting = createMutation.isPending || updateMutation.isPending;
   const isFormValid = !!(form.name.trim() && form.code?.trim());
@@ -667,6 +677,23 @@ export default function SuppliersScreen() {
           </View>
         </View>
       </Modal>
+
+      {/* Confirm dialog de eliminación */}
+      <ConfirmDialog
+        visible={!!deleteTarget}
+        onClose={() => setDeleteTarget(null)}
+        onConfirm={handleConfirmDelete}
+        title="Eliminar proveedor"
+        message={
+          deleteTarget
+            ? `¿Estás seguro de eliminar a "${deleteTarget.name}"? Esta acción no se puede deshacer.`
+            : ''
+        }
+        confirmLabel="Eliminar"
+        cancelLabel="Cancelar"
+        destructive
+        loading={deleteMutation.isPending}
+      />
     </View>
   );
 }

--- a/apps/mobile/src/features/store/services/data-collection.service.ts
+++ b/apps/mobile/src/features/store/services/data-collection.service.ts
@@ -64,6 +64,16 @@ export const DataCollectionService = {
       return unwrap<DataCollectionTemplate>(res);
     },
 
+    async create(data: Partial<DataCollectionTemplate>): Promise<DataCollectionTemplate> {
+      const res = await apiClient.post(TEMPLATES_BASE, data);
+      return unwrap<DataCollectionTemplate>(res);
+    },
+
+    async update(id: number, data: Partial<DataCollectionTemplate>): Promise<DataCollectionTemplate> {
+      const res = await apiClient.patch(`${TEMPLATES_BASE}/${id}`, data);
+      return unwrap<DataCollectionTemplate>(res);
+    },
+
     async delete(id: number): Promise<void> {
       await apiClient.delete(`${TEMPLATES_BASE}/${id}`);
     },

--- a/apps/mobile/src/features/store/types/customer.types.ts
+++ b/apps/mobile/src/features/store/types/customer.types.ts
@@ -6,6 +6,7 @@ export interface Customer {
   last_name: string;
   email: string;
   phone?: string;
+  document_type?: string;
   document_number?: string;
   state: CustomerState;
   created_at: string;
@@ -47,6 +48,7 @@ export interface CreateCustomerDto {
   last_name: string;
   email: string;
   phone?: string;
+  document_type?: string;
   document_number?: string;
   state?: CustomerState;
 }

--- a/apps/mobile/src/features/store/types/inventory.types.ts
+++ b/apps/mobile/src/features/store/types/inventory.types.ts
@@ -166,6 +166,15 @@ export type AdjustmentType = 'damage' | 'loss' | 'theft' | 'expiration' | 'count
 export type AdjustmentState = 'pending' | 'applied';
 export type TransferState = 'pending' | 'in_transit' | 'completed' | 'cancelled';
 export type LocationType = 'warehouse' | 'store' | 'virtual';
+
+/**
+ * Aliases legacy — mantener para compatibilidad hacia atrás.
+ * El contrato real del backend es `is_active: boolean`
+ * (ver Prisma `inventory_locations`/`suppliers`, backend DTOs en
+ * `apps/backend/src/domains/store/inventory/{locations,suppliers}/dto/`,
+ * y el frontend Angular `inventory.interface.ts`).
+ * NO usar en código nuevo — usar `item.is_active` directamente.
+ */
 export type SupplierState = 'active' | 'inactive';
 export type LocationState = 'active' | 'inactive';
 

--- a/apps/mobile/src/shared/components/icon/icon.tsx
+++ b/apps/mobile/src/shared/components/icon/icon.tsx
@@ -392,6 +392,7 @@ import {
   Stethoscope,
   HeartPulse,
   Trash,
+  MapPin,
 } from 'lucide-react-native';
 import { colors } from '@/shared/theme/colors';
 
@@ -407,6 +408,7 @@ const iconMap: Record<string, typeof ShoppingCart> = {
   'user-check': UserCheck,
   'user-plus': UserPlus,
   mail: Mail,
+  'map-pin': MapPin,
   phone: Phone,
   building: Building2,
   store: Store,

--- a/package-lock.json
+++ b/package-lock.json
@@ -7166,7 +7166,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7180,7 +7179,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7194,7 +7192,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7208,7 +7205,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7222,7 +7218,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7236,7 +7231,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [


### PR DESCRIPTION
Cambios de setup/cleanup necesarios para el flujo de desarrollo mobile (web preview + APK debug local).

## Cambios

### apps/mobile/app.json
- `expo.android.package: 'com.quickss.vendix'` — bundle ID legible (antes era el default `com.anonymous.vendix-mobile` que es feo en el launcher)
- Deps `react-dom` y `react-native-web` ya agregadas en commit previo de setup (Expo 54 las necesita para `expo start --web`)

### apps/mobile/src/features/store/types/customer.types.ts
- `Customer.document_type?: string` — alineado con backend y web Angular
- `CreateCustomerDto.document_type?: string` — el modal de Crear/Editar que agregamos en PR #319 depende de esto
- Habilita el dropdown de tipo de documento (CC, CE, NIT, PAS, TI) que se ve en el modal de Crear cliente

### apps/mobile/src/features/store/types/inventory.types.ts
- JSDoc sobre los aliases legacy `SupplierState` y `LocationState`
- Explica que el contrato real es `is_active: boolean` (ver Prisma, backend DTOs, frontend Angular)
- NO usar en código nuevo — usar `item.is_active` directamente
- Mantenidos por compatibilidad hacia atrás

## Dependencias con otros PRs
- `document_type` en `customer.types.ts` es pre-requisito del feature de Crear/Editar Cliente de PR #319
- Si este PR se mergea DESPUÉS de #319, hacer rebase o merge desde dev a PR #319 antes de mergear

## Diff stat
```
 apps/mobile/app.json                                       |  6 +-
 apps/mobile/src/features/store/types/customer.types.ts    |  2 +
 apps/mobile/src/features/store/types/inventory.types.ts   |  9 +
 3 files changed, 15 insertions(+), 2 deletions(-)
```