### PR TITLE
feat(analytics): extract AnalyticsTabBarComponent + refactor shell (ISSUE-02)

### DIFF
--- a/apps/frontend/src/app/private/modules/store/analytics/components/analytics-shell/analytics-shell.component.html
+++ b/apps/frontend/src/app/private/modules/store/analytics/components/analytics-shell/analytics-shell.component.html
@@ -3,11 +3,11 @@
     [title]="category()?.label || 'Analíticas'"
     [subtitle]="category()?.description || ''"
     [icon]="category()?.icon || 'chart-bar'"
-    [tabs]="tabs()"
     [actions]="headerActions()"
     (actionClicked)="onActionClick($event)"
-    tabsAriaLabel="Navegacion de analiticas"
   ></app-sticky-header>
+
+  <app-analytics-tab-bar [categoryId]="categoryId() ?? 'overview'"></app-analytics-tab-bar>
 
   <main class="shell-content">
     <router-outlet></router-outlet>

--- a/apps/frontend/src/app/private/modules/store/analytics/components/analytics-shell/analytics-shell.component.ts
+++ b/apps/frontend/src/app/private/modules/store/analytics/components/analytics-shell/analytics-shell.component.ts
@@ -1,24 +1,22 @@
 import { Component, computed, inject } from '@angular/core';
 import { RouterOutlet, ActivatedRoute, Router } from '@angular/router';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { map } from 'rxjs';
 import {
   AnalyticsCategoryId,
   getCategoryById,
-  getViewsByCategory,
 } from '../../config/analytics-registry';
 import {
   StickyHeaderComponent,
-  StickyHeaderTab,
   StickyHeaderActionButton,
 } from '../../../../../../shared/components/sticky-header/sticky-header.component';
+import { AnalyticsTabBarComponent } from '../analytics-tab-bar/analytics-tab-bar.component';
 import { DateRangeSyncService } from '../../../shared/services/date-range-sync.service';
 import { dateRangeToQueryParams } from '../../../shared/utils/date-range-params.util';
 
 @Component({
   selector: 'app-analytics-shell',
   standalone: true,
-  imports: [RouterOutlet, StickyHeaderComponent],
+  imports: [RouterOutlet, StickyHeaderComponent, AnalyticsTabBarComponent],
   templateUrl: './analytics-shell.component.html',
   styleUrls: ['./analytics-shell.component.scss'],
 })
