### PR TITLE
feat(breadcrumb): wire document.title + analytics registry seed (ISSUE-08)

### DIFF
--- a/apps/frontend/src/app/core/services/breadcrumb.service.spec.ts
+++ b/apps/frontend/src/app/core/services/breadcrumb.service.spec.ts
@@ -1,0 +1,136 @@
+import { TestBed } from '@angular/core/testing';
+import { Router, NavigationEnd, Event } from '@angular/router';
+import { Title } from '@angular/platform-browser';
+import { Subject } from 'rxjs';
+import { BreadcrumbService } from './breadcrumb.service';
+
+describe('BreadcrumbService', () => {
+  let service: BreadcrumbService;
+  let titleSetSpy: jasmine.Spy;
+  let routerEvents$: Subject<Event>;
+  let routerStub: Partial<Router>;
+
+  beforeEach(() => {
+    routerEvents$ = new Subject<Event>();
+    routerStub = {
+      url: '/dashboard',
+      events: routerEvents$.asObservable(),
+    };
+    titleSetSpy = spyOn(Title.prototype, 'setTitle');
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: Router, useValue: routerStub },
+        BreadcrumbService,
+      ],
+    });
+
+    service = TestBed.inject(BreadcrumbService);
+  });
+
+  describe('analytics 8 shells + sub-tabs (ISSUE-08)', () => {
+    const analyticsExpectations: Array<{
+      url: string;
+      expectedTitle: string;
+      expectedParent?: string;
+    }> = [
+      // Overview shell
+      { url: '/admin/analytics/overview', expectedTitle: 'Resumen General' },
+
+      // Sales shell (6 sub-tabs)
+      { url: '/admin/analytics/sales', expectedTitle: 'Ventas', expectedParent: 'Analíticas' },
+      { url: '/admin/analytics/sales/summary', expectedTitle: 'Resumen de Ventas', expectedParent: 'Ventas' },
+      { url: '/admin/analytics/sales/by-product', expectedTitle: 'Por Producto', expectedParent: 'Ventas' },
+      { url: '/admin/analytics/sales/by-category', expectedTitle: 'Por Categoria', expectedParent: 'Ventas' },
+      { url: '/admin/analytics/sales/trends', expectedTitle: 'Tendencias', expectedParent: 'Ventas' },
+      { url: '/admin/analytics/sales/by-customer', expectedTitle: 'Por Cliente', expectedParent: 'Ventas' },
+      { url: '/admin/analytics/sales/by-payment', expectedTitle: 'Por Metodo de Pago', expectedParent: 'Ventas' },
+
+      // Inventory shell (5 sub-tabs)
+      { url: '/admin/analytics/inventory', expectedTitle: 'Inventario', expectedParent: 'Analíticas' },
+      { url: '/admin/analytics/inventory/overview', expectedTitle: 'Resumen de Inventario', expectedParent: 'Analíticas' },
+      { url: '/admin/analytics/inventory/stock-info', expectedTitle: 'Info de Stock', expectedParent: 'Inventario' },
+      { url: '/admin/analytics/inventory/movements', expectedTitle: 'Movimientos de Inventario', expectedParent: 'Inventario' },
+      { url: '/admin/analytics/inventory/valuation', expectedTitle: 'Valoracion', expectedParent: 'Inventario' },
+      { url: '/admin/analytics/inventory/movement-analysis', expectedTitle: 'Analisis de Movimientos', expectedParent: 'Inventario' },
+
+      // Products shell (3 sub-tabs)
+      { url: '/admin/analytics/products', expectedTitle: 'Productos', expectedParent: 'Analíticas' },
+      { url: '/admin/analytics/products/performance', expectedTitle: 'Rendimiento', expectedParent: 'Productos' },
+      { url: '/admin/analytics/products/top-sellers', expectedTitle: 'Top Ventas', expectedParent: 'Productos' },
+      { url: '/admin/analytics/products/profitability', expectedTitle: 'Rentabilidad', expectedParent: 'Productos' },
+
+      // Purchases shell (2 sub-tabs)
+      { url: '/admin/analytics/purchases', expectedTitle: 'Compras', expectedParent: 'Analíticas' },
+      { url: '/admin/analytics/purchases/summary', expectedTitle: 'Resumen de Compras', expectedParent: 'Compras' },
+      { url: '/admin/analytics/purchases/by-supplier', expectedTitle: 'Compras por Proveedor', expectedParent: 'Compras' },
+
+      // Customers shell (3 sub-tabs)
+      { url: '/admin/analytics/customers', expectedTitle: 'Clientes', expectedParent: 'Analíticas' },
+      { url: '/admin/analytics/customers/summary', expectedTitle: 'Resumen de Clientes', expectedParent: 'Clientes' },
+      { url: '/admin/analytics/customers/acquisition', expectedTitle: 'Adquisición de Clientes', expectedParent: 'Clientes' },
+      { url: '/admin/analytics/customers/abandoned-carts', expectedTitle: 'Carritos Abandonados', expectedParent: 'Clientes' },
+
+      // Reviews shell (1 sub-tab)
+      { url: '/admin/analytics/reviews', expectedTitle: 'Reseñas', expectedParent: 'Analíticas' },
+      { url: '/admin/analytics/reviews/summary', expectedTitle: 'Resumen de Reseñas', expectedParent: 'Reseñas' },
+
+      // Financial shell (3 sub-tabs)
+      { url: '/admin/analytics/financial', expectedTitle: 'Financiero', expectedParent: 'Analíticas' },
+      { url: '/admin/analytics/financial/profit-loss', expectedTitle: 'Ganancias y Pérdidas', expectedParent: 'Financiero' },
+      { url: '/admin/analytics/financial/tax-summary', expectedTitle: 'Resumen de Impuestos', expectedParent: 'Financiero' },
+      { url: '/admin/analytics/financial/refunds', expectedTitle: 'Reembolsos', expectedParent: 'Financiero' },
+    ];
+
+    analyticsExpectations.forEach(({ url, expectedTitle, expectedParent }) => {
+      it(`resolves ${url} → title="${expectedTitle}"`, () => {
+        // Re-create the service so the static table is populated for this test
+        // (the seeded registry entries are async; the static table has the same paths)
+        routerEvents$.next(new NavigationEnd(1, url, url));
+        const crumb = service.breadcrumb();
+        expect(crumb.current.label).toBe(expectedTitle);
+        if (expectedParent) {
+          expect(crumb.parent?.label).toBe(expectedParent);
+        }
+      });
+    });
+  });
+
+  describe('document.title sync (effect)', () => {
+    it('sets title with "Padre > Hijo | Vendix" format on admin route', () => {
+      // Reset spy (constructor's effect ran once at boot for the default url)
+      titleSetSpy.calls.reset();
+
+      routerEvents$.next(
+        new NavigationEnd(
+          2,
+          '/admin/analytics/sales/by-product',
+          '/admin/analytics/sales/by-product',
+        ),
+      );
+      TestBed.tick();
+
+      expect(titleSetSpy).toHaveBeenCalledWith('Ventas > Por Producto | Vendix');
+    });
+
+    it('uses just the tab name when there is no parent', () => {
+      titleSetSpy.calls.reset();
+
+      routerEvents$.next(new NavigationEnd(3, '/dashboard', '/dashboard'));
+      TestBed.tick();
+
+      // /dashboard has no parent in the table → "Dashboard | Vendix"
+      expect(titleSetSpy).toHaveBeenCalledWith('Dashboard | Vendix');
+    });
+
+    it('does NOT call setTitle when the breadcrumb is the default fallback (no match)', () => {
+      titleSetSpy.calls.reset();
+
+      routerEvents$.next(new NavigationEnd(4, '/unknown/route', '/unknown/route'));
+      TestBed.tick();
+
+      // Guard: avoids clobbering the public store-ecommerce layout's title
+      expect(titleSetSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/frontend/src/app/core/services/breadcrumb.service.ts
+++ b/apps/frontend/src/app/core/services/breadcrumb.service.ts
@@ -1,6 +1,7 @@
-import { Injectable, signal, DestroyRef, inject } from '@angular/core';
+import { Injectable, signal, DestroyRef, inject, effect } from '@angular/core';
 import { toObservable, takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Router, NavigationEnd } from '@angular/router';
+import { Title } from '@angular/platform-browser';
 import { filter } from 'rxjs/operators';
 
 export interface BreadcrumbItem {
@@ -1083,7 +1084,7 @@ export class BreadcrumbService {
     },
     {
       path: '/admin/analytics/inventory/overview',
-      title: 'Inventario',
+      title: 'Resumen de Inventario',
       parent: 'Analíticas',
       icon: 'warehouse',
     },
@@ -1143,13 +1144,13 @@ export class BreadcrumbService {
     },
     {
       path: '/admin/analytics/sales/by-product',
-      title: 'Ventas por Producto',
+      title: 'Por Producto',
       parent: 'Ventas',
       icon: 'package',
     },
     {
       path: '/admin/analytics/sales/by-category',
-      title: 'Ventas por Categoría',
+      title: 'Por Categoria',
       parent: 'Ventas',
       icon: 'folder',
     },
@@ -1161,13 +1162,13 @@ export class BreadcrumbService {
     },
     {
       path: '/admin/analytics/sales/by-customer',
-      title: 'Ventas por Cliente',
+      title: 'Por Cliente',
       parent: 'Ventas',
       icon: 'users',
     },
     {
       path: '/admin/analytics/sales/by-payment',
-      title: 'Ventas por Pago',
+      title: 'Por Metodo de Pago',
       parent: 'Ventas',
       icon: 'credit-card',
     },
@@ -1191,13 +1192,13 @@ export class BreadcrumbService {
     },
     {
       path: '/admin/analytics/inventory/valuation',
-      title: 'Valoración de Inventario',
+      title: 'Valoracion',
       parent: 'Inventario',
       icon: 'dollar-sign',
     },
     {
       path: '/admin/analytics/inventory/movement-analysis',
-      title: 'Análisis de Movimientos',
+      title: 'Analisis de Movimientos',
       parent: 'Inventario',
       icon: 'bar-chart',
     },
@@ -1321,6 +1322,76 @@ export class BreadcrumbService {
 
   constructor(private router: Router) {
     this.initializeBreadcrumb();
+    this.seedAnalyticsRoutes();
+    this.installTitleEffect();
+  }
+
+  /**
+   * Siembra la tabla de rutas con los views y categorías de Analíticas desde
+   * el `analytics-registry` (single source of truth). Es idempotente: entradas
+   * con el mismo path ya presentes en la tabla estática NO se duplican (gana
+   * la estática, que es la conservadora y permite correcciones manuales).
+   *
+   * Se ejecuta como lazy import para evitar acoplar el ciclo de DI del core
+   * con el del módulo de analytics, y para que SSR (donde `window` no existe)
+   * no rompa la construcción.
+   */
+  private seedAnalyticsRoutes(): void {
+    if (typeof window === 'undefined') return;
+
+    void import(
+      '../../private/modules/store/analytics/config/analytics-registry'
+    ).then(({ ANALYTICS_VIEWS, ANALYTICS_CATEGORIES, getCategoryById }) => {
+      for (const view of ANALYTICS_VIEWS) {
+        if (this.routes.some((r) => r.path === view.route)) continue;
+        const cat = getCategoryById(view.category);
+        if (!cat) continue;
+        this.routes.push({
+          path: view.route,
+          title: view.title,
+          parent: cat.label,
+          icon: view.icon,
+        });
+      }
+
+      for (const cat of ANALYTICS_CATEGORIES) {
+        const shellPath = `/admin/analytics/${cat.id}`;
+        if (this.routes.some((r) => r.path === shellPath)) continue;
+        this.routes.push({
+          path: shellPath,
+          title: cat.label,
+          parent: 'Tienda',
+          icon: cat.icon,
+        });
+      }
+    });
+  }
+
+  /**
+   * Sincroniza `document.title` con el breadcrumb actual usando un `effect()`
+   * zoneless. El guard evita que el fallback por defecto (`Dashboard` sin
+   * parent) pisotee el `Title.setTitle` del layout público
+   * `store-ecommerce-layout.component.ts`, que setea el nombre de la tienda.
+   *
+   * Formato del título: `Padre > Hijo | Vendix` (cuando hay parent) o
+   * `Vendix` (cuando no hay match y se muestra el fallback — pero en ese caso
+   * el guard ya retornó sin tocar el title).
+   */
+  private installTitleEffect(): void {
+    const titleService = inject(Title);
+    effect(() => {
+      const crumb = this.breadcrumb();
+      // Guard: no pisar el título del layout público store-ecommerce
+      if (crumb.current.label === 'Dashboard' && !crumb.parent) return;
+
+      const segments = [crumb.parent?.label, crumb.current.label].filter(
+        Boolean,
+      ) as string[];
+      const fullTitle = segments.length
+        ? `${segments.join(' > ')} | Vendix`
+        : 'Vendix';
+      titleService.setTitle(fullTitle);
+    });
   }
 
   private initializeBreadcrumb() {


### PR DESCRIPTION
## Summary

Sincroniza `document.title` con el breadcrumb actual y siembra las 27 entradas de analíticas desde el registry en el BreadcrumbService. Cierra ISSUE-08 del EPIC 'Normalización del Módulo de Analíticas'.

## ⚠️ DATABASE MIGRATION

**N/A** — Este PR no incluye migraciones de base de datos. Solo modifica el BreadcrumbService de Angular (zoneless signals + lazy import) y añade un spec de Karma.

## Skill `git-workflow` gates (verificados)

| Gate | Estado | Detalle |
|---|---|---|
| **RULE 1** — No push a `main`/`master` | ✅ | PR targeta `dev` (`baseRefName: "dev"`) |
| **RULE 2** — No AI co-authors | ✅ | Commit sin `Co-Authored-By` (verificado con `git log -1 --format='%B' \| grep -c 'Co-Authored-By'` = 0) |
| **RULE 3** — DB migration alerts | ⏭️ N/A | Sin migraciones (declarado arriba) |
| **RULE 4** — Conflict resolution | ⏭️ N/A | Branch fresh desde `origin/dev`, sin conflicts |

## Cambios

### `apps/frontend/src/app/core/services/breadcrumb.service.ts`
- **Sincronización de `document.title`** vía `effect()` zoneless en el constructor del service. Formato: `Padre > Hijo | Vendix`. Guard evita pisar el título del layout público `store-ecommerce-layout`.
- **Seed desde `analytics-registry`**: en el constructor, `import()` dinámico del registry siembra las 8 categorías y 26 views en la tabla de rutas. Idempotente (no duplica si la estática ya tiene la entrada) y SSR-safe (`typeof window === 'undefined'` check).
- **7 correcciones de título** en la tabla estática para alinear con el registry.

### `apps/frontend/src/app/core/services/breadcrumb.service.spec.ts` (nuevo)
- Spec Karma + Jasmine que cubre los 8 shells + sub-tabs de analytics
- Tests del `effect()` de `document.title` con guard

## Skills aplicadas

- `vendix-zoneless-signals` — efecto zoneless + signal; sin `subscribe()` fuera de DestroyRef
- `vendix-frontend-component` — match nearest pattern, reuse shared, no new abstractions
- `vendix-analytics-pattern` — respeto del registry como single source of truth

## Diff summary

```
apps/frontend/src/app/core/services/breadcrumb.service.ts         | 79 +++++++++-
apps/frontend/src/app/core/services/breadcrumb.service.spec.ts   | 136 +++++++++++++
```

## Branch state

```
HEAD          → 025621d2 feat(breadcrumb): wire document.title + analytics registry seed
origin/dev    → cc44afe0 chore(mobile): config cleanup for web + APK packaging (#320)
```
1 commit ahead de dev, sin divergence.

## Verificación local

- ✅ `npx tsc --noEmit -p tsconfig.app.json` → clean
- ✅ `npx tsc --noEmit -p tsconfig.spec.json` → clean
- ✅ `npx ng build --configuration=development` → success
- ⏳ Runtime tests (Karma) requieren Chrome — pendientes para CI / máquina con browser

## Estimación

1h (alineado con el estimado original del issue).