### PR TITLE
hotfix(frontend): arreglar build de producción roto en main

### DIFF
--- a/apps/frontend/src/app/private/modules/store/orders/components/generate-dispatch-wizard/generate-dispatch-wizard.component.ts
+++ b/apps/frontend/src/app/private/modules/store/orders/components/generate-dispatch-wizard/generate-dispatch-wizard.component.ts
@@ -17,6 +17,8 @@ import {
   ButtonComponent,
   IconComponent,
   SelectorComponent,
+  StepsLineComponent,
+  StepsLineItem,
   ToastService,
 } from '../../../../../../shared/components';
 import { StoreUserSelectComponent } from '../../../../../../shared/components/store-user-select/store-user-select.component';

--- a/apps/frontend/src/app/private/modules/store/reservations/components/reservation-form-modal/reservation-form-modal.component.ts
+++ b/apps/frontend/src/app/private/modules/store/reservations/components/reservation-form-modal/reservation-form-modal.component.ts
@@ -18,7 +18,7 @@ import { ReservationsService } from '../../services/reservations.service';
 import { AvailabilitySlot, Booking, CreateBookingDto } from '../../interfaces/reservation.interface';
 import { CalendarWeekViewComponent, FreeSlot } from '../calendar/calendar-week-view/calendar-week-view.component';
 import { environment } from '../../../../../../../environments/environment';
-import { debounceTime, Subject, switchMap, of, forkJoin } from 'rxjs';
+import { debounceTime, Subject, switchMap, of, forkJoin, finalize } from 'rxjs';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({


### PR DESCRIPTION
## Contexto
El build de producción del frontend (`ng build --configuration production`) está **roto en `main`**: dos componentes ya presentes en `main` usan símbolos sin importar.

Este hotfix aplica la corrección de forma aislada (cherry-pick de `af2fb1c5`, mergeado a `dev` vía #359) para devolver el build de `main` a verde sin esperar el release completo (#358 también lo incluye).

## Errores corregidos
1. **`generate-dispatch-wizard.component.ts`** — `NG1010` + `TS2304`: usaba `StepsLineComponent` (en `imports`) y el tipo `StepsLineItem` sin importarlos. Se agregan al barrel `shared/components`.
2. **`reservation-form-modal.component.ts`** — `TS2304`/`TS2769`/`TS7006`: faltaba `finalize` en el import de `rxjs`. Su ausencia degradaba el `.pipe(...)` a `Observable<unknown>`, cascadeando al error del `subscribe` y al `implicit any`. Un solo import resuelve los tres.

## Diff
3 líneas (solo imports):
```
generate-dispatch-wizard.component.ts | 2 ++
reservation-form-modal.component.ts   | 2 +-
```

## Verificación
- Fix idéntico al verificado en `dev` (`npm run build:prod` → exit 0).
- Verificación de `build:prod` sobre esta rama (`main` + fix) en curso; se confirma en el hilo.

## Relación
- Mismo fix que #359 (a `dev`) y ya contenido en el release #358 (`dev`→`main`). Si se mergea #358 primero, este hotfix queda redundante (se puede cerrar).