### PR TITLE
fix(pos): show variant-specific image in POS cart instead of product default

### DIFF
--- a/apps/frontend/src/app/private/modules/store/pos/cart/pos-cart.component.ts
+++ b/apps/frontend/src/app/private/modules/store/pos/cart/pos-cart.component.ts
@@ -371,15 +371,15 @@ import {
                 <div
                   class="row-span-1 w-10 h-10 shrink-0 bg-muted rounded-md overflow-hidden relative border border-border/50"
                 >
-                  @if (item.product.image_url || item.product.image) {
+                  @if (item.variant_image_url || item.product.image_url || item.product.image) {
                     <img
-                      [src]="item.product.image_url || item.product.image"
+                      [src]="item.variant_image_url || item.product.image_url || item.product.image"
                       [alt]="item.product.name"
                       class="absolute inset-0 w-full h-full object-cover"
                       (error)="handleImageError($event)"
                     />
                   }
-                  @if (!item.product.image_url && !item.product.image) {
+                  @if (!item.variant_image_url && !item.product.image_url && !item.product.image) {
                     <div
                       class="absolute inset-0 flex items-center justify-center text-text-secondary"
                     >

--- a/apps/frontend/src/app/private/modules/store/pos/components/pos-cart-modal.component.ts
+++ b/apps/frontend/src/app/private/modules/store/pos/components/pos-cart-modal.component.ts
@@ -100,14 +100,14 @@ import {
                   >
                   <!-- Product Image -->
                   <div class="item-image">
-                    @if (item.product.image_url || item.product.image) {
+                    @if (item.variant_image_url || item.product.image_url || item.product.image) {
                       <img
-                        [src]="item.product.image_url || item.product.image"
+                        [src]="item.variant_image_url || item.product.image_url || item.product.image"
                         [alt]="item.product.name"
                         (error)="handleImageError($event)"
                         />
                     }
-                    @if (!item.product.image_url && !item.product.image) {
+                    @if (!item.variant_image_url && !item.product.image_url && !item.product.image) {
                       <div
                         class="image-placeholder"
                         >

--- a/apps/frontend/src/app/private/modules/store/pos/models/cart.model.ts
+++ b/apps/frontend/src/app/private/modules/store/pos/models/cart.model.ts
@@ -24,6 +24,14 @@ export interface CartItem {
   variant_sku?: string;
   variant_attributes?: string;
   variant_display_name?: string;
+  /**
+   * Image URL of the selected variant, captured from `PosProductVariant.image_url`
+   * at add-to-cart time. Used by the POS cart templates as the primary image
+   * source before falling back to the parent product's image. Falls back to
+   * `product.image_url` when the variant has no own image (most seed variants
+   * have `image_id = null` in the DB).
+   */
+  variant_image_url?: string;
   // Weight product fields
   weight?: number;
   weight_unit?: 'kg' | 'g' | 'lb';

--- a/apps/frontend/src/app/private/modules/store/pos/services/pos-cart.service.ts
+++ b/apps/frontend/src/app/private/modules/store/pos/services/pos-cart.service.ts
@@ -950,6 +950,10 @@ export class PosCartService {
           ?.map(a => `${a.attribute_name}: ${a.attribute_value}`).join(', '),
         variant_display_name: request.variant?.attributes
           ?.map(a => a.attribute_value).join(' / '),
+        // Capture the variant's own image so the cart renders the right
+        // thumbnail for colored/sized variants. Falls back to the product
+        // image in the template when this is undefined.
+        variant_image_url: request.variant?.image_url,
         // Weight product fields
         weight: isWeightProduct ? weight : undefined,
         weight_unit: isWeightProduct ? (request.weight_unit || 'kg') : undefined,

--- a/apps/frontend/src/app/private/modules/store/weekly-report/components/weekly-report-stories/weekly-report-stories.component.ts
+++ b/apps/frontend/src/app/private/modules/store/weekly-report/components/weekly-report-stories/weekly-report-stories.component.ts
@@ -80,7 +80,7 @@ const TIER_LABEL: Record<WeeklyTier, string> = {
  *   9. Closing
  *
  * Al cerrar, emite `viewed` (el padre marca `viewed_at` en backend).
- * Implementado zoneless: usa signals + toSignal, sin NgZone/ZoneJS.
+ * Implementado zoneless: usa signals + toSignal, sin zone.js.
  */
 @Component({
   selector: 'app-weekly-report-stories',


### PR DESCRIPTION
## Summary

When a cashier picks a colored variant (e.g. AirPods 3 AZUL or ROJO) in the POS "Seleccionar variante" modal, the cart row kept showing the parent product's default image (black AirPods). Root cause: the cart item persisted `variant_id` / `variant_sku` / `variant_attributes` / `variant_display_name` but **dropped `variant.image_url`**. The templates then read only `item.product.image_url` and rendered the wrong image.

This PR captures the variant's own image at add-to-cart time and prefers it in the cart row, falling back to the product image for variants without one (the common case — most seed variants have `image_id = null` in the DB).

## Root cause

```ts
// apps/frontend/src/app/private/modules/store/pos/services/pos-cart.service.ts
// (before) — dropped the variant image
const newItem: CartItem = {
  variant_id: request.variant?.id,
  variant_sku: request.variant?.sku ?? undefined,
  variant_attributes: ...,
  variant_display_name: ...,
  // ❌ request.variant?.image_url  was never captured
};

// apps/frontend/src/app/private/modules/store/pos/cart/pos-cart.component.ts
// (before) — only read product image
@if (item.product.image_url || item.product.image) {
  <img [src]="item.product.image_url || item.product.image" ... />
}
```

The e-commerce cart backend already handles this server-side (`cart.service.ts:343` re-resolves the variant image and embeds it in `product.image_url`). The POS doesn't roundtrip to the backend on add — the variant image must be captured client-side.

## Changes

| File | Change |
|------|--------|
| `pos/models/cart.model.ts` | Added `variant_image_url?: string` to `CartItem` interface |
| `pos/services/pos-cart.service.ts` | Capture `request.variant?.image_url` in `processAddToCart` |
| `pos/cart/pos-cart.component.ts` | Cart row template prefers `variant_image_url \|\| product.image_url \|\| product.image` |
| `pos/components/pos-cart-modal.component.ts` | Same fallback chain for mobile/tablet cart modal |
| `weekly-report/components/weekly-report-stories/weekly-report-stories.component.ts` | Drop "NgZone" literal from a JSDoc comment to clear the CI Zoneless Audit false positive (pre-existing on `origin/dev` from PR #349; identical to the fix in PR #351 `cc8055aa`) |

## Commits

```
3a82468d chore(weekly-report): drop 'NgZone' literal from comment to clear CI audit false positive
b24eda2c fix(pos): show variant-specific image in POS cart instead of product default
```

## No DB migrations

Pure frontend change. The Prisma schema already has `product_variants.image_id` (nullable 1:1 FK to `product_images`) and the POS variant selector already receives `variant.image_url` from the backend — it just wasn't being persisted into the cart item.

## Out of scope

- **E-commerce cart:** already works (backend resolves it).
- **POP cart modal** (`pop-cart-modal.component.ts`): same pattern but the user didn't report it. Can be a follow-up if confirmed broken.
- **Adding UI to upload variant images** during product creation: the schema and admin form already support it (`variant_image_url` in `CreateProductVariantDto`); most variants just don't have one assigned.

## Verification

- ✅ `bash scripts/zoneless-audit.sh` → 0 errors, 2 warnings (allowed).
- ✅ Manually tested in dev: variant image renders correctly for variants with `image_id`; falls back to product image for variants without one (no regression).

## Rollback

`git revert b24eda2c 3a82468d && git push origin fix/pos-cart-variant-image`