### PR TITLE
fix(backend): add Metro web ports to CORS allowlist

### DIFF
--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -94,9 +94,11 @@ async function bootstrap() {
 
   const staticOrigins = [
     'http://localhost:4200',
+    'http://localhost:8081', // Expo Go (mobile dev)
+    'http://localhost:8082', // Metro web dev (reservado)
+    'http://localhost:8083', // Metro web dev con Expo SDK 54+
     'http://localhost',
     'http://localhost:3000',
-    'http://localhost:8081',
     // Production - Dynamically generated using BASE_DOMAIN env var
     `https://${baseDomain}`,
     `https://www.${baseDomain}`,


### PR DESCRIPTION
Permite que el mobile renderizado como web en localhost pueda hacer login contra el backend en api.vendix.online sin error de CORS preflight.

## Problema

Al ejecutar `expo start --web` en apps/mobile, Metro arranca en http://localhost:8083 con la app renderizada como web. Al intentar login, el navegador hace preflight OPTIONS contra https://api.vendix.online/api/auth/login que devolvia 404 porque localhost:8083 no estaba en la allowlist de CORS.

El 'Network Error' que ve el usuario en el browser es en realidad el preflight OPTIONS fallando — el endpoint real (POST /auth/login) si responde 200, como confirme con curl.

## Cambio

apps/backend/src/main.ts (staticOrigins, linea 95-103):
- http://localhost:8081  // Expo Go (mobile dev, antes en linea 100)
- http://localhost:8082  // Metro web dev (reservado)
- http://localhost:8083  // Metro web dev con Expo SDK 54+

Eliminado duplicado de http://localhost:8081 (estaba 2 veces antes).

## Relacion con PR #315

PR #315 (`fix(frontend): proxy /api to api.vendix.com in dev to bypass CORS`) resuelve el mismo problema desde el lado del frontend Angular (proxy). Este PR lo resuelve desde el backend NestJS (allowlist). Ambos pueden coexistir: PR #315 aplica solo a devs que usan Angular, PR #322 aplica a cualquiera que use localhost:808X (mobile en web, Expo Go, otros frameworks).

## Como verificar

Despues de mergear y redeploy:
1. `cd apps/mobile && EXPO_PUBLIC_API_URL=https://api.vendix.online/api npx expo start --web --port 8083`
2. Abrir http://localhost:8083/login en el navegador
3. DevTools > Network: el preflight OPTIONS debe devolver 200 con `Access-Control-Allow-Origin: http://localhost:8083`
4. Login con credenciales reales; ya no debe aparecer 'Network Error'

## Alternativa local (sin redeploy)

Usar Chrome extension 'Allow CORS' o configurar `CORS_ORIGIN=http://localhost:8083` en .env local del backend.

## Diff

```
 apps/backend/src/main.ts | 4 +++-
 1 file changed, 3 insertions(+), 1 deletion(-)
```

## Note

Cierra y reemplaza PR #322 que tenia el mismo cambio pero con un diff inflado (incluia tambien el commit de chore/mobile-deps-update-sdk54, 2085+/3089-). Esta version limpia es 3+/1-.