### PR TITLE
feat(sidebar): add analytics_purchases + analytics_reviews panel-ui mappings (ISSUE-06)

### DIFF
--- a/apps/frontend/src/app/core/services/menu-filter.service.ts
+++ b/apps/frontend/src/app/core/services/menu-filter.service.ts
@@ -71,8 +71,8 @@ export class MenuFilterService {
     'Plan Separe': 'orders_layaway',
     Reservas: 'orders_reservations',
 
-    // ORG_ADMIN - Compras (consolidado)
-    Compras: ['purchase_orders', 'orders_purchase_orders', 'orders'],
+    // ORG_ADMIN - Compras (consolidado) + analytics_purchases (Analiticas > Compras)
+    Compras: ['analytics_purchases', 'purchase_orders', 'orders_purchase_orders', 'orders'],
 
     // STORE_ADMIN - Inventario (padre + submódulos)
     Inventario: 'inventory',
@@ -86,7 +86,7 @@ export class MenuFilterService {
     // STORE_ADMIN - Clientes (padre + submódulos)
     Clientes: 'customers',
     'Todos los Clientes': 'customers_all',
-    Reseñas: 'customers_reviews',
+    Reseñas: ['analytics_reviews', 'customers_reviews'],
     'Recolección de Datos': 'customers_data_collection',
 
     // STORE_ADMIN - Marketing (padre + submódulos)


### PR DESCRIPTION
## ISSUE-06 · Sidebar: mappings panel-ui para Compras y Reseñas

Completa el último criterio de aceptación pendiente de ISSUE-06. El layout (`store-admin-layout.component.ts`) ya tenía las 8 entradas de Analíticas con icons y rutas correctas; faltaba el mapeo label→key en `MenuFilterService.moduleKeyMap` para que las dos entradas que colisionan con otros módulos puedan ser gobernadas desde el panel UI.

## Cambios

### `apps/frontend/src/app/core/services/menu-filter.service.ts`
- **Línea 75**: `Compras` ahora mapea a `['analytics_purchases', 'purchase_orders', 'orders_purchase_orders', 'orders']` (prepend de la key nueva al array OR existente).
- **Línea 89**: `Reseñas` ahora mapea a `['analytics_reviews', 'customers_reviews']` (expansión de string a array OR).

## Patrón reutilizado

**OR-array pattern**: ya usado en el service para `Compras` (mismo lugar), `Usuarios` (línea 53: `['users', 'settings_users']`). El skill `vendix-panel-ui` lo documenta explícitamente:

> Array mappings in `moduleKeyMap` mean OR logic across multiple keys.

## Skills aplicadas

- `vendix-panel-ui` — pattern label-driven, OR arrays, single source en `moduleKeyMap`. **Critical Plan Decisions N/A** porque las keys ya existen en `APP_MODULES.STORE_ADMIN` y `PANEL_UI_FALLBACK` (skill SKILL.md:34-47 aplica solo a keys nuevas).
- `git-workflow` — branch `feature/issue-06-sidebar-purchases-reviews` desde `origin/dev`, sin AI co-author.

## Verificación local

- ✅ `npx tsc --noEmit -p tsconfig.app.json` → clean
- ✅ `npx ng build --configuration=development` → success

## Out of scope

El `alwaysVisible: true` de las entradas en `store-admin-layout.component.ts:479-490` y `533-544` bypasea `moduleKeyMap` en runtime. Los mappings nuevos no cambian la visibilidad actual del sidebar, pero **sí** desbloquean el toggle granular desde `Settings → Módulos del Panel`. Corregir `alwaysVisible: true` es trabajo de otro issue (señalado en el plan para visibilidad del equipo).

## Estimación

1h (alineado con el estimado original del issue). Cambios: 3 líneas modificadas en 1 archivo, 0 archivos nuevos, 0 dependencias, 0 migraciones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)