### PR TITLE
fix(frontend): resolver errores que rompían el build de producción

### DIFF
--- a/apps/frontend/src/app/private/modules/store/orders/components/generate-dispatch-wizard/generate-dispatch-wizard.component.ts
+++ b/apps/frontend/src/app/private/modules/store/orders/components/generate-dispatch-wizard/generate-dispatch-wizard.component.ts
@@ -17,6 +17,8 @@ import {
   ButtonComponent,
   IconComponent,
   SelectorComponent,
+  StepsLineComponent,
+  StepsLineItem,
   ToastService,
 } from '../../../../../../shared/components';
 import { StoreUserSelectComponent } from '../../../../../../shared/components/store-user-select/store-user-select.component';

--- a/apps/frontend/src/app/private/modules/store/reservations/components/reservation-form-modal/reservation-form-modal.component.ts
+++ b/apps/frontend/src/app/private/modules/store/reservations/components/reservation-form-modal/reservation-form-modal.component.ts
@@ -18,7 +18,7 @@ import { ReservationsService } from '../../services/reservations.service';
 import { AvailabilitySlot, Booking, CreateBookingDto } from '../../interfaces/reservation.interface';
 import { CalendarWeekViewComponent, FreeSlot } from '../calendar/calendar-week-view/calendar-week-view.component';
 import { environment } from '../../../../../../../environments/environment';
-import { debounceTime, Subject, switchMap, of, forkJoin } from 'rxjs';
+import { debounceTime, Subject, switchMap, of, forkJoin, finalize } from 'rxjs';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({


### PR DESCRIPTION
## Resumen
El build de producción (`npm run build:prod`) fallaba con 2 errores de compilación en código ya mergeado a `dev`. Este PR los corrige (solo imports faltantes) y deja el build en verde, desbloqueando el release PR #358.

## Errores corregidos
1. **`generate-dispatch-wizard.component.ts`** — `NG1010` + `TS2304`: usaba `StepsLineComponent` (en `imports`) y `StepsLineItem` (tipo) sin importarlos. Se agregan al barrel `shared/components`.
2. **`reservation-form-modal.component.ts`** — `TS2304`/`TS2769`/`TS7006`: faltaba `finalize` en el import de `rxjs`. Su ausencia degradaba el `.pipe(...)` a `Observable<unknown>`, lo que cascadeaba en el error del `subscribe` y el `implicit any`. Un solo import resuelve los tres.

## Por qué pasó el watch de dev pero no prod
El AOT de producción valida que cada símbolo en `imports: []` exista y sea estático, y aplica typecheck estricto de plantillas/operadores; el watch de desarrollo es más laxo. Por eso solo el `build:prod` (CI) lo detectó.

## Verificación
- `npm run build:prod` → **exit 0** (Application bundle generation OK). Solo quedan warnings preexistentes (NG8107 `?.` removibles, imports sin usar, presupuesto de bundle), ninguno bloquea.