### PR TITLE
fix(ecommerce): show all payment methods for any delivery shipping type

### DIFF
--- a/apps/backend/src/domains/ecommerce/checkout/checkout.service.ts
+++ b/apps/backend/src/domains/ecommerce/checkout/checkout.service.ts
@@ -100,8 +100,13 @@ export class CheckoutService {
 
   async getPaymentMethods(shippingMethodType?: string) {
     // Determine allowed processing modes based on shipping method type
-    // - pickup: DIRECT (cash at store) + ONLINE (online payments)
-    // - delivery/carrier/own_fleet: ONLINE + ON_DELIVERY (pay on delivery)
+    // - pickup: DIRECT (cash at store) + ONLINE (online payments). No
+    //   ON_DELIVERY because the customer is already at the store.
+    // - delivery methods (own_fleet, carrier, custom, third_party_provider):
+    //   ALL enabled modes. Cash (DIRECT) and prepaid wallet (DIRECT) are still
+    //   valid for any delivery type — the wallet balance is prepaid online
+    //   and the customer can choose how to settle at confirmation.
+    // - no shipping_type: ALL modes (initial load before shipping is selected).
     let allowedModes: payment_processing_mode_enum[];
 
     if (shippingMethodType === 'pickup') {
@@ -110,13 +115,14 @@ export class CheckoutService {
         payment_processing_mode_enum.ONLINE,
       ];
     } else if (shippingMethodType) {
-      // For delivery methods (own_fleet, carrier, custom, third_party_provider)
+      // Delivery methods: show all configured payment methods.
       allowedModes = [
+        payment_processing_mode_enum.DIRECT,
         payment_processing_mode_enum.ONLINE,
         payment_processing_mode_enum.ON_DELIVERY,
       ];
     } else {
-      // No shipping type specified - return all methods (backwards compatibility)
+      // No shipping type specified - return all methods (initial load).
       allowedModes = [
         payment_processing_mode_enum.DIRECT,
         payment_processing_mode_enum.ONLINE,

--- a/skills/vendix-ecommerce-checkout/SKILL.md
+++ b/skills/vendix-ecommerce-checkout/SKILL.md
@@ -69,11 +69,13 @@ Current flow:
 
 `GET /ecommerce/checkout/payment-methods` filters enabled store payment methods by `system_payment_method.processing_mode` and shipping type:
 
-- `pickup`: `DIRECT`, `ONLINE`.
-- Delivery/other shipping types: `ONLINE`, `ON_DELIVERY`.
-- No shipping type: all supported modes.
+- `pickup`: `DIRECT` (cash/wallet at the store) + `ONLINE`. `ON_DELIVERY` is excluded because the customer is already at the store.
+- Delivery methods (`own_fleet`, `carrier`, `custom`, `third_party_provider`): **all enabled modes** — `DIRECT` + `ONLINE` + `ON_DELIVERY`. The customer can pay with cash, prepaid wallet, online gateway, or on delivery regardless of who delivers.
+- No shipping type: all supported modes (initial load before shipping is selected).
 
-Frontend reloads payment methods after shipping selection because shipping method type changes eligible payment methods.
+Frontend reloads payment methods after shipping selection so the UI reflects the current context.
+
+**Why all modes for delivery:** A delivery destination does not preclude paying with wallet balance (already prepaid) or with cash on arrival. Showing all configured methods gives the customer the full set of options their store enabled, which matches the expected UX.
 
 ## Wompi Flow
 


### PR DESCRIPTION
## Summary

When a customer buys a product with **local delivery** in Riohacha
(`own_fleet` shipping), only **2 payment methods** appear in the
checkout: "Vouchers de Pago" and "Pago Contra Entrega". When the
customer selects a **different location** (no shipping available),
**all 4 methods** appear: Efectivo, Vouchers, Contra Entrega,
Saldo Wallet.

The root cause is in `CheckoutService.getPaymentMethods()` (backend):
for any delivery shipping type it filters out `DIRECT` payment modes,
which excludes cash (Efectivo) and wallet (Saldo).

## Fix

Backend service in
`apps/backend/src/domains/ecommerce/checkout/checkout.service.ts`:

```diff
 } else if (shippingMethodType) {
-  // For delivery methods (own_fleet, carrier, custom, third_party_provider)
-  allowedModes = [
-    payment_processing_mode_enum.ONLINE,
-    payment_processing_mode_enum.ON_DELIVERY,
-  ];
+  // Delivery methods: show all configured payment methods.
+  allowedModes = [
+    payment_processing_mode_enum.DIRECT,
+    payment_processing_mode_enum.ONLINE,
+    payment_processing_mode_enum.ON_DELIVERY,
+  ];
 }
```

Pickup still filters to `DIRECT + ONLINE` (no contra entrega at the
store). No shipping_type still returns all modes (initial load).

## Files

- `apps/backend/src/domains/ecommerce/checkout/checkout.service.ts` (1 file, +11/-3)
- `skills/vendix-ecommerce-checkout/SKILL.md` (docs updated)

## Verification

### Manual
1. Open `e-tech-shop.vendix.online/checkout`
2. Select a **Riohacha** address with `own_fleet` shipping
3. ✅ All 4 payment methods appear (Efectivo, Vouchers, Contra Entrega, Wallet)
4. Select an **other** address with no shipping available
5. ✅ All 4 methods still appear
6. (If pickup supported) Select pickup → only 2 methods (Efectivo + Wallet + online, no Contra Entrega)

### API
```bash
# Before fix: own_fleet → 2 methods (ONLINE + ON_DELIVERY)
# After fix:  own_fleet → 4 methods (all)
curl -s 'http://localhost:3000/ecommerce/checkout/payment-methods?shipping_type=own_fleet' | jq '.data | length'
```

## Why this approach

| Alternative | Why rejected |
|---|---|
| Remove the filter entirely | Too aggressive — `pickup` legitimately shouldn't show contra entrega. |
| Frontend always calls without `shipping_type` | Hides backend contract from frontend. The query param is meaningful for `pickup`. |
| New `include_all` query param | Adds API surface for a one-line fix. Over-engineered. |

Smallest change that fixes the user's exact complaint while keeping
the sensible `pickup` restriction.

## Migration

None. No DB schema change, no data migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)