### PR TITLE
fix(analytics,reports): align export button with date inputs

### DIFF
--- a/apps/frontend/src/app/private/modules/store/analytics/components/date-range-filter/date-range-filter.component.ts
+++ b/apps/frontend/src/app/private/modules/store/analytics/components/date-range-filter/date-range-filter.component.ts
@@ -33,7 +33,8 @@ type DatePreset =
           [ngModel]="selectedPreset()"
           (ngModelChange)="onPresetChange($event)"
           size="sm"
-          placeholder="Período"
+          label="Período"
+          placeholder="Selecciona un período"
         ></app-selector>
       </div>
 

--- a/apps/frontend/src/app/private/modules/store/analytics/pages/customers/abandoned-carts.component.html
+++ b/apps/frontend/src/app/private/modules/store/analytics/pages/customers/abandoned-carts.component.html
@@ -69,7 +69,7 @@
       </div>
     </div>
 
-    <div class="flex items-center gap-2 md:gap-3 shrink-0">
+    <div class="flex items-end gap-2 md:gap-3 shrink-0">
       <vendix-date-range-filter
         [value]="dateRange()"
         (valueChange)="onDateRangeChange($event)"

--- a/apps/frontend/src/app/private/modules/store/analytics/pages/customers/customer-acquisition.component.html
+++ b/apps/frontend/src/app/private/modules/store/analytics/pages/customers/customer-acquisition.component.html
@@ -69,7 +69,7 @@
       </div>
     </div>
 
-    <div class="flex items-center gap-2 md:gap-3 shrink-0">
+    <div class="flex items-end gap-2 md:gap-3 shrink-0">
       <vendix-date-range-filter
         [value]="dateRange()"
         (valueChange)="onDateRangeChange($event)"

--- a/apps/frontend/src/app/private/modules/store/analytics/pages/customers/customer-summary.component.html
+++ b/apps/frontend/src/app/private/modules/store/analytics/pages/customers/customer-summary.component.html
@@ -77,7 +77,7 @@
       </div>
     </div>
 
-    <div class="flex items-center gap-2 md:gap-3 flex-shrink-0">
+    <div class="flex items-end gap-2 md:gap-3 flex-shrink-0">
       <vendix-date-range-filter
         [value]="dateRange()"
         (valueChange)="onDateRangeChange($event)"

--- a/apps/frontend/src/app/private/modules/store/analytics/pages/financial/profit-loss.component.ts
+++ b/apps/frontend/src/app/private/modules/store/analytics/pages/financial/profit-loss.component.ts
@@ -103,7 +103,7 @@ import { queryParamsToDateRange } from '../../../shared/utils/date-range-params.
           </div>
         </div>
 
-        <div class="flex items-center gap-2 md:gap-3 flex-shrink-0">
+        <div class="flex items-end gap-2 md:gap-3 flex-shrink-0">
           <vendix-date-range-filter
             [value]="dateRange()"
             (valueChange)="onDateRangeChange($event)"

--- a/apps/frontend/src/app/private/modules/store/analytics/pages/financial/refunds-summary.component.ts
+++ b/apps/frontend/src/app/private/modules/store/analytics/pages/financial/refunds-summary.component.ts
@@ -99,7 +99,7 @@ import { queryParamsToDateRange } from '../../../shared/utils/date-range-params.
           </div>
         </div>
 
-        <div class="flex items-center gap-2 md:gap-3 shrink-0">
+        <div class="flex items-end gap-2 md:gap-3 shrink-0">
           <vendix-date-range-filter
             [value]="dateRange()"
             (valueChange)="onDateRangeChange($event)"

--- a/apps/frontend/src/app/private/modules/store/analytics/pages/financial/tax-summary.component.ts
+++ b/apps/frontend/src/app/private/modules/store/analytics/pages/financial/tax-summary.component.ts
@@ -104,7 +104,7 @@ import { queryParamsToDateRange } from '../../../shared/utils/date-range-params.
           </div>
         </div>
 
-        <div class="flex items-center gap-2 md:gap-3 flex-shrink-0">
+        <div class="flex items-end gap-2 md:gap-3 flex-shrink-0">
           <vendix-date-range-filter
             [value]="dateRange()"
             (valueChange)="onDateRangeChange($event)"

--- a/apps/frontend/src/app/private/modules/store/analytics/pages/inventory/inventory-valuation.component.ts
+++ b/apps/frontend/src/app/private/modules/store/analytics/pages/inventory/inventory-valuation.component.ts
@@ -92,7 +92,7 @@ import { AnalyticsCardComponent } from '../../components/analytics-card/analytic
             </p>
           </div>
         </div>