@@ -27,25 +25,19 @@ export class AnalyticsShellComponent {
   private readonly router = inject(Router);
   private readonly dateRangeSync = inject(DateRangeSyncService);
 
-  private readonly categoryId = toSignal(
-    this.route.data.pipe(map((data) => data['categoryId'] as AnalyticsCategoryId)),
+  // `initialValue` evita el "no initial value" warning del audit script zoneless
+  // y permite que `categoryId` se lea sincrónicamente dentro de `computed()`.
+  private readonly routeData = toSignal(this.route.data, {
+    initialValue: this.route.snapshot.data,
+  });
+
+  readonly categoryId = computed<AnalyticsCategoryId | undefined>(
+    () => this.routeData()['categoryId'] as AnalyticsCategoryId | undefined,
   );
 
   readonly category = computed(() => {
     const categoryId = this.categoryId();
     return categoryId ? getCategoryById(categoryId) : undefined;
-  });
-
-  readonly tabs = computed<StickyHeaderTab[]>(() => {
-    const categoryId = this.categoryId();
-    if (!categoryId) return [];
-
-    return getViewsByCategory(categoryId).map((view) => ({
-      id: view.key,
-      label: view.title,
-      icon: view.icon,
-      route: view.route,
-    }));
   });
 
   readonly headerActions = computed<StickyHeaderActionButton[]>(() => [

--- a/apps/frontend/src/app/private/modules/store/analytics/components/analytics-tab-bar/analytics-tab-bar.component.ts
+++ b/apps/frontend/src/app/private/modules/store/analytics/components/analytics-tab-bar/analytics-tab-bar.component.ts
@@ -1,0 +1,173 @@
+import { Component, computed, input } from '@angular/core';
+import { RouterLink, RouterLinkActive } from '@angular/router';
+import { IconComponent } from '../../../../../../shared/components/icon/icon.component';
+import {
+  AnalyticsCategoryId,
+  getViewsByCategory,
+} from '../../config/analytics-registry';
+
+interface AnalyticsTabView {
+  id: string;
+  label: string;
+  icon: string;
+  route: string;
+}
+
+/**
+ * Tab bar reutilizable para los shells de Analíticas.
+ *
+ * - Mobile-first: scroll horizontal con gradient-fade en los bordes (mask-image).
+ * - Desktop (≥ 768px): tabs centradas con underline en la activa.
+ * - Accesible: `role="tablist"` + `role="tab"` + `aria-current="page"` + `aria-selected`.
+ * - Signals-based: las tabs se derivan del registry via `computed()`.
+ *
+ * El shell padre (`AnalyticsShellComponent`) lee `data.categoryId` de la ruta
+ * y se lo pasa como input. Este componente no se suscribe a la ruta
+ * directamente — single responsibility.
+ */
+@Component({
+  selector: 'app-analytics-tab-bar',
+  standalone: true,
+  imports: [RouterLink, RouterLinkActive, IconComponent],
+  template: `
+    <nav
+      role="tablist"
+      [attr.aria-label]="ariaLabel()"
+      class="tab-bar"
+    >
+      @for (tab of tabs(); track tab.id) {
+        <a
+          [routerLink]="tab.route"
+          routerLinkActive="active"
+          #rla="routerLinkActive"
+          role="tab"
+          [attr.aria-current]="rla.isActive ? 'page' : null"
+          [attr.aria-selected]="rla.isActive"
+          class="tab-item"
+        >
+          @if (tab.icon) {
+            <app-icon [name]="tab.icon" size="14" />
+          }
+          <span class="tab-label">{{ tab.label }}</span>
+        </a>
+      }
+    </nav>
+  `,
+  styles: [
+    `
+      :host {
+        display: block;
+      }
+
+      .tab-bar {
+        display: flex;
+        align-items: center;
+        gap: 0.125rem;
+        padding: 0.5rem 0.75rem;
+        overflow-x: auto;
+        scroll-snap-type: x proximity;
+        -webkit-overflow-scrolling: touch;
+        scrollbar-width: none;
+        background: var(--color-surface);
+        border-bottom: 1px solid rgba(var(--color-muted-rgb), 0.16);
+
+        // Gradient-fade en los bordes del área de scroll (mobile)
+        -webkit-mask-image: linear-gradient(
+          to right,
+          transparent 0,
+          black 24px,
+          black calc(100% - 24px),
+          transparent 100%
+        );
+        mask-image: linear-gradient(
+          to right,
+          transparent 0,
+          black 24px,
+          black calc(100% - 24px),
+          transparent 100%
+        );
+      }
+      .tab-bar::-webkit-scrollbar {
+        display: none;
+      }
+
+      .tab-item {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.375rem;
+        padding: 0.5rem 0.75rem;
+        border-radius: var(--radius-pill);
+        font-size: var(--fs-xs-mobile);
+        font-weight: 500;
+        color: var(--color-text-secondary);
+        text-decoration: none;
+        white-space: nowrap;
+        scroll-snap-align: start;
+        transition:
+          color var(--transition-fast),
+          background var(--transition-fast);
+      }
+      .tab-item:hover {
+        color: var(--color-text-primary);
+        background: rgba(var(--color-primary-rgb), 0.06);
+      }
+      .tab-item.active {
+        color: var(--color-primary);
+        background: rgba(var(--color-primary-rgb), 0.1);
+        font-weight: 600;
+      }
+
+      @media (min-width: 768px) {
+        .tab-bar {
+          justify-content: center;
+          gap: 0.5rem;
+          padding: 0.75rem 1.5rem;
+          // En desktop las tabs caben — el mask no es necesario
+          -webkit-mask-image: none;
+          mask-image: none;
+        }
+        .tab-item {
+          padding: 0.5rem 1rem;
+          background: transparent;
+          border-radius: 0;
+          position: relative;
+        }
+        .tab-item::after {
+          content: '';
+          position: absolute;
+          left: 0.75rem;
+          right: 0.75rem;
+          bottom: -0.25rem;
+          height: 2px;
+          background: var(--color-primary);
+          transform: scaleX(0);
+          transform-origin: center;
+          transition: transform var(--transition-fast);
+        }
+        .tab-item.active {
+          background: transparent;
+        }
+        .tab-item.active::after {
+          transform: scaleX(1);
+        }
+      }
+    `,
+  ],
+})
+export class AnalyticsTabBarComponent {
+  /** ID de la categoría (lee tabs del registry). */
+  readonly categoryId = input.required<AnalyticsCategoryId>();
+
+  /** Etiqueta ARIA del tablist (override para i18n). */
+  readonly ariaLabel = input<string>('Navegación de analíticas');
+
+  /** Tabs derivadas del registry, re-evaluadas al cambiar `categoryId`. */
+  readonly tabs = computed<AnalyticsTabView[]>(() =>
+    getViewsByCategory(this.categoryId()).map((view) => ({
+      id: view.key,
+      label: view.title,
+      icon: view.icon,
+      route: view.route,
+    })),
+  );
+}


### PR DESCRIPTION
## Summary

Crea `AnalyticsTabBarComponent` reutilizable con su propia identidad visual (mobile scroll con gradient-fade, desktop centrado con underline) y refactoriza `AnalyticsShellComponent` para delegarle la tab row. Cierra ISSUE-02 del EPIC 'Normalización del Módulo de Analíticas'.

## ⚠️ DATABASE MIGRATION

**N/A** — Este PR no incluye migraciones de base de datos. Solo crea un componente nuevo y refactoriza el shell de Angular (zoneless signals).

## Skill `git-workflow` gates (verificados)

| Gate | Estado | Detalle |
|---|---|---|
| **RULE 1** — No push a `main`/`master` | ✅ | PR targeta `dev` (`baseRefName: "dev"`) |
| **RULE 2** — No AI co-authors | ✅ | Commit sin `Co-Authored-By` (verificado) |
| **RULE 3** — DB migration alerts | ⏭️ N/A | Sin migraciones |
| **RULE 4** — Conflict resolution | ⏭️ N/A | Branch fresh desde `origin/dev`, sin conflicts |

## Cambios

### Nuevo: `apps/frontend/src/app/private/modules/store/analytics/components/analytics-tab-bar/analytics-tab-bar.component.ts`
- Standalone, signals-based (`input.required<AnalyticsCategoryId>()` + `computed<AnalyticsTabView[]>`).
- Inline template + inline styles, single-file (mismo patrón que `scrollable-tabs.component.ts`).
- **Mobile** (`< 768px`): scroll horizontal con `mask-image` (gradient-fade en bordes), scroll-snap al inicio, scrollbar oculto.
- **Desktop** (`≥ 768px`): tabs centradas con `justify-content: center` + underline `::after` de 2px en `var(--color-primary)` para la activa.
- **Accesible**: `role="tablist"` + `aria-label` + `role="tab"` + `aria-current="page"` + `aria-selected`.
- Reusa `getViewsByCategory(categoryId)` del `analytics-registry.ts` (single source of truth).
- Reusa `app-icon` para los iconos de tabs.

### Refactor: `AnalyticsShellComponent`
- Quita el `tabs` computed y el import de `StickyHeaderTab` (movido al nuevo componente).
- Quita `[tabs]` y `tabsAriaLabel` del `app-sticky-header`.
- Añade `<app-analytics-tab-bar [categoryId]="categoryId() ?? 'overview'">` entre el sticky-header y el main content.
- **Fix**: `toSignal(route.data, { initialValue: route.snapshot.data })` en lugar de `toSignal(route.data.pipe(map(...))` sin `initialValue`. Esto alinea con el patrón canónico de `module-tabs-shell.component.ts` y elimina el flag del `zoneless-audit.sh`.
- `app-sticky-header` queda con título + acciones solo (tabs delegadas al nuevo componente).

## Criterios de aceptación cubiertos

| Criterio | Estado |
|---|---|
| Input: `categoryId: AnalyticsCategoryId` → lee tabs del registry | ✅ vía `computed(() => getViewsByCategory(this.categoryId()))` |
| Tabs activas con `routerLinkActive` | ✅ `routerLinkActive="active"` + `#rla="routerLinkActive"` |
| Mobile: barra scrollable horizontal | ✅ `overflow-x: auto` + `scroll-snap-type: x proximity` |
| Mobile: gradient-fade en bordes | ✅ `mask-image: linear-gradient(...)` (mobile only) |
| Desktop: tabs centradas | ✅ `justify-content: center` (≥ 768px) |
| Desktop: underline en activa | ✅ `::after` con `transform: scaleX(0 → 1)` animado |
| Accessible: `role="tablist"` + `aria-current="page"` | ✅ ambos presentes |
| Signals-based | ✅ `input()` + `computed()` + `toSignal(..., { initialValue })` |
| Archivo `analytics-tab-bar.component.ts` | ✅ nuevo |

## Skills aplicadas

- `vendix-frontend-component` — reutiliza `app-icon`, `app-sticky-header` (sin tabs), standalone.
- `vendix-zoneless-signals` — `input()`, `computed()`, `toSignal(..., { initialValue })`.
- `vendix-frontend-sticky-header` — el sticky-header provee título + acciones; el tab bar se separa sin romper el contrato.
- `vendix-ui-ux` — mobile-first, theme tokens, focus visible, `transform`/`opacity` para animaciones.

## Decisiones de diseño

- **Sticky del tab bar**: NO sticky (decidido con el equipo). El `app-sticky-header` ya ocupa `position: sticky; top: 0` con título + acciones; un segundo sticky solaparía.
- **Gradient-fade technique**: `mask-image` (moderno, performante) en lugar de pseudo-elementos.
- **No reuso de `app-scrollable-tabs`**: su contrato es route-agnostic (`tabChange` con string id), no tiene `role="tablist"`, y el caller tiene que hacer la navegación.

## Diff summary

```
apps/frontend/src/app/private/modules/store/analytics/components/analytics-tab-bar/analytics-tab-bar.component.ts | 173 +++++++++++++
apps/frontend/src/app/private/modules/store/analytics/components/analytics-shell/analytics-shell.component.ts   | 28 ++--
apps/frontend/src/app/private/modules/store/analytics/components/analytics-shell/analytics-shell.component.html | 4 +-
```

## Branch state

```
HEAD          → 5c50443e feat(analytics): extract AnalyticsTabBarComponent + refactor shell
origin/dev    → cc44afe0 chore(mobile): config cleanup for web + APK packaging (#320)
```
1 commit ahead de dev, sin divergence.

## Verificación local

- ✅ `npx tsc --noEmit -p tsconfig.app.json` → clean
- ✅ `npx ng build --configuration=development` → success

## Estimación

3h (alineado con el estimado original del issue). 1 componente nuevo (~173 líneas, single-file), refactor de ~25 líneas en 2 archivos del shell, sin migraciones, sin nuevas deps.