### PR TITLE
feat(sidebar): add analytics_purchases + analytics_reviews panel-ui mappings (ISSUE-06)

### DIFF
--- a/apps/frontend/src/app/core/services/menu-filter.service.ts
+++ b/apps/frontend/src/app/core/services/menu-filter.service.ts
@@ -71,8 +71,8 @@ export class MenuFilterService {
     'Plan Separe': 'orders_layaway',
     Reservas: 'orders_reservations',
 
-    // ORG_ADMIN - Compras (consolidado)
-    Compras: ['purchase_orders', 'orders_purchase_orders', 'orders'],
+    // ORG_ADMIN - Compras (consolidado) + analytics_purchases (Analiticas > Compras)
+    Compras: ['analytics_purchases', 'purchase_orders', 'orders_purchase_orders', 'orders'],
 
     // STORE_ADMIN - Inventario (padre + submódulos)
     Inventario: 'inventory',
@@ -86,7 +86,7 @@ export class MenuFilterService {
     // STORE_ADMIN - Clientes (padre + submódulos)
     Clientes: 'customers',
     'Todos los Clientes': 'customers_all',
-    Reseñas: 'customers_reviews',
+    Reseñas: ['analytics_reviews', 'customers_reviews'],
     'Recolección de Datos': 'customers_data_collection',
 
     // STORE_ADMIN - Marketing (padre + submódulos)


### PR DESCRIPTION
## Summary

Cierra ISSUE-06 del EPIC 'Normalización del Módulo de Analíticas' añadiendo los 2 mappings faltantes en `MenuFilterService.moduleKeyMap` (`Compras → analytics_purchases` y `Reseñas → analytics_reviews`).

## ⚠️ DATABASE MIGRATION

**N/A** — Este PR no incluye migraciones de base de datos. Solo modifica `MenuFilterService` (frontend).

## Skill `git-workflow` gates (verificados)

| Gate | Estado | Detalle |
|---|---|---|
| **RULE 1** — No push a `main`/`master` | ✅ | PR targeta `dev` (`baseRefName: "dev"`) |
| **RULE 2** — No AI co-authors | ✅ | Commit sin `Co-Authored-By` (verificado) |
| **RULE 3** — DB migration alerts | ⏭️ N/A | Sin migraciones |
| **RULE 4** — Conflict resolution | ⏭️ N/A | Branch fresh desde `origin/dev`, sin conflicts |

## Cambios

### `apps/frontend/src/app/core/services/menu-filter.service.ts`
- **Línea 75**: `Compras` ahora mapea a `['analytics_purchases', 'purchase_orders', 'orders_purchase_orders', 'orders']` (prepend de la key nueva al array OR existente).
- **Línea 89**: `Reseñas` ahora mapea a `['analytics_reviews', 'customers_reviews']` (expansión de string a array OR).

## Patrón reutilizado

**OR-array pattern**: ya usado en el service para `Compras` (mismo lugar), `Usuarios` (línea 53: `['users', 'settings_users']`). El skill `vendix-panel-ui` lo documenta explícitamente:

> Array mappings in `moduleKeyMap` mean OR logic across multiple keys.

## Skills aplicadas

- `vendix-panel-ui` — pattern label-driven, OR arrays, single source en `moduleKeyMap`. **Critical Plan Decisions N/A** porque las keys ya existen en `APP_MODULES.STORE_ADMIN` y `PANEL_UI_FALLBACK` (skill SKILL.md:34-47 aplica solo a keys nuevas).
- `git-workflow` — branch `feature/issue-06-sidebar-purchases-reviews` desde `origin/dev`, sin AI co-author.

## Diff summary

```
apps/frontend/src/app/core/services/menu-filter.service.ts | 6 ++++--
```

## Branch state

```
HEAD          → a31c4190 feat(sidebar): add analytics_purchases + analytics_reviews panel-ui mappings
origin/dev    → cc44afe0 chore(mobile): config cleanup for web + APK packaging (#320)
```
1 commit ahead de dev, sin divergence.

## Verificación local

- ✅ `npx tsc --noEmit -p tsconfig.app.json` → clean
- ✅ `npx ng build --configuration=development` → success

## Out of scope

El `alwaysVisible: true` de las entradas en `store-admin-layout.component.ts:479-490` y `533-544` bypasea `moduleKeyMap` en runtime. Los mappings nuevos no cambian la visibilidad actual del sidebar, pero **sí** desbloquean el toggle granular desde `Settings → Módulos del Panel`. Corregir `alwaysVisible: true` es trabajo de otro issue (señalado en el plan para visibilidad del equipo).

## Estimación

1h (alineado con el estimado original del issue). Cambios: 3 líneas modificadas en 1 archivo, 0 archivos nuevos, 0 dependencias, 0 migraciones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)