-        <div class="flex items-center gap-2 md:gap-3 shrink-0">
+        <div class="flex items-end gap-2 md:gap-3 shrink-0">
           <vendix-date-range-filter
             [value]="dateRange()"
             (valueChange)="onDateRangeChange($event)"

--- a/apps/frontend/src/app/private/modules/store/analytics/pages/inventory/low-stock.component.ts
+++ b/apps/frontend/src/app/private/modules/store/analytics/pages/inventory/low-stock.component.ts
@@ -94,7 +94,7 @@ import { AnalyticsCardComponent } from '../../components/analytics-card/analytic
           </div>
         </div>
 
-        <div class="flex items-center gap-2 md:gap-3 shrink-0">
+        <div class="flex items-end gap-2 md:gap-3 shrink-0">
           <vendix-date-range-filter
             [value]="dateRange()"
             (valueChange)="onDateRangeChange($event)"

--- a/apps/frontend/src/app/private/modules/store/analytics/pages/inventory/movement-analysis.component.ts
+++ b/apps/frontend/src/app/private/modules/store/analytics/pages/inventory/movement-analysis.component.ts
@@ -97,7 +97,7 @@ import { queryParamsToDateRange } from '../../../shared/utils/date-range-params.
           </div>
         </div>
 
-        <div class="flex items-center gap-2 md:gap-3 shrink-0">
+        <div class="flex items-end gap-2 md:gap-3 shrink-0">
           <vendix-date-range-filter
             [value]="dateRange()"
             (valueChange)="onDateRangeChange($event)"

--- a/apps/frontend/src/app/private/modules/store/analytics/pages/inventory/overview/inventory-overview.component.html
+++ b/apps/frontend/src/app/private/modules/store/analytics/pages/inventory/overview/inventory-overview.component.html
@@ -69,7 +69,7 @@
       </div>
     </div>
 
-    <div class="flex items-center gap-2 md:gap-3 shrink-0">
+    <div class="flex items-end gap-2 md:gap-3 shrink-0">
       <vendix-date-range-filter
         [value]="dateRange()"
         (valueChange)="onDateRangeChange($event)"

