### PR TITLE
feat(analytics): date-range filter now exposes Desde + Hasta so reports accept a true range

### DIFF
--- a/apps/frontend/src/app/private/modules/store/analytics/components/date-range-filter/date-range-filter.component.ts
+++ b/apps/frontend/src/app/private/modules/store/analytics/components/date-range-filter/date-range-filter.component.ts
@@ -37,13 +37,27 @@ type DatePreset =
         ></app-selector>
       </div>
 
-      <!-- Date Input -->
+      <!-- Start date -->
       <div class="w-full sm:w-40 flex-shrink-0">
         <app-input
           type="date"
           size="sm"
-          [ngModel]="selectedDate()"
-          (ngModelChange)="onDateChange($event)"
+          [label]="'Desde'"
+          [ngModel]="startDate()"
+          (ngModelChange)="onStartDateChange($event)"
+          [max]="endDate() || undefined"
+        ></app-input>
+      </div>
+
+      <!-- End date -->
+      <div class="w-full sm:w-40 flex-shrink-0">
+        <app-input
+          type="date"
+          size="sm"
+          [label]="'Hasta'"
+          [ngModel]="endDate()"
+          (ngModelChange)="onEndDateChange($event)"
+          [min]="startDate() || undefined"
         ></app-input>
       </div>
     </div>
@@ -56,7 +70,8 @@ export class DateRangeFilterComponent {
   valueChange = output<DateRangeFilter>();
 
   selectedPreset = signal<DatePreset>('thisMonth');
-  selectedDate = signal<string>('');
+  startDate = signal<string>('');
+  endDate = signal<string>('');
 
   presetOptions: SelectorOption[] = [
     { value: 'today', label: 'Hoy' },
@@ -77,7 +92,10 @@ export class DateRangeFilterComponent {
         this.selectedPreset.set(v.preset as DatePreset);
       }
       if (v?.start_date) {
-        this.selectedDate.set(v.start_date);
+        this.startDate.set(v.start_date);
+      }
+      if (v?.end_date) {
+        this.endDate.set(v.end_date);
       }
     });
   }
@@ -86,18 +104,34 @@ export class DateRangeFilterComponent {
     this.selectedPreset.set(preset as DatePreset);
     const range = this.getDateRange(preset as DatePreset);
     if (range) {
-      this.selectedDate.set(range.start_date);
+      this.startDate.set(range.start_date);
+      this.endDate.set(range.end_date);
       this.dateRangeSync.setDateRange(range);
       this.valueChange.emit(range);
     }
   }
 
-  onDateChange(date: string): void {
-    this.selectedDate.set(date);
+  onStartDateChange(date: string): void {
+    this.startDate.set(date);
+    // Clamp end_date if it is now before start_date.
+    const end = this.endDate();
+    const clampedEnd = end && end < date ? date : end;
+    if (clampedEnd !== end) {
+      this.endDate.set(clampedEnd!);
+    }
+    this.emitRange('custom');
+  }
+
+  onEndDateChange(date: string): void {
+    this.endDate.set(date);
+    this.emitRange('custom');
+  }
+
+  private emitRange(preset: DateRangeFilter['preset']): void {
     const range: DateRangeFilter = {
-      start_date: date,
-      end_date: date,
-      preset: this.selectedPreset(),
+      start_date: this.startDate(),
+      end_date: this.endDate(),
+      preset,
     };
     this.dateRangeSync.setDateRange(range);
     this.valueChange.emit(range);


### PR DESCRIPTION
## Summary

El módulo de reportes solo dejaba escoger **una fecha** cuando el usuario necesita un **rango** (ejemplo: del 1 al 10 de junio). El componente `vendix-date-range-filter` (que se usa en 26 lugares entre reports y analytics) renderizaba un solo `<input type="date">` y colapsaba `end_date = start_date` automáticamente.

El fix es de **un solo archivo** porque el resto del pipeline (NgRx state, HTTP service, backend DTO) ya soportaba rangos — solo el control UI estaba desfasado.

## Causa raíz

El archivo `apps/frontend/src/app/private/modules/store/analytics/components/date-range-filter/date-range-filter.component.ts` exponía:

- Un selector de presets (Hoy, Esta Semana, Este Mes, etc.) → esos SÍ calculaban `start_date` y `end_date` correctamente.
- Un único `<input type="date">` mapeado a `selectedDate` → al cambiar, el handler `onDateChange` colapsaba `end_date = start_date`.

Resultado: el usuario solo podía elegir un día, no un rango.

## Solución

Agregar un segundo input (`Hasta`) al template del componente existente, con cross-validation `min`/`max`. Reemplazar el signal único `selectedDate` por dos signals (`startDate` + `endDate`). Cuando el usuario cambia `Desde` y deja `Hasta` por debajo, se clampa automáticamente. Los presets siguen emitiendo ambos extremos.

## Archivos modificados (1)

`apps/frontend/src/app/private/modules/store/analytics/components/date-range-filter/date-range-filter.component.ts`
- Template: segundo `<app-input type="date">` con `label="Hasta"` y `[min]="startDate()"`
- TS: `selectedDate` → `startDate` + `endDate`, nuevo `onEndDateChange()`, clamp en `onStartDateChange()`
- `emitRange()` privado para evitar duplicación

## Commits

```
56d78737 feat(analytics): add end-date input to date-range-filter so reports accept a true range
```

## Verificación

- ✅ `npx tsc --noEmit -p tsconfig.json` → 0 errores
- ✅ Manual: en `/admin/reports/sales/by-product` ahora hay dos inputs "Desde" y "Hasta". Se puede elegir 1 al 10 de junio y el reporte refleja datos entre esas fechas.
- ✅ Los presets (Hoy, Esta Semana, Este Mes, etc.) siguen funcionando y siguen emitiendo ambos extremos.
- ✅ Cross-validation: si pones `Desde = 15/06`, el input `Hasta` no acepta fechas < 15/06.

## Por qué UN solo archivo en vez de 26

Originalmente el plan era reemplazar `vendix-date-range-filter` por `app-date-range-picker` (shared) en los 26 archivos. Esto requería:
- Cambiar 26 templates
- Cambiar 26 imports
- Crear un mapper `DateRange { from, to }` ↔ `DateRangeFilter { start_date, end_date, preset }` en cada consumer

**Alternativa más simple que el plan adoptó:** extender el componente existente con un segundo input. **Misma funcionalidad, 1 archivo, 45 líneas añadidas**. Todos los 26 consumers ganan el rango automáticamente porque comparten la misma interface `DateRangeFilter` (que ya tenía `start_date` y `end_date`).

## Riesgo y comportamiento

- **Cambio 100% aditivo** en UI (1 input extra, signals nuevos).
- **No cambia** el shape de `DateRangeFilter` ni el output del componente.
- **No afecta** NgRx state, HTTP service, backend.
- **No migración de BD.**

## Rollback

```bash
git revert 56d78737 && git push origin feature/reports-analytics-date-range
```

1 commit revertido → comportamiento anterior restaurado.

## Out of scope

- Migrar `app-date-range-picker` (shared) a ser el picker estándar en lugar de `vendix-date-range-filter` — eso requeriría tocar los 26 archivos y homogenizar UX (preset chips vs rango puro). PR separado si se quiere.
- Tests E2E automatizados del flujo de rango — se puede agregar después.