--- a/apps/frontend/src/app/private/modules/store/analytics/pages/inventory/stock-movements.component.ts
+++ b/apps/frontend/src/app/private/modules/store/analytics/pages/inventory/stock-movements.component.ts
@@ -92,7 +92,7 @@ imports: [
           </div>
         </div>
 
-        <div class="flex items-center gap-2 md:gap-3 shrink-0">
+        <div class="flex items-end gap-2 md:gap-3 shrink-0">
           <vendix-date-range-filter
             [value]="dateRange()"
             (valueChange)="onDateRangeChange($event)"

--- a/apps/frontend/src/app/private/modules/store/analytics/pages/overview/overview-summary/overview-summary.component.html
+++ b/apps/frontend/src/app/private/modules/store/analytics/pages/overview/overview-summary/overview-summary.component.html
@@ -80,7 +80,7 @@
       </div>
     </div>
 
-    <div class="flex items-center gap-2 md:gap-3 shrink-0">
+    <div class="flex items-end gap-2 md:gap-3 shrink-0">
       <vendix-date-range-filter
         [value]="dateRange()"
         (valueChange)="onDateRangeChange($event)"

--- a/apps/frontend/src/app/private/modules/store/analytics/pages/products/product-performance.component.html
+++ b/apps/frontend/src/app/private/modules/store/analytics/pages/products/product-performance.component.html
@@ -71,7 +71,7 @@
       </div>
     </div>
 
-    <div class="flex items-center gap-2 md:gap-3 shrink-0">
+    <div class="flex items-end gap-2 md:gap-3 shrink-0">
       <vendix-date-range-filter
         [value]="dateRange()"
         (valueChange)="onDateRangeChange($event)"

--- a/apps/frontend/src/app/private/modules/store/analytics/pages/products/product-profitability.component.html
+++ b/apps/frontend/src/app/private/modules/store/analytics/pages/products/product-profitability.component.html
@@ -64,7 +64,7 @@
       </div>
     </div>
 
-    <div class="flex items-center gap-2 md:gap-3 shrink-0">
+    <div class="flex items-end gap-2 md:gap-3 shrink-0">
       <vendix-date-range-filter
         [value]="dateRange()"
         (valueChange)="onDateRangeChange($event)"

--- a/apps/frontend/src/app/private/modules/store/analytics/pages/products/top-sellers.component.html
+++ b/apps/frontend/src/app/private/modules/store/analytics/pages/products/top-sellers.component.html
@@ -52,7 +52,7 @@
       </div>
     </div>
 
-    <div class="flex items-center gap-2 md:gap-3 shrink-0">
+    <div class="flex items-end gap-2 md:gap-3 shrink-0">
       <vendix-date-range-filter
           [value]="dateRange()"
           (valueChange)="onDateRangeChange($event)"

--- a/apps/frontend/src/app/private/modules/store/analytics/pages/purchases/purchase-summary.component.ts
+++ b/apps/frontend/src/app/private/modules/store/analytics/pages/purchases/purchase-summary.component.ts
@@ -104,7 +104,7 @@ import { queryParamsToDateRange } from '../../../shared/utils/date-range-params.
           </div>
         </div>
 
-        <div class="flex items-center gap-2 md:gap-3 flex-shrink-0">
+        <div class="flex items-end gap-2 md:gap-3 flex-shrink-0">
           <vendix-date-range-filter
             [value]="dateRange()"
             (valueChange)="onDateRangeChange($event)"

--- a/apps/frontend/src/app/private/modules/store/analytics/pages/purchases/purchases-by-supplier.component.ts
+++ b/apps/frontend/src/app/private/modules/store/analytics/pages/purchases/purchases-by-supplier.component.ts
@@ -71,7 +71,7 @@ import { ExportButtonComponent } from '../../components/export-button/export-but
           </div>
         </div>
 
-        <div class="flex items-center gap-2 md:gap-3 shrink-0">
+        <div class="flex items-end gap-2 md:gap-3 shrink-0">
           <vendix-date-range-filter
             [value]="dateRange()"
             (valueChange)="onDateRangeChange($event)"

--- a/apps/frontend/src/app/private/modules/store/analytics/pages/reviews/review-summary.component.ts
+++ b/apps/frontend/src/app/private/modules/store/analytics/pages/reviews/review-summary.component.ts
@@ -101,7 +101,7 @@ import { queryParamsToDateRange } from '../../../shared/utils/date-range-params.
           </div>
         </div>
 
-        <div class="flex items-center gap-2 md:gap-3 flex-shrink-0">
+        <div class="flex items-end gap-2 md:gap-3 flex-shrink-0">
           <vendix-date-range-filter
             [value]="dateRange()"
             (valueChange)="onDateRangeChange($event)"

--- a/apps/frontend/src/app/private/modules/store/analytics/pages/sales/sales-by-category.component.ts
+++ b/apps/frontend/src/app/private/modules/store/analytics/pages/sales/sales-by-category.component.ts
@@ -99,7 +99,7 @@ import { AnalyticsCardComponent } from '../../components/analytics-card/analytic
             </p>
           </div>
         </div>
-        <div class="flex items-center gap-2 md:gap-3 shrink-0">
+        <div class="flex items-end gap-2 md:gap-3 shrink-0">
           <vendix-date-range-filter
             [value]="dateRange()"
             (valueChange)="onDateRangeChange($event)"

--- a/apps/frontend/src/app/private/modules/store/analytics/pages/sales/sales-by-customer.component.ts
+++ b/apps/frontend/src/app/private/modules/store/analytics/pages/sales/sales-by-customer.component.ts
@@ -92,7 +92,7 @@ import { AnalyticsCardComponent } from '../../components/analytics-card/analytic
             </p>
           </div>
         </div>
-        <div class="flex items-center gap-2 md:gap-3 shrink-0">
+        <div class="flex items-end gap-2 md:gap-3 shrink-0">
           <vendix-date-range-filter
             [value]="dateRange()"
             (valueChange)="onDateRangeChange($event)"

--- a/apps/frontend/src/app/private/modules/store/analytics/pages/sales/sales-by-payment.component.ts
+++ b/apps/frontend/src/app/private/modules/store/analytics/pages/sales/sales-by-payment.component.ts
@@ -98,7 +98,7 @@ import { AnalyticsCardComponent } from '../../components/analytics-card/analytic
             </p>
           </div>
         </div>
-        <div class="flex items-center gap-2 md:gap-3 shrink-0">
+        <div class="flex items-end gap-2 md:gap-3 shrink-0">
           <vendix-date-range-filter
             [value]="dateRange()"
             (valueChange)="onDateRangeChange($event)"

--- a/apps/frontend/src/app/private/modules/store/analytics/pages/sales/sales-by-product.component.ts
+++ b/apps/frontend/src/app/private/modules/store/analytics/pages/sales/sales-by-product.component.ts
@@ -92,7 +92,7 @@ import { AnalyticsCardComponent } from '../../components/analytics-card/analytic
             </p>
           </div>
         </div>
-        <div class="flex items-center gap-2 md:gap-3 shrink-0">
+        <div class="flex items-end gap-2 md:gap-3 shrink-0">
           <vendix-date-range-filter
             [value]="dateRange()"
             (valueChange)="onDateRangeChange($event)"

--- a/apps/frontend/src/app/private/modules/store/analytics/pages/sales/sales-summary/sales-summary.component.html
+++ b/apps/frontend/src/app/private/modules/store/analytics/pages/sales/sales-summary/sales-summary.component.html
@@ -69,7 +69,7 @@
       </div>
     </div>
 
-    <div class="flex items-center gap-2 md:gap-3 shrink-0">
+    <div class="flex items-end gap-2 md:gap-3 shrink-0">
       <vendix-date-range-filter
         [value]="dateRange()"
         (valueChange)="onDateRangeChange($event)"

--- a/apps/frontend/src/app/private/modules/store/analytics/pages/sales/sales-trends.component.ts
+++ b/apps/frontend/src/app/private/modules/store/analytics/pages/sales/sales-trends.component.ts
@@ -104,7 +104,7 @@ import { AnalyticsCardComponent } from '../../components/analytics-card/analytic
             </p>
           </div>
         </div>
-        <div class="flex items-center gap-2 md:gap-3 shrink-0">
+        <div class="flex items-end gap-2 md:gap-3 shrink-0">
           <vendix-date-range-filter
             [value]="dateRange()"
             (valueChange)="onDateRangeChange($event)"

--- a/apps/frontend/src/app/private/modules/store/reports/components/report-viewer/report-viewer.component.ts
+++ b/apps/frontend/src/app/private/modules/store/reports/components/report-viewer/report-viewer.component.ts
@@ -98,7 +98,7 @@ function formatStatValue(value: any, type: string): string | number {
               }
             </p>
           </div>
-          <div class="flex flex-col sm:flex-row items-stretch sm:items-center gap-3 w-full sm:w-auto">
+          <div class="flex flex-col sm:flex-row items-stretch sm:items-end gap-3 w-full sm:w-auto">
             @if (report()?.requiresDateRange) {
               <vendix-date-range-filter [value]="dateRange()" (valueChange)="dateRangeChange.emit($event)" />
             }

--- a/apps/frontend/src/app/private/modules/store/reports/pages/report-detail/report-detail.component.scss
+++ b/apps/frontend/src/app/private/modules/store/reports/pages/report-detail/report-detail.component.scss
@@ -38,7 +38,7 @@
 .config-toolbar {
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
+  align-items: end;
   gap: 0.5rem;
   padding: 0.5rem 0.75rem;
   background: var(--color-surface);
@@ -58,7 +58,7 @@
 
     @media (min-width: 768px) {
       flex-direction: row !important;
-      align-items: center;
+      align-items: end;
     }
   }
 }


### PR DESCRIPTION
## Summary

Aligns the **Export button** with the **date inputs** baseline in all analytics and reports filter bars.

Previously, the Export button floated at the top of the row while the date inputs sat at the bottom because:
1. `app-input` and `app-selector` with `styleVariant='modern'` render their label block above the control, but the preset selector had no label and was ~20px shorter than the labeled inputs.
2. `items-center` on a flex row aligns the centers of children of different heights, not their tops or bottoms, leaving the unlabelled button visually offset.

## Changes

**Component (1 file)**
- `date-range-filter.component.ts` — add `label='Período'` to the preset `<app-selector>` so all three children share the same height.

**Analytics pages — 25 `items-center` → `items-end`**
- customers: abandoned-carts, customer-acquisition, customer-summary
- financial: profit-loss, refunds-summary, tax-summary
- inventory: overview, inventory-valuation, low-stock, movement-analysis, stock-movements
- overview: overview-summary
- products: product-performance, top-sellers, product-profitability
- purchases: purchases-by-supplier, purchase-summary
- reviews: review-summary
- sales: sales-by-category, sales-by-customer, sales-by-payment, sales-by-product, sales-summary, sales-trends

**Reports — 3 places**
- `report-viewer.component.ts` — `sm:items-center` → `sm:items-end`
- `report-detail.component.scss` — `align-items: center` → `align-items: end` on `.config-toolbar` and on the `::ng-deep` date-range-filter override

## Visual result

```
PERÍODO          DESDE          HASTA
[Este Mes ▾]    [01/06/2026 📅]  [22/06/2026 📅]   [ ⬇ Exportar ]
                ←———— shared baseline ————→
```

## Verification

- ✅ All 27 filter bars in analytics + reports updated
- ✅ 0 remaining `items-center` containers around `<vendix-date-range-filter>`
- ✅ Frontend build clean (HMR reload succeeded)
- ✅ Branch rebased onto latest `origin/dev` (`af2fb1c5`)

## Files

27 files changed, 29 insertions(+), 28 deletions(-)