### PR TITLE
fix(dispatch): sincroniza estados orden↔remisión + elimina pagos parciales + scan/confirm idempotente

### DIFF
--- a/apps/backend/src/common/errors/error-codes.ts
+++ b/apps/backend/src/common/errors/error-codes.ts
@@ -1962,6 +1962,12 @@ export const ErrorCodes = {
     devMessage:
       'One or more route stops have no delivery address; the route cannot be dispatched',
   },
+  DISPATCH_ROUTE_PARTIAL_DISABLED: {
+    code: 'DISPATCH_ROUTE_PARTIAL_DISABLED',
+    httpStatus: 400,
+    devMessage:
+      'Partial deliveries are not enabled on dispatch routes; payment must be total (delivered) or the stop must be rejected/released',
+  },
 
   // MCP (Model Context Protocol)
   AI_MCP_001: {

--- a/apps/backend/src/domains/store/dispatch-routes/route-flow/cash-settlement.service.ts
+++ b/apps/backend/src/domains/store/dispatch-routes/route-flow/cash-settlement.service.ts
@@ -150,6 +150,16 @@ export class CashSettlementService {
   }
 
   async emitCreditSale(input: CreditSaleInput) {
+    // Sin crédito / pago parcial en ruta: el pago es total o no hay pago. La
+    // liquidación de paradas ya nunca produce credit_amount > 0, así que esta
+    // rama queda muerta. La protegemos como defensa en profundidad para que un
+    // monto residual jamás genere un accounts_receivable ni emita
+    // 'credit_sale.created' por una venta a crédito en ruta. NO toca las demás
+    // emisiones (payment.received / refund.completed / withholding).
+    if (!(input.amount > 0)) {
+      return null;
+    }
+
     const store = await this.prisma.stores.findUnique({
       where: { id: input.store_id },
       select: { organization_id: true },

--- a/apps/backend/src/domains/store/dispatch-routes/route-flow/route-flow.service.spec.ts
+++ b/apps/backend/src/domains/store/dispatch-routes/route-flow/route-flow.service.spec.ts
@@ -1,6 +1,7 @@
 import { Prisma } from '@prisma/client';
 import { RouteFlowService } from './route-flow.service';
 import { RequestContextService } from '@common/context/request-context.service';
+import { VendixHttpException } from '@common/errors';
 
 describe('RouteFlowService — settleStop (cash settlement event fan-out)', () => {
   let service: RouteFlowService;
@@ -165,43 +166,24 @@ describe('RouteFlowService — settleStop (cash settlement event fan-out)', () =
     );
   });
 
-  // ── b) CRÉDITO (partial) ───────────────────────────────────────────
-  it('b) credit stop (partial collection): emits credit_sale with amount = net - total_paid - withholding', async () => {
+  // ── b) PARCIAL DESHABILITADO ───────────────────────────────────────
+  it('b) partial result is rejected: throws DISPATCH_ROUTE_PARTIAL_DISABLED and never settles', async () => {
     prismaMock.dispatch_routes.findFirst.mockResolvedValue(buildRoute());
     prismaMock.dispatch_route_stops.findFirst.mockResolvedValue(buildStop());
 
-    // net=200, collected=120 → credit_amount = 200 - 120 - 0 = 80
-    await service.settleStop(ROUTE_ID, STOP_ID, {
-      result: 'partial',
-      collected_amount: 120,
-      payment_method: 'cash',
-    } as any);
+    // No hay crédito / pago parcial en ruta: el pago es total o no hay pago.
+    await expect(
+      service.settleStop(ROUTE_ID, STOP_ID, {
+        result: 'partial',
+        collected_amount: 120,
+        payment_method: 'cash',
+      } as any),
+    ).rejects.toBeInstanceOf(VendixHttpException);
 
-    expect(cashSettlementMock.emitCreditSale).toHaveBeenCalledTimes(1);
-    expect(cashSettlementMock.emitCreditSale).toHaveBeenCalledWith(
-      expect.objectContaining({
-        store_id: STORE_ID,
-        route_id: ROUTE_ID,
-        stop_id: STOP_ID,
-        customer_id: 42,
-        amount: 80,
-      }),
-    );
-    // Partial collection still triggers a payment for the collected portion.
-    expect(cashSettlementMock.emitPaymentReceived).toHaveBeenCalledWith(
-      expect.objectContaining({ amount: 120 }),
-    );
-
-    expect(prismaMock.dispatch_route_stops.update).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({
-          status: 'partial',
-          result: 'partial',
-          collected_amount: 120,
-          credit_amount: 80,
-        }),
-      }),
-    );
+    // The stop is never updated and no credit-sale / payment is emitted.
+    expect(prismaMock.dispatch_route_stops.update).not.toHaveBeenCalled();
+    expect(cashSettlementMock.emitCreditSale).not.toHaveBeenCalled();
+    expect(cashSettlementMock.emitPaymentReceived).not.toHaveBeenCalled();
   });
 
   // ── c) RETENCIÓN (withholding) ─────────────────────────────────────
@@ -360,27 +342,27 @@ describe('RouteFlowService — settleStop (cash settlement event fan-out)', () =
     );
   });
 
-  // ── h) PARTIAL → also delivers the remisión ────────────────────────
-  it("h) result 'partial' on a confirmed note: updates dispatch_note → delivered and emits dispatch_note.delivered", async () => {
+  // ── h) PARTIAL → rejected, never delivers the remisión ─────────────
+  it("h) result 'partial' is rejected: does NOT transition the remisión to delivered nor emit the event", async () => {
     prismaMock.dispatch_routes.findFirst.mockResolvedValue(buildRoute());
     prismaMock.dispatch_route_stops.findFirst.mockResolvedValue(buildStop());
 
-    // net=200, collected=120 → partial (credit 80), still delivers the remisión.
-    await service.settleStop(ROUTE_ID, STOP_ID, {
-      result: 'partial',
-      collected_amount: 120,
-      payment_method: 'cash',
-    } as any);
+    // Partial is disabled: the whole settle is aborted before any side effect.
+    await expect(
+      service.settleStop(ROUTE_ID, STOP_ID, {
+        result: 'partial',
+        collected_amount: 120,
+        payment_method: 'cash',
+      } as any),
+    ).rejects.toBeInstanceOf(VendixHttpException);
 
-    expect(prismaMock.dispatch_notes.update).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { id: 900 },
-        data: expect.objectContaining({ status: 'delivered' }),
-      }),
+    const deliveredUpdate = prismaMock.dispatch_notes.update.mock.calls.find(
+      (c: any[]) => c[0]?.data?.status === 'delivered',
     );
-    expect(eventEmitterMock.emit).toHaveBeenCalledWith(
+    expect(deliveredUpdate).toBeUndefined();
+    expect(eventEmitterMock.emit).not.toHaveBeenCalledWith(
       'dispatch_note.delivered',
-      expect.objectContaining({ dispatch_note_id: 900 }),
+      expect.anything(),
     );
   });
 

--- a/apps/backend/src/domains/store/dispatch-routes/route-flow/route-flow.service.ts
+++ b/apps/backend/src/domains/store/dispatch-routes/route-flow/route-flow.service.ts
@@ -600,6 +600,16 @@ export class RouteFlowService {
       throw new BadRequestException(`La parada ya está '${stop.status}'`);
     }
 
+    // No hay entregas parciales / crédito en ruta: el pago es TOTAL o no hay
+    // pago. Entregada ⇒ pagada al 100% (o prepaga). Resultados válidos:
+    // 'delivered', 'rejected', 'released'. 'partial' queda deshabilitado.
+    if ((dto.result as string) === 'partial') {
+      throw new VendixHttpException(
+        ErrorCodes.DISPATCH_ROUTE_PARTIAL_DISABLED,
+        "Las entregas parciales no están habilitadas en ruta: el pago debe ser total. Marca la parada como entregada (pago completo) o rechazada.",
+      );
+    }
+
     // DERIVED prepaid for this stop from the live note/order payment state.
     // Never trust the persisted (frozen) stop.is_prepaid for the COD logic.
     const stopIsPrepaid = deriveStopIsPrepaid(stop);
@@ -619,7 +629,7 @@ export class RouteFlowService {
       Number(breakdown?.retefuente || 0) +
       Number(breakdown?.reteiva || 0) +
       Number(breakdown?.reteica || 0);
-    if (isWithholdingAgent && (dto.result === 'delivered' || dto.result === 'partial')) {
+    if (isWithholdingAgent && dto.result === 'delivered') {
       if (withholdingAmount <= 0 || !breakdown || breakdownSum <= 0) {
         throw new BadRequestException(
           `El cliente es agente retenedor: la liquidación requiere un desglose de retención (retefuente / reteiva / reteica) con suma > 0.`,
@@ -651,11 +661,10 @@ export class RouteFlowService {
       }
     }
 
-    // Compute credit amount for partial
-    let credit_amount = 0;
-    if (dto.result === 'partial') {
-      credit_amount = Math.max(0, net - total_paid - withholding);
-    }
+    // Sin crédito en ruta: el pago es total o no hay pago. `credit_amount`
+    // permanece en 0 siempre (la columna se conserva en el schema, pero ya no
+    // se usa). `anticipo_amount` deja de funcionar como pago parcial.
+    const credit_amount = 0;
 
     const from_status = stop.status;
 
@@ -711,24 +720,21 @@ export class RouteFlowService {
       await this.refreshRouteTotals(tx, id);
 
       // Live order-state mode: reflect the COD order as "delivered" the moment
-      // the stop is settled as delivered/partial. `rejected` is intentionally
-      // excluded (a refused delivery does not deliver the order). The walk to
-      // `finished` still happens at route close. No-op for `on_close` mode.
+      // the stop is settled as delivered (pago total). `rejected` is excluded
+      // (a refused delivery does not deliver the order). The walk to `finished`
+      // still happens at route close. No-op for `on_close` mode.
       if (orderStateUpdateMode === 'live') {
         const order_id = stop.dispatch_note?.order_id;
-        if (
-          order_id &&
-          (dto.result === 'delivered' || dto.result === 'partial')
-        ) {
+        if (order_id && dto.result === 'delivered') {
           await this.advanceOrderToDelivered(tx, store_id, order_id);
         }
       }
 
-      // Sync the remisión with the route close-out: a stop settled as
-      // delivered/partial drives its dispatch_note → 'delivered' (idempotent).
+      // Sync the remisión with the route close-out: a stop settled as delivered
+      // (pago total) drives its dispatch_note → 'delivered' (idempotent).
       // rejected/released do NOT deliver the note. The event is emitted AFTER
       // the tx commits (see deliveredEventPayload below).
-      if (dto.result === 'delivered' || dto.result === 'partial') {
+      if (dto.result === 'delivered') {
         deliveredEventPayload = await this.markDispatchNoteDeliveredInTx(
           tx,
           stop.dispatch_note as any,
@@ -1029,27 +1035,16 @@ export class RouteFlowService {
         include: ROUTE_INCLUDE,
       });
 
-      // COD: finish each linked order that was DELIVERED and fully COLLECTED.
-      // Delivered = stop result in {delivered, partial}. Collected = the COD
-      // order has no outstanding balance (settled via paso 7) OR the stop is
-      // prepaid. remaining_balance is read live from the order (the COD payment
-      // listener already decremented it on settleStop). Idempotent + scoped.
+      // COD: finish each linked order whose stop was ENTREGADA. Con la regla
+      // "entregada = pagada al 100% (o prepaga)" ya no hay gate de recaudo: toda
+      // parada con result='delivered' sincroniza su orden shipped → delivered →
+      // finished. Esto cierra el gap donde las órdenes se quedaban en 'shipped'.
+      // rejected/released NO avanzan. `advanceOrderToFinished` es idempotente
+      // (no-op si la orden ya está en/past target) y store-scoped.
       for (const stop of updated_route.stops) {
         const order_id = stop.dispatch_note?.order_id;
         if (!order_id) continue;
-        const delivered =
-          stop.result === 'delivered' || stop.result === 'partial';
-        if (!delivered) continue;
-
-        let collected = stop.is_prepaid === true;
-        if (!collected) {
-          const order = await tx.orders.findFirst({
-            where: { id: order_id, store_id },
-            select: { remaining_balance: true },
-          });
-          collected = order ? Number(order.remaining_balance) <= 0 : false;
-        }
-        if (!collected) continue;
+        if (stop.result !== 'delivered') continue;
 
         await this.advanceOrderToFinished(tx, store_id, order_id);
       }

--- a/apps/backend/src/domains/store/dispatch-routes/route-flow/route-sheet-scanner.service.spec.ts
+++ b/apps/backend/src/domains/store/dispatch-routes/route-flow/route-sheet-scanner.service.spec.ts
@@ -18,6 +18,7 @@ describe('RouteSheetScannerService', () => {
   let aiMock: any;
   let prismaMock: any;
   let routeFlowMock: any;
+  let dispatchRoutesMock: any;
   let s3Mock: any;
 
   // The AI app returns a JSON string matching the route_sheet_ocr schema.
@@ -78,12 +79,18 @@ describe('RouteSheetScannerService', () => {
     };
 
     routeFlowMock = { settleStop: jest.fn().mockResolvedValue({}) };
+    // confirmAndSettle re-reads the route via DispatchRoutesService.findOne to
+    // return the updated route in its response.
+    dispatchRoutesMock = {
+      findOne: jest.fn().mockResolvedValue({ id: ROUTE_ID, status: 'settling' }),
+    };
     s3Mock = { uploadFile: jest.fn().mockResolvedValue('s3/key/planilla.jpg') };
 
     service = new RouteSheetScannerService(
       aiMock as any,
       prismaMock as any,
       routeFlowMock as any,
+      dispatchRoutesMock as any,
       s3Mock as any,
     );
   });
@@ -221,10 +228,12 @@ describe('RouteSheetScannerService', () => {
       prismaMock.dispatch_route_stops.findMany.mockResolvedValue([
         {
           id: 51,
+          status: 'pending',
           dispatch_note: { grand_total: new Prisma.Decimal(200) },
         },
         {
           id: 52,
+          status: 'pending',
           dispatch_note: { grand_total: new Prisma.Decimal(150) },
         },
       ]);
@@ -269,6 +278,90 @@ describe('RouteSheetScannerService', () => {
 
       expect(result.planilla_pdf_key).toBe('s3/key/planilla.jpg');
       expect(result.settled).toHaveLength(2);
+      expect(result.skipped).toHaveLength(0);
+      expect(result.errors).toHaveLength(0);
+      // The updated route is re-read and returned for the frontend refresh.
+      expect(dispatchRoutesMock.findOne).toHaveBeenCalledWith(ROUTE_ID);
+      expect(result.route).toMatchObject({ id: ROUTE_ID });
+    });
+
+    it('reconciles idempotently: skips already-terminal and not-in-route stops', async () => {
+      // Stop 51 is already delivered (terminal), stop 52 is pending. Stop 99 is
+      // not part of the route at all (absent from findMany).
+      prismaMock.dispatch_route_stops.findMany.mockResolvedValue([
+        {
+          id: 51,
+          status: 'delivered',
+          dispatch_note: { grand_total: new Prisma.Decimal(200) },
+        },
+        {
+          id: 52,
+          status: 'pending',
+          dispatch_note: { grand_total: new Prisma.Decimal(150) },
+        },
+      ]);
+
+      const dto: any = {
+        stops: [
+          { stop_id: 51, delivered: true, collected_amount: 200 },
+          { stop_id: 52, delivered: true, collected_amount: 150 },
+          { stop_id: 99, delivered: true, collected_amount: 10 },
+        ],
+        scan_result: { stops: [], confidence: 88 },
+      };
+
+      const result = await service.confirmAndSettle(ROUTE_ID, file(), dto);
+
+      // Only the pending stop 52 is settled — 51 (terminal) and 99 (not in
+      // route) are reconciled as skipped, never re-settled.
+      expect(routeFlowMock.settleStop).toHaveBeenCalledTimes(1);
+      expect(routeFlowMock.settleStop).toHaveBeenCalledWith(
+        ROUTE_ID,
+        52,
+        expect.objectContaining({ result: 'delivered' }),
+      );
+      expect(result.settled).toEqual([{ stop_id: 52, result: 'delivered' }]);
+      expect(result.skipped).toEqual(
+        expect.arrayContaining([
+          { stop_id: 51, reason: 'already_settled' },
+          { stop_id: 99, reason: 'not_in_route' },
+        ]),
+      );
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('collects per-stop settle failures without aborting the batch', async () => {
+      prismaMock.dispatch_route_stops.findMany.mockResolvedValue([
+        {
+          id: 51,
+          status: 'pending',
+          dispatch_note: { grand_total: new Prisma.Decimal(200) },
+        },
+        {
+          id: 52,
+          status: 'pending',
+          dispatch_note: { grand_total: new Prisma.Decimal(150) },
+        },
+      ]);
+
+      // Stop 51 throws (e.g. validation 400); stop 52 must still settle.
+      routeFlowMock.settleStop
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockResolvedValueOnce({});
+
+      const dto: any = {
+        stops: [
+          { stop_id: 51, delivered: true, collected_amount: 200 },
+          { stop_id: 52, delivered: true, collected_amount: 150 },
+        ],
+        scan_result: { stops: [], confidence: 90 },
+      };
+
+      const result = await service.confirmAndSettle(ROUTE_ID, file(), dto);
+
+      expect(result.settled).toEqual([{ stop_id: 52, result: 'delivered' }]);
+      expect(result.errors).toEqual([{ stop_id: 51, message: 'boom' }]);
+      expect(result.skipped).toHaveLength(0);
     });
   });
 });

--- a/apps/backend/src/domains/store/dispatch-routes/route-flow/route-sheet-scanner.service.ts
+++ b/apps/backend/src/domains/store/dispatch-routes/route-flow/route-sheet-scanner.service.ts
@@ -315,6 +315,19 @@ export class RouteSheetScannerService {
       settleDto.collected_amount = Number(decision.collected_amount ?? 0);
       settleDto.payment_method = decision.payment_method;
       settleDto.withholding_breakdown = decision.withholding_breakdown;
+      // Derive withholding_amount from the breakdown sum. settleStop reads
+      // `dto.withholding_amount` (not the breakdown) for the withholding-agent
+      // gate and requires it to equal the breakdown sum, so a scanner payload
+      // that only carries the breakdown would otherwise 400 for a retenedor.
+      const wb = decision.withholding_breakdown as
+        | { retefuente?: number; reteiva?: number; reteica?: number }
+        | undefined;
+      if (wb) {
+        settleDto.withholding_amount =
+          Number(wb.retefuente || 0) +
+          Number(wb.reteiva || 0) +
+          Number(wb.reteica || 0);
+      }
       settleDto.notes = decision.notes;
 
       // Wrap each settle so a single failure (e.g. validation 400) is collected

--- a/apps/backend/src/domains/store/dispatch-routes/route-flow/route-sheet-scanner.service.ts
+++ b/apps/backend/src/domains/store/dispatch-routes/route-flow/route-sheet-scanner.service.ts
@@ -7,6 +7,7 @@ import { RequestContextService } from '@common/context/request-context.service';
 import { S3Service } from '@common/services/s3.service';
 import { VendixHttpException, ErrorCodes } from '@common/errors';
 import { RouteFlowService } from './route-flow.service';
+import { DispatchRoutesService } from '../dispatch-routes.service';
 import { SettleStopDto } from '../dto';
 import {
   ConfirmRouteSheetDto,
@@ -38,6 +39,7 @@ export class RouteSheetScannerService {
     private readonly aiEngine: AIEngineService,
     private readonly prisma: StorePrismaService,
     private readonly routeFlow: RouteFlowService,
+    private readonly dispatchRoutes: DispatchRoutesService,
     private readonly s3Service: S3Service,
   ) {}
 
@@ -250,40 +252,84 @@ export class RouteSheetScannerService {
       throw new VendixHttpException(ErrorCodes.RTSCAN_MATCH_001);
     }
 
+    // Read every stop of the route once: net total (for result derivation) and
+    // CURRENT status (for the idempotent reconciliation). We index by the stop's
+    // own id so a decision pointing at a stop NOT in this route is detected.
     const stopIds = dto.stops.map((s) => s.stop_id);
     const stops = await this.prisma.dispatch_route_stops.findMany({
       where: { route_id: routeId, id: { in: stopIds } },
       select: {
         id: true,
+        status: true,
         dispatch_note: { select: { grand_total: true } },
       },
     });
-    const netById = new Map<number, number>(
-      stops.map((s) => [s.id, Number(s.dispatch_note?.grand_total ?? 0)]),
+    const stopById = new Map<
+      number,
+      { net: number; status: string }
+    >(
+      stops.map((s) => [
+        s.id,
+        {
+          net: Number(s.dispatch_note?.grand_total ?? 0),
+          status: s.status as string,
+        },
+      ]),
     );
 
-    // 1. Settle each confirmed stop via the existing settleStop flow.
+    // Terminal stop states are already settled — re-liquidating them throws a
+    // 400 ("La parada ya está 'delivered'"). The scan/confirm batch must be
+    // idempotent and reconcile against the live state, so we skip them.
+    const TERMINAL_STATUSES = new Set(['delivered', 'rejected', 'released']);
+
+    // 1. Settle each confirmed stop via the existing settleStop flow, with
+    //    per-stop reconciliation. One failing stop must NOT abort the batch.
     const settled: Array<{ stop_id: number; result: string }> = [];
+    const skipped: Array<{ stop_id: number; reason: string }> = [];
+    const errors: Array<{ stop_id: number; message: string }> = [];
+
     for (const decision of dto.stops) {
-      if (!netById.has(decision.stop_id)) {
-        // Stop is not part of this route / store — skip silently (scoped guard).
+      const current = stopById.get(decision.stop_id);
+
+      // Stop is not part of this route / store — reconcile as skipped.
+      if (!current) {
+        skipped.push({ stop_id: decision.stop_id, reason: 'not_in_route' });
         continue;
       }
+
+      // Already in a terminal state — do NOT call settleStop (it would 400).
+      // This is the reconciliation that makes re-confirming a sheet idempotent.
+      if (TERMINAL_STATUSES.has(current.status)) {
+        skipped.push({ stop_id: decision.stop_id, reason: 'already_settled' });
+        continue;
+      }
+
       const settleDto = new SettleStopDto();
       settleDto.result =
         (decision.result as dispatch_route_stop_result_enum) ??
         this.deriveResult(
           decision.delivered,
           Number(decision.collected_amount ?? 0),
-          netById.get(decision.stop_id) ?? 0,
+          current.net,
         );
       settleDto.collected_amount = Number(decision.collected_amount ?? 0);
       settleDto.payment_method = decision.payment_method;
       settleDto.withholding_breakdown = decision.withholding_breakdown;
       settleDto.notes = decision.notes;
 
-      await this.routeFlow.settleStop(routeId, decision.stop_id, settleDto);
-      settled.push({ stop_id: decision.stop_id, result: settleDto.result });
+      // Wrap each settle so a single failure (e.g. validation 400) is collected
+      // and the rest of the batch still runs.
+      try {
+        await this.routeFlow.settleStop(routeId, decision.stop_id, settleDto);
+        settled.push({ stop_id: decision.stop_id, result: settleDto.result });
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : 'Error liquidando la parada';
+        this.logger.warn(
+          `[RouteSheetScan] settleStop failed for stop ${decision.stop_id}: ${message}`,
+        );
+        errors.push({ stop_id: decision.stop_id, message });
+      }
     }
 
     // 2. Upload the route sheet to S3 (store the KEY, not a presigned URL).
@@ -305,11 +351,23 @@ export class RouteSheetScannerService {
       },
     });
 
+    // 4. Re-read the route in its updated state (same canonical shape the rest
+    //    of the flow returns: stops + reconciliation + derived is_prepaid) so
+    //    the frontend can refresh the detail view without a second round-trip.
+    const route_updated = await this.dispatchRoutes.findOne(routeId);
+
     this.logger.log(
-      `[RouteSheetScan] Route #${routeId} settled ${settled.length} stops + planilla persisted (${s3Key})`,
+      `[RouteSheetScan] Route #${routeId}: settled=${settled.length} skipped=${skipped.length} errors=${errors.length} + planilla persisted (${s3Key})`,
     );
 
-    return { route_id: routeId, planilla_pdf_key: s3Key, settled };
+    return {
+      route_id: routeId,
+      planilla_pdf_key: s3Key,
+      settled,
+      skipped,
+      errors,
+      route: route_updated,
+    };
   }
 
   // ───────────────────────────────────────────────────────────────────────────

--- a/apps/frontend/src/app/private/modules/store/dispatch-notes/components/dispatch-note-detail/dispatch-note-detail.component.html
+++ b/apps/frontend/src/app/private/modules/store/dispatch-notes/components/dispatch-note-detail/dispatch-note-detail.component.html
@@ -226,6 +226,19 @@
                 </button>
               </div>
             }
+            @if (activeRoute(); as route) {
+              <div class="flex justify-between items-center text-sm">
+                <span class="text-[var(--color-text-secondary)]">Ruta</span>
+                <button
+                  type="button"
+                  (click)="goToRoute(route.id)"
+                  class="inline-flex items-center gap-1 font-medium text-primary-600 hover:text-primary-700 hover:underline"
+                >
+                  Ver ruta {{ route.route_number }}
+                  <app-icon name="external-link" [size]="14"></app-icon>
+                </button>
+              </div>
+            }
             @if (dispatch_note().invoice) {
               <div class="flex justify-between text-sm">
                 <span class="text-[var(--color-text-secondary)]">Factura</span>

--- a/apps/frontend/src/app/private/modules/store/dispatch-notes/components/dispatch-note-detail/dispatch-note-detail.component.ts
+++ b/apps/frontend/src/app/private/modules/store/dispatch-notes/components/dispatch-note-detail/dispatch-note-detail.component.ts
@@ -130,6 +130,23 @@ export class DispatchNoteDetailComponent {
 
   readonly hasCustomerAddress = computed<boolean>(() => this.customerAddressLines().length > 0);
 
+  // ── Ruta activa (planilla) ─────────────────────────
+  /**
+   * Asignación activa de la remisión a una planilla de ruta: el primer stop
+   * cuyo `route` está presente y cuyo estado NO es `released`. Devuelve `null`
+   * cuando la remisión no está actualmente en una ruta (sin asignar o liberada
+   * y nunca reasignada). Replica el patrón `activeRoute` de la lista de
+   * remisiones para ofrecer navegación a la planilla.
+   */
+  readonly activeRoute = computed<{ id: number; route_number: string } | null>(() => {
+    const stop = (this.dispatch_note().dispatch_route_stops ?? []).find(
+      (s) => s.status !== 'released' && !!s.route,
+    );
+    return stop?.route
+      ? { id: stop.route.id, route_number: stop.route.route_number }
+      : null;
+  });
+
   readonly customerPhone = computed<string>(() => {
     const a = this.dispatch_note().customer_address as { phone_number?: string } | string | null | undefined;
     return a && typeof a === 'object' ? a.phone_number || '' : '';
@@ -254,6 +271,11 @@ export class DispatchNoteDetailComponent {
   // ── Navigation ──────────────────────────────────────
   goToOrder(orderId: number): void {
     this.router.navigate(['/admin/orders', orderId]);
+  }
+
+  /** Navega al detalle de la planilla (ruta) asignada a la remisión. */
+  goToRoute(routeId: number): void {
+    this.router.navigate(['/admin/orders/planillas', routeId]);
   }
 
   // ── Utility methods ─────────────────────────────────

--- a/apps/frontend/src/app/private/modules/store/orders/components/generate-dispatch-wizard/generate-dispatch-wizard.component.ts
+++ b/apps/frontend/src/app/private/modules/store/orders/components/generate-dispatch-wizard/generate-dispatch-wizard.component.ts
@@ -28,6 +28,7 @@ import { SelectorOption } from '../../../../../../shared/components/selector/sel
 import { CurrencyPipe } from '../../../../../../shared/pipes/currency';
 
 import { Address, Order, OrderItem } from '../../interfaces/order.interface';
+import { toLocalDateString } from '../../../../../../shared/utils/date.util';
 import { DispatchNotesService } from '../../../dispatch-notes/services/dispatch-notes.service';
 import {
   CreateDispatchFromOrderDto,
@@ -166,7 +167,10 @@ export class GenerateDispatchWizardComponent {
   // ── Step 2: dispatch data ─────────────────────────────────────────────
   readonly dataForm = this.fb.group({
     dispatch_location_id: this.fb.control<number | null>(null),
-    agreed_delivery_date: this.fb.control<string>(''),
+    // Default the delivery date to TODAY (local timezone) so the wizard opens
+    // with a sensible, editable value. Use toLocalDateString() — never
+    // toISOString() — to avoid the UTC off-by-one bug (see vendix-date-timezone).
+    agreed_delivery_date: this.fb.control<string>(toLocalDateString()),
     notes: this.fb.control<string>(''),
     target_status: this.fb.control<'draft' | 'confirmed'>('draft', {
       nonNullable: true,
@@ -263,7 +267,8 @@ export class GenerateDispatchWizardComponent {
     this.posLocationId.set(null);
     this.dataForm.reset({
       dispatch_location_id: null,
-      agreed_delivery_date: '',
+      // Re-seed the delivery date to TODAY (local) on every open/reset.
+      agreed_delivery_date: toLocalDateString(),
       notes: '',
       target_status: 'draft',
     });

--- a/apps/frontend/src/app/private/modules/store/orders/pages/order-details/order-details-page.component.html
+++ b/apps/frontend/src/app/private/modules/store/orders/pages/order-details/order-details-page.component.html
@@ -1952,6 +1952,49 @@
       (closed)="showDispatchModal.set(false)"
     ></app-generate-dispatch-wizard>
 
+    <!-- REMISIÓN GENERADA: navegar a la remisión o a su ruta (planilla) -->
+    <app-modal
+      [isOpen]="showDispatchGeneratedModal()"
+      (closed)="dismissDispatchGeneratedModal()"
+      title="Remision generada"
+      size="sm"
+    >
+      <div class="p-4">
+        <div
+          class="bg-emerald-50 border border-emerald-200 rounded-xl p-3 flex items-start gap-3"
+        >
+          <app-icon
+            name="check-circle"
+            size="18"
+            class="text-emerald-600 mt-0.5"
+          ></app-icon>
+          <div>
+            <p class="text-sm font-bold text-emerald-800">
+              La remision se creo correctamente
+            </p>
+            <p class="text-xs text-emerald-600 mt-0.5">
+              Quedo asignada a una ruta. Puedes ver la remision o ir a la ruta.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div
+        slot="footer"
+        class="flex flex-col sm:flex-row items-stretch sm:items-center justify-end gap-2 p-4 border-t border-border"
+      >
+        <app-button variant="outline" (clicked)="dismissDispatchGeneratedModal()"
+          >Seguir aqui</app-button
+        >
+        <app-button variant="outline" (clicked)="goToGeneratedDispatchRoute()"
+          >Ver ruta</app-button
+        >
+        <app-button variant="primary" (clicked)="goToGeneratedDispatchNote()"
+          >Ver remision</app-button
+        >
+      </div>
+    </app-modal>
+
     <!-- A3-edit: CAPTURA DE DIRECCIÓN DE ENVÍO EN PÁGINA -->
     @if (showShippingAddressModal()) {
       <app-shipping-address-modal

--- a/apps/frontend/src/app/private/modules/store/orders/pages/order-details/order-details-page.component.ts
+++ b/apps/frontend/src/app/private/modules/store/orders/pages/order-details/order-details-page.component.ts
@@ -169,6 +169,18 @@ export class OrderDetailsPageComponent {
   showDispatchModal = signal(false);
   /** Chooser modal: "con remisión" vs "sin remisión" (single dispatch entry). */
   showDispatchSelector = signal(false);
+  /**
+   * Post-generación de remisión: modal "Remisión generada" cuando la remisión
+   * quedó asignada a una ruta (planilla). Ofrece navegar a la remisión o a la
+   * ruta. Cuando NO hay ruta, se usa el `dialogService.confirm` clásico (solo
+   * "Ver remisión"). El contexto guarda el id de la remisión y, si aplica, el
+   * id de la ruta activa para construir la navegación.
+   */
+  showDispatchGeneratedModal = signal(false);
+  dispatchGeneratedContext = signal<{ dispatchNoteId: number; routeId: number | null }>({
+    dispatchNoteId: 0,
+    routeId: null,
+  });
   /** A3-edit: modal de captura de dirección de envío en página. */
   showShippingAddressModal = signal(false);
   /** True mientras se persiste la dirección (POST address + PATCH order). */
@@ -1487,22 +1499,67 @@ export class OrderDetailsPageComponent {
     });
   }
 
-  private promptViewDispatchNote(dispatchNoteId: number): void {
-    this.dialogService
-      .confirm({
-        title: 'Remision generada',
-        message: 'La remision se creo correctamente. Deseas verla ahora?',
-        confirmText: 'Ver remision',
-        cancelText: 'Seguir aqui',
-        confirmVariant: 'primary',
-      })
-      .then((confirmed: boolean) => {
-        if (confirmed) {
-          this.router.navigate(['/admin/orders/dispatch-notes', dispatchNoteId]);
-        } else {
-          this.loadData();
-        }
-      });
+  private async promptViewDispatchNote(dispatchNoteId: number): Promise<void> {
+    // La remisión recién creada puede haber quedado asignada a una ruta
+    // (planilla) en la misma transacción. Para ofrecer "Ver ruta" necesitamos
+    // sus `dispatch_route_stops`, que el evento del wizard no entrega (solo el
+    // id), así que los traemos puntualmente. El fetch es best-effort: si falla,
+    // caemos al flujo clásico de solo "Ver remisión".
+    let routeId: number | null = null;
+    try {
+      const note = await firstValueFrom(
+        this.dispatchNotesService.getDispatchNote(dispatchNoteId),
+      );
+      routeId = this.activeRoute(note)?.id ?? null;
+    } catch {
+      routeId = null;
+    }
+
+    if (routeId != null) {
+      // Hay ruta activa: el dialog de 2 botones no alcanza para 3 acciones, así
+      // que usamos un app-modal pequeño con dos navegaciones + cerrar.
+      this.dispatchGeneratedContext.set({ dispatchNoteId, routeId });
+      this.showDispatchGeneratedModal.set(true);
+      return;
+    }
+
+    // Sin ruta: comportamiento clásico (solo "Ver remisión").
+    const confirmed = await this.dialogService.confirm({
+      title: 'Remision generada',
+      message: 'La remision se creo correctamente. Deseas verla ahora?',
+      confirmText: 'Ver remision',
+      cancelText: 'Seguir aqui',
+      confirmVariant: 'primary',
+    });
+    if (confirmed) {
+      this.router.navigate(['/admin/orders/dispatch-notes', dispatchNoteId]);
+    } else {
+      this.loadData();
+    }
+  }
+
+  /** Navega a la remisión generada y cierra el modal de confirmación. */
+  goToGeneratedDispatchNote(): void {
+    const { dispatchNoteId } = this.dispatchGeneratedContext();
+    this.showDispatchGeneratedModal.set(false);
+    if (dispatchNoteId) {
+      this.router.navigate(['/admin/orders/dispatch-notes', dispatchNoteId]);
+    }
+  }
+
+  /** Navega a la ruta (planilla) de la remisión generada y cierra el modal. */
+  goToGeneratedDispatchRoute(): void {
+    const { routeId } = this.dispatchGeneratedContext();
+    this.showDispatchGeneratedModal.set(false);
+    if (routeId != null) {
+      this.router.navigate(['/admin/orders/planillas', routeId]);
+    }
+  }
+
+  /** Cierra el modal "Remisión generada" y refresca la orden. */
+  dismissDispatchGeneratedModal(): void {
+    this.showDispatchGeneratedModal.set(false);
+    this.loadData();
   }
 
   openDeliverModal(): void {

--- a/apps/frontend/src/app/private/modules/store/planillas-rutas/components/route-sheet-scanner-modal/route-sheet-scanner-modal.component.ts
+++ b/apps/frontend/src/app/private/modules/store/planillas-rutas/components/route-sheet-scanner-modal/route-sheet-scanner-modal.component.ts
@@ -64,6 +64,17 @@ interface EditableStopDecision {
   collected_amount: number;
   payment_method: string;
   notes: string;
+  /**
+   * Optional fiscal-withholding breakdown for withholding-agent customers. The
+   * scan/match response does NOT surface `customer.is_withholding_agent` per
+   * stop, so the operator opts in via a "registrar retención" toggle. When set,
+   * the sum is sent as `withholding_breakdown` in the confirm payload and is
+   * counted toward covering the total (cash + withholding = total, NO partial).
+   */
+  withholding_enabled: boolean;
+  retefuente: number;
+  reteiva: number;
+  reteica: number;
 }
 
 @Component({
@@ -340,10 +351,55 @@ interface EditableStopDecision {
 
                     @if (isUndercollected(stop)) {
                       <p class="text-xs text-red-700">
-                        El monto recaudado no cubre el total
+                        Efectivo + retención no cubren el total
                         ({{ stop.net_total | currency }}). No se permiten pagos
-                        parciales: cobra el total o desmarca "Entregado".
+                        parciales: completa el cobro o desmarca "Entregado".
                       </p>
+                    }
+
+                    <!-- Withholding capture (cliente agente retenedor) -->
+                    <label class="flex items-center gap-2 cursor-pointer select-none">
+                      <input
+                        type="checkbox"
+                        [checked]="stop.withholding_enabled"
+                        (change)="updateWithholdingEnabled(i, $event)"
+                        class="h-4 w-4 rounded border-border text-primary-600 focus:ring-primary-600"
+                      />
+                      <span class="text-sm text-text-primary"
+                        >Cliente agente retenedor (registrar retención)</span
+                      >
+                    </label>
+
+                    @if (stop.withholding_enabled) {
+                      <div class="rounded-md border border-amber-200 bg-amber-50 p-2 space-y-2">
+                        <p class="text-xs text-amber-900">
+                          El cliente paga el neto en efectivo + certificado de
+                          retención. La suma se descuenta del total a cobrar.
+                        </p>
+                        <div class="grid grid-cols-3 gap-2">
+                          <app-input
+                            label="Retefuente"
+                            [currency]="true"
+                            [ngModel]="stop.retefuente"
+                            (ngModelChange)="updateWithholdingField(i, 'retefuente', $event)"
+                            [name]="'retefuente_' + i"
+                          ></app-input>
+                          <app-input
+                            label="Reteiva"
+                            [currency]="true"
+                            [ngModel]="stop.reteiva"
+                            (ngModelChange)="updateWithholdingField(i, 'reteiva', $event)"
+                            [name]="'reteiva_' + i"
+                          ></app-input>
+                          <app-input
+                            label="Reteica"
+                            [currency]="true"
+                            [ngModel]="stop.reteica"
+                            (ngModelChange)="updateWithholdingField(i, 'reteica', $event)"
+                            [name]="'reteica_' + i"
+                          ></app-input>
+                        </div>
+                      </div>
                     }
 
                     <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
@@ -507,10 +563,19 @@ export class RouteSheetScannerModalComponent {
       .reduce((sum, s) => sum + (s.collected_amount || 0), 0),
   );
 
+  /** Sum of the per-row withholding breakdown (0 unless capture is enabled). */
+  private rowWithholding(stop: EditableStopDecision): number {
+    if (!stop.withholding_enabled) return 0;
+    return (
+      (stop.retefuente || 0) + (stop.reteiva || 0) + (stop.reteica || 0)
+    );
+  }
+
   /**
    * True when at least one editable (non-settled) row is marked delivered but
-   * its collected amount does not cover the net total. Blocks confirm to keep
-   * the "pago total o no pago" rule (no partial payments).
+   * cash + withholding does not cover the net total. Blocks confirm to keep
+   * the "pago total o no pago" rule (no partial payments). For a withholding
+   * agent the customer pays cash + withholding certificate = total.
    */
   readonly hasUndercollectedDelivery = computed(() =>
     this.editableStops().some(
@@ -519,17 +584,17 @@ export class RouteSheetScannerModalComponent {
         !s.already_settled &&
         s.delivered &&
         (s.net_total || 0) > 0 &&
-        (s.collected_amount || 0) < (s.net_total || 0),
+        (s.collected_amount || 0) + this.rowWithholding(s) < (s.net_total || 0),
     ),
   );
 
-  /** Per-row helper: a delivered row whose collected amount is below total. */
+  /** Per-row helper: a delivered row whose cash + withholding is below total. */
   isUndercollected(stop: EditableStopDecision): boolean {
     return (
       !stop.already_settled &&
       stop.delivered &&
       (stop.net_total || 0) > 0 &&
-      (stop.collected_amount || 0) < (stop.net_total || 0)
+      (stop.collected_amount || 0) + this.rowWithholding(stop) < (stop.net_total || 0)
     );
   }
 
@@ -703,6 +768,10 @@ export class RouteSheetScannerModalComponent {
       collected_amount: ex.collected_amount ?? 0,
       payment_method: ex.payment_method ?? 'cash',
       notes: ex.notes ?? '',
+      withholding_enabled: false,
+      retefuente: 0,
+      reteiva: 0,
+      reteica: 0,
     };
   }
 
@@ -745,6 +814,27 @@ export class RouteSheetScannerModalComponent {
     this.patchStop(index, { notes: value });
   }
 
+  /** Toggle the withholding-capture section for a withholding-agent customer. */
+  updateWithholdingEnabled(index: number, event: Event): void {
+    const enabled = (event.target as HTMLInputElement).checked;
+    // When disabling, zero the breakdown so it never reaches the payload.
+    this.patchStop(
+      index,
+      enabled
+        ? { withholding_enabled: true }
+        : { withholding_enabled: false, retefuente: 0, reteiva: 0, reteica: 0 },
+    );
+  }
+
+  updateWithholdingField(
+    index: number,
+    field: 'retefuente' | 'reteiva' | 'reteica',
+    value: number | null,
+  ): void {
+    const amount = value == null || value < 0 ? 0 : Number(value);
+    this.patchStop(index, { [field]: amount });
+  }
+
   private patchStop(index: number, patch: Partial<EditableStopDecision>): void {
     const stops = [...this.editableStops()];
     stops[index] = { ...stops[index], ...patch };
@@ -773,13 +863,30 @@ export class RouteSheetScannerModalComponent {
     // unnecessary and was the source of the previous 400.
     const stops: ConfirmRouteSheetStopDto[] = this.editableStops()
       .filter((s) => s.stop_id !== null && !s.already_settled)
-      .map((s) => ({
-        stop_id: s.stop_id as number,
-        delivered: s.delivered,
-        collected_amount: s.collected_amount,
-        payment_method: s.payment_method || undefined,
-        notes: s.notes || undefined,
-      }));
+      .map((s) => {
+        const decision: ConfirmRouteSheetStopDto = {
+          stop_id: s.stop_id as number,
+          delivered: s.delivered,
+          collected_amount: s.collected_amount,
+          payment_method: s.payment_method || undefined,
+          notes: s.notes || undefined,
+        };
+        // Withholding-agent stops: carry the captured breakdown so the backend
+        // settles the order 100% (cash + withholding certificate, no AR) and
+        // does not 400 on its withholding-agent validation. Only non-zero lines.
+        if (this.rowWithholding(s) > 0) {
+          const breakdown: {
+            retefuente?: number;
+            reteiva?: number;
+            reteica?: number;
+          } = {};
+          if (s.retefuente > 0) breakdown.retefuente = s.retefuente;
+          if (s.reteiva > 0) breakdown.reteiva = s.reteiva;
+          if (s.reteica > 0) breakdown.reteica = s.reteica;
+          decision.withholding_breakdown = breakdown;
+        }
+        return decision;
+      });
 
     if (stops.length === 0) {
       this.toast.error(

--- a/apps/frontend/src/app/private/modules/store/planillas-rutas/components/route-sheet-scanner-modal/route-sheet-scanner-modal.component.ts
+++ b/apps/frontend/src/app/private/modules/store/planillas-rutas/components/route-sheet-scanner-modal/route-sheet-scanner-modal.component.ts
@@ -26,12 +26,16 @@ import { CurrencyPipe } from '../../../../../../shared/pipes/currency/currency.p
 import { PlanillasRutasService } from '../../services/planillas-rutas.service';
 import {
   ConfirmRouteSheetDto,
+  ConfirmRouteSheetResult,
   ConfirmRouteSheetStopDto,
   DispatchRoute,
   RouteSheetMatchResult,
   RouteSheetMatchedStop,
   RouteSheetScanResult,
 } from '../../interfaces/planilla.interface';
+
+/** Stop statuses that are already settled/terminal and cannot be re-settled. */
+const TERMINAL_STOP_STATUSES = ['delivered', 'partial', 'rejected', 'released'];
 
 /**
  * Editable per-stop review row. Built from each `RouteSheetMatchedStop`:
@@ -47,6 +51,14 @@ interface EditableStopDecision {
   /** Net amount expected for this stop (from `current.grand_total`). */
   net_total: number;
   current_collected: number;
+  /**
+   * Current persisted status of the resolved stop (from `current.status`).
+   * When this is terminal (delivered/partial/rejected/released) the row is
+   * already settled: it is excluded from the confirm payload and rendered as
+   * "ya liquidada (conciliada)" instead of being editable.
+   */
+  current_status: string | null;
+  already_settled: boolean;
   // Editable fields
   delivered: boolean;
   collected_amount: number;
@@ -249,16 +261,23 @@ interface EditableStopDecision {
           <div>
             <h4 class="text-sm font-semibold text-text-primary mb-3">
               Paradas ({{ confirmableCount() }} de {{ editableStops().length }} liquidables)
+              @if (alreadySettledCount() > 0) {
+                <span class="text-xs font-normal text-text-secondary">
+                  · {{ alreadySettledCount() }} ya liquidada(s) (conciliada)
+                </span>
+              }
             </h4>
 
             <div class="space-y-3">
               @for (stop of editableStops(); track $index; let i = $index) {
                 <div
                   class="rounded-lg border p-3 space-y-3"
-                  [class.border-border]="stop.stop_id !== null"
-                  [class.bg-surface]="stop.stop_id !== null"
+                  [class.border-border]="stop.stop_id !== null && !stop.already_settled"
+                  [class.bg-surface]="stop.stop_id !== null && !stop.already_settled"
                   [class.border-red-200]="stop.stop_id === null"
                   [class.bg-red-50]="stop.stop_id === null"
+                  [class.border-emerald-200]="stop.already_settled"
+                  [class.bg-emerald-50]="stop.already_settled"
                 >
                   <!-- Header row -->
                   <div class="flex items-start justify-between gap-2 flex-wrap">
@@ -272,6 +291,11 @@ interface EditableStopDecision {
                       <app-badge [variant]="matchMethodVariant(stop.match_method)" size="xsm">
                         {{ matchMethodLabel(stop.match_method) }}
                       </app-badge>
+                      @if (stop.already_settled) {
+                        <app-badge variant="success" size="xsm">
+                          Ya liquidada (conciliada)
+                        </app-badge>
+                      }
                     </div>
                     @if (stop.net_total > 0) {
                       <span class="text-sm font-semibold text-text-primary">
@@ -284,6 +308,12 @@ interface EditableStopDecision {
                     <p class="text-xs text-red-700">
                       No se pudo emparejar esta fila con una parada real; se omitirá.
                     </p>
+                  } @else if (stop.already_settled) {
+                    <p class="text-xs text-emerald-700">
+                      Esta parada ya está
+                      <strong>{{ settledStatusLabel(stop.current_status) }}</strong
+                      >; se conciliará automáticamente y no se volverá a liquidar.
+                    </p>
                   } @else {
                     <!-- Editable fields -->
                     <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
@@ -295,7 +325,7 @@ interface EditableStopDecision {
                           (change)="updateDelivered(i, $event)"
                           class="h-4 w-4 rounded border-border text-primary-600 focus:ring-primary-600"
                         />
-                        <span class="text-sm text-text-primary">Entregado</span>
+                        <span class="text-sm text-text-primary">Entregado (cobro total)</span>
                       </label>
 
                       <!-- Collected amount (currency input) -->
@@ -307,6 +337,14 @@ interface EditableStopDecision {
                         [name]="'collected_' + i"
                       ></app-input>
                     </div>
+
+                    @if (isUndercollected(stop)) {
+                      <p class="text-xs text-red-700">
+                        El monto recaudado no cubre el total
+                        ({{ stop.net_total | currency }}). No se permiten pagos
+                        parciales: cobra el total o desmarca "Entregado".
+                      </p>
+                    }
 
                     <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
                       <!-- Payment method selector -->
@@ -384,7 +422,7 @@ interface EditableStopDecision {
             <app-button
               variant="primary"
               [loading]="isConfirming()"
-              [disabled]="confirmableCount() === 0 || isConfirming()"
+              [disabled]="!canConfirm() || isConfirming()"
               (clicked)="onConfirm()"
             >
               Confirmar y liquidar
@@ -406,7 +444,11 @@ export class RouteSheetScannerModalComponent {
   readonly route = input<DispatchRoute | null>(null);
 
   readonly closed = output<void>();
-  readonly confirmed = output<void>();
+  /**
+   * Emits the fully-updated route returned by `/scan/confirm` so the parent
+   * can refresh the detail without a second round-trip to `GET :id`.
+   */
+  readonly confirmed = output<DispatchRoute>();
 
   /**
    * ViewChild refs for the hidden file inputs. Using `viewChild()` (zoneless
@@ -436,21 +478,64 @@ export class RouteSheetScannerModalComponent {
     return file?.type?.startsWith('image/') ?? false;
   });
 
-  /** Stops that can actually be confirmed (resolved to a real stop). */
+  /**
+   * Stops that can actually be confirmed: resolved to a real stop AND not
+   * already settled. Already-settled stops are reconciled by the backend and
+   * must NOT be re-sent in the confirm payload.
+   */
   readonly confirmableCount = computed(
-    () => this.editableStops().filter((s) => s.stop_id !== null).length,
+    () =>
+      this.editableStops().filter(
+        (s) => s.stop_id !== null && !s.already_settled,
+      ).length,
+  );
+
+  /** Count of rows that are already settled (shown as "conciliada"). */
+  readonly alreadySettledCount = computed(
+    () => this.editableStops().filter((s) => s.already_settled).length,
   );
 
   readonly totalNet = computed(() =>
     this.editableStops()
-      .filter((s) => s.stop_id !== null)
+      .filter((s) => s.stop_id !== null && !s.already_settled)
       .reduce((sum, s) => sum + (s.net_total || 0), 0),
   );
 
   readonly totalCollected = computed(() =>
     this.editableStops()
-      .filter((s) => s.stop_id !== null)
+      .filter((s) => s.stop_id !== null && !s.already_settled)
       .reduce((sum, s) => sum + (s.collected_amount || 0), 0),
+  );
+
+  /**
+   * True when at least one editable (non-settled) row is marked delivered but
+   * its collected amount does not cover the net total. Blocks confirm to keep
+   * the "pago total o no pago" rule (no partial payments).
+   */
+  readonly hasUndercollectedDelivery = computed(() =>
+    this.editableStops().some(
+      (s) =>
+        s.stop_id !== null &&
+        !s.already_settled &&
+        s.delivered &&
+        (s.net_total || 0) > 0 &&
+        (s.collected_amount || 0) < (s.net_total || 0),
+    ),
+  );
+
+  /** Per-row helper: a delivered row whose collected amount is below total. */
+  isUndercollected(stop: EditableStopDecision): boolean {
+    return (
+      !stop.already_settled &&
+      stop.delivered &&
+      (stop.net_total || 0) > 0 &&
+      (stop.collected_amount || 0) < (stop.net_total || 0)
+    );
+  }
+
+  /** Confirm enabled only when there is something to settle and no under-collection. */
+  readonly canConfirm = computed(
+    () => this.confirmableCount() > 0 && !this.hasUndercollectedDelivery(),
   );
 
   readonly wizardSteps = [
@@ -600,6 +685,11 @@ export class RouteSheetScannerModalComponent {
   /** Build an editable review row from a backend matched stop. */
   private toEditable(s: RouteSheetMatchedStop): EditableStopDecision {
     const ex = s.extracted;
+    const currentStatus = s.current?.status ?? null;
+    const alreadySettled =
+      s.stop_id !== null &&
+      currentStatus !== null &&
+      TERMINAL_STOP_STATUSES.includes(currentStatus);
     return {
       stop_id: s.stop_id,
       stop_sequence: s.stop_sequence,
@@ -607,11 +697,29 @@ export class RouteSheetScannerModalComponent {
       match_method: s.match_method,
       net_total: s.current?.grand_total ?? 0,
       current_collected: s.current?.collected_amount ?? 0,
+      current_status: currentStatus,
+      already_settled: alreadySettled,
       delivered: ex.delivered,
       collected_amount: ex.collected_amount ?? 0,
       payment_method: ex.payment_method ?? 'cash',
       notes: ex.notes ?? '',
     };
+  }
+
+  /** Spanish label for a terminal stop status (shown in the conciliada chip). */
+  settledStatusLabel(status: string | null): string {
+    switch (status) {
+      case 'delivered':
+        return 'Entregada';
+      case 'rejected':
+        return 'Rechazada';
+      case 'released':
+        return 'Liberada';
+      case 'partial':
+        return 'Liquidada';
+      default:
+        return 'Liquidada';
+    }
   }
 
   // ============================================================
@@ -652,8 +760,19 @@ export class RouteSheetScannerModalComponent {
     const scan = this.scanResult();
     if (!file) return;
 
+    // Guard: never submit an under-collected delivery (no partial payments).
+    if (this.hasUndercollectedDelivery()) {
+      this.toast.error(
+        'Hay paradas marcadas como entregadas cuyo monto no cubre el total. Cobra el total o desmarca "Entregado": no se permiten pagos parciales.',
+      );
+      return;
+    }
+
+    // Only send resolved, NOT-yet-settled stops. Already-terminal stops are
+    // reconciled by the backend (returned in `skipped`); re-sending them is
+    // unnecessary and was the source of the previous 400.
     const stops: ConfirmRouteSheetStopDto[] = this.editableStops()
-      .filter((s) => s.stop_id !== null)
+      .filter((s) => s.stop_id !== null && !s.already_settled)
       .map((s) => ({
         stop_id: s.stop_id as number,
         delivered: s.delivered,
@@ -663,7 +782,9 @@ export class RouteSheetScannerModalComponent {
       }));
 
     if (stops.length === 0) {
-      this.toast.error('No hay paradas liquidables en el escaneo');
+      this.toast.error(
+        'No hay paradas pendientes de liquidar en el escaneo (todas ya están liquidadas).',
+      );
       return;
     }
 
@@ -679,17 +800,55 @@ export class RouteSheetScannerModalComponent {
       .subscribe({
         next: (res) => {
           this.isConfirming.set(false);
-          this.toast.success(
-            `Planilla liquidada (${res.settled.length} paradas)`,
-          );
-          this.confirmed.emit();
+          this.showConfirmSummary(res);
+          // Hand the fully-updated route back to the parent so it can refresh
+          // the detail without a second GET round-trip.
+          this.confirmed.emit(res.route);
           this.closeAndReset();
         },
-        error: (err: Error) => {
+        error: (err: any) => {
           this.isConfirming.set(false);
-          this.toast.error(err?.message || 'Error al liquidar la planilla');
+          this.toast.error(this.mapConfirmError(err));
         },
       });
+  }
+
+  /**
+   * Summarize the idempotent settle response: how many stops were settled,
+   * how many were reconciled (already settled / not in route), and list any
+   * per-stop errors so the operator can react instead of seeing a raw toast.
+   */
+  private showConfirmSummary(res: ConfirmRouteSheetResult): void {
+    const settled = res.settled?.length ?? 0;
+    const skipped = res.skipped?.length ?? 0;
+    const errors = res.errors ?? [];
+
+    const summary = `Liquidadas: ${settled} / Conciliadas: ${skipped} / Errores: ${errors.length}`;
+
+    if (errors.length > 0) {
+      const detail = errors
+        .map((e) => `Parada #${e.stop_id}: ${e.message}`)
+        .join('\n');
+      // Keep the summary visible and surface the failing stops explicitly.
+      this.toast.warning(`${summary}\n${detail}`);
+    } else if (skipped > 0) {
+      this.toast.success(`${summary} (paradas ya liquidadas conciliadas)`);
+    } else {
+      this.toast.success(summary);
+    }
+  }
+
+  /**
+   * Map known backend error codes to clear Spanish messages. In particular,
+   * `DISPATCH_ROUTE_PARTIAL_DISABLED` is the 400 the backend returns if a
+   * partial result ever reaches it — surface it instead of the raw string.
+   */
+  private mapConfirmError(err: any): string {
+    const code = err?.error?.error_code || err?.error_code;
+    if (code === 'DISPATCH_ROUTE_PARTIAL_DISABLED') {
+      return 'No se permiten pagos parciales en una ruta: cada parada debe cobrarse completa o quedar como rechazada/liberada.';
+    }
+    return err?.message || 'Error al liquidar la planilla';
   }
 
   // ============================================================

--- a/apps/frontend/src/app/private/modules/store/planillas-rutas/components/stop-settle-modal/stop-settle-modal.component.ts
+++ b/apps/frontend/src/app/private/modules/store/planillas-rutas/components/stop-settle-modal/stop-settle-modal.component.ts
@@ -14,18 +14,25 @@ import {
 } from '../../interfaces/planilla.interface';
 
 /**
- * Settle modal — TOTAL payment only.
+ * Settle modal — TOTAL payment only (NO partial / credit / advance).
  *
- * Per the dispatch-route business rule, a stop can only be settled as fully
- * paid or not paid at all. There are NO partial payments, NO credit, and NO
- * advance ("anticipo"). The result options are therefore reduced to:
+ * Per the dispatch-route business rule a stop is settled as fully paid or not
+ * paid at all. There are NO partial payments, NO credit, and NO advance
+ * ("anticipo"). Result options are therefore:
  *
- *   - `delivered`: full payment — the collected amount MUST equal the total
- *     (prepaid stops collect 0 and are recorded with payment_method=`prepaid`).
+ *   - `delivered`: the order is 100% settled. For a normal customer the cash
+ *     collected MUST cover the total. For a **withholding agent** the customer
+ *     pays the NET in cash and hands over a withholding certificate
+ *     (retefuente / reteiva / reteica); the order is still 100% settled with
+ *     NO accounts receivable, so the rule becomes
+ *     `collected_amount (cash) + withholding_amount >= total`.
  *   - `rejected`:  customer refused delivery — no cash collected.
  *
- * The "Liberar" path (release) lives in its own modal. The payload NEVER
- * carries `result='partial'`, `anticipo_amount`, or `credit_amount`.
+ * Withholding capture is shown **only** when the customer is a withholding
+ * agent (`customer_is_withholding_agent`). For everyone else the modal stays a
+ * clean total-payment flow with no withholding fields. The "Liberar" path lives
+ * in its own modal. The payload NEVER carries `result='partial'`,
+ * `anticipo_amount`, or `credit_amount`.
  */
 @Component({
   selector: 'app-stop-settle-modal',
@@ -63,6 +70,19 @@ import {
           </div>
         }
 
+        @if (isWithholdingAgent() && !isPrepaid()) {
+          <div
+            class="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900"
+          >
+            <strong>Cliente agente retenedor.</strong> El cliente paga el
+            <em>neto</em> en efectivo y entrega un certificado de retención
+            (retefuente / reteiva / reteica). La orden queda
+            <strong>100% saldada</strong> (sin cuenta por cobrar): registra el
+            desglose de retención y el efectivo de modo que
+            <strong>efectivo + retención = total</strong>.
+          </div>
+        }
+
         <app-selector
           label="Resultado"
           [options]="resultOptions"
@@ -72,7 +92,7 @@ import {
         @if (isDelivered() && !isPrepaid()) {
           <div class="grid grid-cols-2 gap-2">
             <app-input
-              label="Recaudado (debe cubrir el total)"
+              label="Recaudado (efectivo)"
               [currency]="true"
               [(ngModel)]="collectedAmount"
             ></app-input>
@@ -83,14 +103,54 @@ import {
             ></app-selector>
           </div>
 
-          @if (!collectedCoversTotal()) {
+          @if (isWithholdingAgent()) {
+            <div class="rounded-md border border-border bg-surface p-2 space-y-2">
+              <p class="text-xs font-medium text-text-secondary">
+                Desglose de retención (la suma se descuenta del total a cobrar
+                en efectivo):
+              </p>
+              <div class="grid grid-cols-3 gap-2">
+                <app-input
+                  label="Retefuente"
+                  [currency]="true"
+                  [(ngModel)]="retefuente"
+                ></app-input>
+                <app-input
+                  label="Reteiva"
+                  [currency]="true"
+                  [(ngModel)]="reteiva"
+                ></app-input>
+                <app-input
+                  label="Reteica"
+                  [currency]="true"
+                  [(ngModel)]="reteica"
+                ></app-input>
+              </div>
+              <div class="flex justify-between text-xs text-text-secondary">
+                <span>Retención total</span>
+                <strong class="text-text-primary">{{
+                  withholdingTotal() | currency
+                }}</strong>
+              </div>
+            </div>
+          }
+
+          @if (!coversTotal()) {
             <div
               class="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-800"
             >
-              El monto recaudado ({{ collectedAmount | currency }}) debe ser
-              igual al total ({{ grandTotal() | currency }}). No se permiten
-              pagos parciales: cobra el total o registra la parada como
-              <strong>rechazada</strong>.
+              @if (isWithholdingAgent()) {
+                Efectivo ({{ collectedAmount | currency }}) + retención ({{
+                  withholdingTotal() | currency
+                }}) deben cubrir el total ({{ grandTotal() | currency }}). No se
+                permiten pagos parciales: completa el desglose y el efectivo, o
+                registra la parada como <strong>rechazada</strong>.
+              } @else {
+                El monto recaudado ({{ collectedAmount | currency }}) debe ser
+                igual al total ({{ grandTotal() | currency }}). No se permiten
+                pagos parciales: cobra el total o registra la parada como
+                <strong>rechazada</strong>.
+              }
             </div>
           }
         }
@@ -136,13 +196,29 @@ export class StopSettleModalComponent {
    */
   readonly isPrepaid = input<boolean>(false);
 
+  /**
+   * True when the dispatch note's customer is a withholding agent. Sourced
+   * from `dispatch_note.customer_is_withholding_agent` (top-level alias) with a
+   * fallback to the nested `customer.is_withholding_agent`. Only then does the
+   * modal expose the retefuente/reteiva/reteica capture; the backend
+   * re-validates the rule on settle (requires a breakdown with sum > 0 for a
+   * `delivered` withholding-agent stop).
+   */
+  readonly isWithholdingAgent = computed(() => {
+    const note = this.stop()?.dispatch_note;
+    return !!(
+      note?.customer_is_withholding_agent ?? note?.customer?.is_withholding_agent
+    );
+  });
+
   readonly close = output<void>();
   readonly submitted = output<SettleStopDto>();
 
   /**
    * Only TWO outcomes are allowed: full delivery (cobro total) or rejection.
    * "Partial" was removed entirely — half/credit/advance payments are not a
-   * supported flow on a dispatch route.
+   * supported flow on a dispatch route. A withholding agent is still a FULL
+   * delivery: cash + withholding certificate together cover the total.
    */
   readonly resultOptions: SelectorOption[] = [
     { value: 'delivered', label: 'Entregada y cobrada (total)' },
@@ -175,34 +251,76 @@ export class StopSettleModalComponent {
     this.collectedSig.set(Number(value) || 0);
   }
 
+  /** Withholding breakdown fields (only used for withholding agents). */
+  private _retefuente = 0;
+  get retefuente(): number {
+    return this._retefuente;
+  }
+  set retefuente(value: number) {
+    this._retefuente = value;
+    this.retefuenteSig.set(Number(value) || 0);
+  }
+
+  private _reteiva = 0;
+  get reteiva(): number {
+    return this._reteiva;
+  }
+  set reteiva(value: number) {
+    this._reteiva = value;
+    this.reteivaSig.set(Number(value) || 0);
+  }
+
+  private _reteica = 0;
+  get reteica(): number {
+    return this._reteica;
+  }
+  set reteica(value: number) {
+    this._reteica = value;
+    this.reteicaSig.set(Number(value) || 0);
+  }
+
   paymentMethod = 'cash';
   readonly submitting = signal(false);
 
   // Signal mirrors so templates/computed react in the zoneless runtime.
   private readonly resultSig = signal<DispatchRouteStopResult>('delivered');
   private readonly collectedSig = signal(0);
+  private readonly retefuenteSig = signal(0);
+  private readonly reteivaSig = signal(0);
+  private readonly reteicaSig = signal(0);
 
   readonly isDelivered = computed(() => this.resultSig() === 'delivered');
   readonly isRejected = computed(() => this.resultSig() === 'rejected');
 
+  /** Sum of the withholding breakdown = `withholding_amount` sent to the backend. */
+  readonly withholdingTotal = computed(
+    () => this.retefuenteSig() + this.reteivaSig() + this.reteicaSig(),
+  );
+
   /**
-   * Whether the collected amount fully covers the total. Prepaid stops cover
-   * the total by definition (collection happened before dispatch).
+   * Whether cash + withholding fully covers the total. Prepaid stops cover the
+   * total by definition (collection happened before dispatch). For a normal
+   * customer withholding is always 0, so this reduces to "cash >= total".
    */
-  readonly collectedCoversTotal = computed(() => {
+  readonly coversTotal = computed(() => {
     if (this.isPrepaid()) return true;
     const total = Number(this.grandTotal()) || 0;
-    return (this.collectedSig() || 0) >= total;
+    const withholding = this.isWithholdingAgent() ? this.withholdingTotal() : 0;
+    return (this.collectedSig() || 0) + withholding >= total;
   });
 
   /**
    * Confirm is allowed when the stop is rejected, or when it is delivered with
-   * a collected amount that covers the total. Never with a partial amount.
+   * cash + withholding that covers the total. For a withholding agent the
+   * breakdown sum must additionally be > 0 (backend hard requirement).
+   * Never with a partial amount.
    */
   readonly canConfirm = computed(() => {
     if (this.isRejected()) return true;
     if (this.isPrepaid()) return true;
-    return this.isDelivered() && this.collectedCoversTotal();
+    if (!this.isDelivered()) return false;
+    if (this.isWithholdingAgent() && this.withholdingTotal() <= 0) return false;
+    return this.coversTotal();
   });
 
   submit() {
@@ -220,13 +338,24 @@ export class StopSettleModalComponent {
     }
 
     // Delivered: full payment only. Prepaid stops collect 0; everyone else
-    // must have collected the full total (guarded by canConfirm).
+    // must cover the full total (guarded by canConfirm). Withholding agents
+    // settle the order 100% via cash + withholding certificate (no AR).
     const dto: SettleStopDto = {
       result: 'delivered',
       collected_amount: this.isPrepaid() ? 0 : Number(this.collectedAmount) || 0,
       change_amount: 0,
       payment_method: this.isPrepaid() ? 'prepaid' : this.paymentMethod,
     };
+
+    if (this.isWithholdingAgent() && !this.isPrepaid()) {
+      const breakdown: { retefuente?: number; reteiva?: number; reteica?: number } = {};
+      if (this.retefuenteSig() > 0) breakdown.retefuente = this.retefuenteSig();
+      if (this.reteivaSig() > 0) breakdown.reteiva = this.reteivaSig();
+      if (this.reteicaSig() > 0) breakdown.reteica = this.reteicaSig();
+      dto.withholding_breakdown = breakdown;
+      dto.withholding_amount = this.withholdingTotal();
+    }
+
     this.submitted.emit(dto);
   }
 }

--- a/apps/frontend/src/app/private/modules/store/planillas-rutas/components/stop-settle-modal/stop-settle-modal.component.ts
+++ b/apps/frontend/src/app/private/modules/store/planillas-rutas/components/stop-settle-modal/stop-settle-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, effect, input, output, signal } from "@angular/core";
+import { Component, computed, input, output, signal } from "@angular/core";
 import { FormsModule } from '@angular/forms';
 import { CurrencyPipe } from '../../../../../../shared/pipes/currency';
 import { ModalComponent } from '../../../../../../shared/components/modal/modal.component';
@@ -13,6 +13,20 @@ import {
   SettleStopDto,
 } from '../../interfaces/planilla.interface';
 
+/**
+ * Settle modal — TOTAL payment only.
+ *
+ * Per the dispatch-route business rule, a stop can only be settled as fully
+ * paid or not paid at all. There are NO partial payments, NO credit, and NO
+ * advance ("anticipo"). The result options are therefore reduced to:
+ *
+ *   - `delivered`: full payment — the collected amount MUST equal the total
+ *     (prepaid stops collect 0 and are recorded with payment_method=`prepaid`).
+ *   - `rejected`:  customer refused delivery — no cash collected.
+ *
+ * The "Liberar" path (release) lives in its own modal. The payload NEVER
+ * carries `result='partial'`, `anticipo_amount`, or `credit_amount`.
+ */
 @Component({
   selector: 'app-stop-settle-modal',
   standalone: true,
@@ -49,62 +63,46 @@ import {
           </div>
         }
 
-        @if (isWithholdingAgent()) {
-          <div
-            class="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900"
-          >
-            <strong>Cliente agente retenedor.</strong> Para liquidações
-            <em>delivered</em> o <em>partial</em> debes registrar un
-            desglose de retención (retefuente / reteiva / reteica) cuyo
-            total coincida con el monto retenido. El backend rechaza la
-            liquidación si la suma no coincide.
-          </div>
-        }
-
         <app-selector
           label="Resultado"
           [options]="resultOptions"
           [(ngModel)]="result"
         ></app-selector>
 
-        <div class="grid grid-cols-2 gap-2">
-          <app-input
-            label="Recaudado"
-            [currency]="true"
-            [(ngModel)]="collectedAmount"
-            (inputChange)="recalcCredit()"
-            [disabled]="isPrepaid()"
-          ></app-input>
-          <app-input
-            label="Retención"
-            [currency]="true"
-            [(ngModel)]="withholdingAmount"
-            (inputChange)="recalcCredit()"
-          ></app-input>
-          <app-input
-            label="Cambio"
-            [currency]="true"
-            [(ngModel)]="changeAmount"
-          ></app-input>
-          <app-selector
-            label="Método"
-            [options]="paymentMethodOptions"
-            [(ngModel)]="paymentMethod"
-            [disabled]="isPrepaid()"
-          ></app-selector>
-        </div>
-
-        @if (computedCredit() > 0) {
-          <div class="text-xs text-yellow-700 bg-yellow-50 p-2 rounded">
-            Saldo a crédito (calculado):
-            <strong>{{ computedCredit() | currency }}</strong>
+        @if (isDelivered() && !isPrepaid()) {
+          <div class="grid grid-cols-2 gap-2">
+            <app-input
+              label="Recaudado (debe cubrir el total)"
+              [currency]="true"
+              [(ngModel)]="collectedAmount"
+            ></app-input>
+            <app-selector
+              label="Método"
+              [options]="paymentMethodOptions"
+              [(ngModel)]="paymentMethod"
+            ></app-selector>
           </div>
+
+          @if (!collectedCoversTotal()) {
+            <div
+              class="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-800"
+            >
+              El monto recaudado ({{ collectedAmount | currency }}) debe ser
+              igual al total ({{ grandTotal() | currency }}). No se permiten
+              pagos parciales: cobra el total o registra la parada como
+              <strong>rechazada</strong>.
+            </div>
+          }
         }
 
-        <div class="text-xs text-text-secondary">
-          <strong>Tip:</strong> Si el cliente es agente retenedor, registra el
-          valor en "Retención".
-        </div>
+        @if (isRejected()) {
+          <div
+            class="rounded-md border border-border bg-surface px-3 py-2 text-xs text-text-secondary"
+          >
+            La parada se marcará como <strong>rechazada</strong>. No se
+            registrará recaudo.
+          </div>
+        }
       </div>
 
       <div slot="footer" class="flex gap-2">
@@ -118,7 +116,7 @@ import {
         <button
           type="button"
           (click)="submit()"
-          [disabled]="submitting()"
+          [disabled]="submitting() || !canConfirm()"
           class="flex-1 rounded-md bg-primary-600 text-white px-4 py-2 text-sm font-medium disabled:opacity-50"
         >
           {{ submitting() ? 'Guardando...' : 'Confirmar' }}
@@ -133,25 +131,21 @@ export class StopSettleModalComponent {
   /**
    * True when the stop's dispatch note was already paid before dispatch.
    * The backend forces collected_amount=0 and payment_method='prepaid' in
-   * that case; the modal surfaces a banner and disables the collected/method
+   * that case; the modal surfaces a banner and hides the collected/method
    * fields so the operator does not enter a value that will be discarded.
    */
   readonly isPrepaid = input<boolean>(false);
 
-  /**
-   * True when the dispatch note's customer is a `users.is_withholding_agent`.
-   * Backend re-validates the rule on settle; this is a UI affordance.
-   */
-  readonly isWithholdingAgent = computed(
-    () => !!this.stop()?.dispatch_note?.customer?.is_withholding_agent,
-  );
-
   readonly close = output<void>();
   readonly submitted = output<SettleStopDto>();
 
+  /**
+   * Only TWO outcomes are allowed: full delivery (cobro total) or rejection.
+   * "Partial" was removed entirely — half/credit/advance payments are not a
+   * supported flow on a dispatch route.
+   */
   readonly resultOptions: SelectorOption[] = [
-    { value: 'delivered', label: 'Entregada y cobrada' },
-    { value: 'partial', label: 'Parcial (crédito y/o retención)' },
+    { value: 'delivered', label: 'Entregada y cobrada (total)' },
     { value: 'rejected', label: 'Rechazada' },
   ];
 
@@ -161,49 +155,78 @@ export class StopSettleModalComponent {
     { value: 'card', label: 'Tarjeta' },
   ];
 
-  result: DispatchRouteStopResult = 'delivered';
-  collectedAmount = 0;
-  withholdingAmount = 0;
-  changeAmount = 0;
+  /** Selected outcome — bound to the selector via ngModel. Mirrored to a signal. */
+  private _result: DispatchRouteStopResult = 'delivered';
+  get result(): DispatchRouteStopResult {
+    return this._result;
+  }
+  set result(value: DispatchRouteStopResult) {
+    this._result = value;
+    this.resultSig.set(value);
+  }
+
+  /** Collected amount (raw numeric from the currency CVA). Mirrored to a signal. */
+  private _collectedAmount = 0;
+  get collectedAmount(): number {
+    return this._collectedAmount;
+  }
+  set collectedAmount(value: number) {
+    this._collectedAmount = value;
+    this.collectedSig.set(Number(value) || 0);
+  }
+
   paymentMethod = 'cash';
   readonly submitting = signal(false);
 
-  readonly computedCredit = signal(0);
+  // Signal mirrors so templates/computed react in the zoneless runtime.
+  private readonly resultSig = signal<DispatchRouteStopResult>('delivered');
+  private readonly collectedSig = signal(0);
 
-  constructor() {
-    // Recalculate the credit projection whenever the modal opens or the
-    // grand-total input changes. Without this, the operator would see a
-    // stale `0` until they edited the collected/withholding fields.
-    effect(() => {
-      this.grandTotal();
-      this.recalcCredit();
-    });
-  }
+  readonly isDelivered = computed(() => this.resultSig() === 'delivered');
+  readonly isRejected = computed(() => this.resultSig() === 'rejected');
 
-  recalcCredit() {
-    const net = Number(this.grandTotal()) || 0;
-    const credit = Math.max(
-      0,
-      net - (Number(this.collectedAmount) || 0) - (Number(this.withholdingAmount) || 0),
-    );
-    this.computedCredit.set(credit);
-  }
+  /**
+   * Whether the collected amount fully covers the total. Prepaid stops cover
+   * the total by definition (collection happened before dispatch).
+   */
+  readonly collectedCoversTotal = computed(() => {
+    if (this.isPrepaid()) return true;
+    const total = Number(this.grandTotal()) || 0;
+    return (this.collectedSig() || 0) >= total;
+  });
+
+  /**
+   * Confirm is allowed when the stop is rejected, or when it is delivered with
+   * a collected amount that covers the total. Never with a partial amount.
+   */
+  readonly canConfirm = computed(() => {
+    if (this.isRejected()) return true;
+    if (this.isPrepaid()) return true;
+    return this.isDelivered() && this.collectedCoversTotal();
+  });
 
   submit() {
+    if (!this.canConfirm()) return;
     this.submitting.set(true);
+
+    if (this.isRejected()) {
+      this.submitted.emit({
+        result: 'rejected',
+        collected_amount: 0,
+        change_amount: 0,
+        payment_method: this.paymentMethod,
+      });
+      return;
+    }
+
+    // Delivered: full payment only. Prepaid stops collect 0; everyone else
+    // must have collected the full total (guarded by canConfirm).
     const dto: SettleStopDto = {
-      // Prepaid stops are always reported as fully delivered with no
-      // cash collection; the result dropdown is hidden in that case but
-      // we keep the same field for safety.
-      result: this.isPrepaid() ? 'delivered' : this.result,
+      result: 'delivered',
       collected_amount: this.isPrepaid() ? 0 : Number(this.collectedAmount) || 0,
-      withholding_amount: Number(this.withholdingAmount) || 0,
-      change_amount: Number(this.changeAmount) || 0,
+      change_amount: 0,
       payment_method: this.isPrepaid() ? 'prepaid' : this.paymentMethod,
     };
-    if (this.withholdingAmount > 0) {
-      dto.withholding_breakdown = { retefuente: Number(this.withholdingAmount) };
-    }
     this.submitted.emit(dto);
   }
 }

--- a/apps/frontend/src/app/private/modules/store/planillas-rutas/interfaces/planilla.interface.ts
+++ b/apps/frontend/src/app/private/modules/store/planillas-rutas/interfaces/planilla.interface.ts
@@ -324,9 +324,24 @@ export interface ConfirmRouteSheetDto {
   scan_result?: RouteSheetScanResult;
 }
 
-/** `POST /scan/confirm` → settlement summary returned by the backend. */
+/**
+ * `POST /scan/confirm` → idempotent settlement summary returned by the backend.
+ *
+ * The endpoint no longer throws 400 for already-settled stops; instead it
+ * reconciles them into `skipped`. `settled` are the stops settled in this call,
+ * `errors` are per-stop failures, and `route` is the fully-updated route (same
+ * shape as `GET /store/dispatch-routes/:id`) so the caller can refresh without
+ * a second round-trip.
+ */
 export interface ConfirmRouteSheetResult {
   route_id: number;
   planilla_pdf_key: string;
   settled: Array<{ stop_id: number; result: string }>;
+  skipped: Array<{
+    stop_id: number;
+    reason: 'not_in_route' | 'already_settled';
+  }>;
+  errors: Array<{ stop_id: number; message: string }>;
+  /** Fully-updated route, same shape as `GET /store/dispatch-routes/:id`. */
+  route: DispatchRoute;
 }

--- a/apps/frontend/src/app/private/modules/store/planillas-rutas/pages/planilla-detail-page/planilla-detail-page.component.ts
+++ b/apps/frontend/src/app/private/modules/store/planillas-rutas/pages/planilla-detail-page/planilla-detail-page.component.ts
@@ -312,7 +312,7 @@ type StopCollectionState = 'prepaid' | 'collected' | 'pending_cod' | 'none';
         [isOpen]="showScannerModal()"
         [route]="route()"
         (closed)="showScannerModal.set(false)"
-        (confirmed)="onScanConfirmed()"
+        (confirmed)="onScanConfirmed($event)"
       ></app-route-sheet-scanner-modal>
     }
 
@@ -922,10 +922,19 @@ export class PlanillaDetailPageComponent {
     this.showScannerModal.set(true);
   }
 
-  /** After a scan-confirm settlement, refresh the route to reflect new stops. */
-  onScanConfirmed() {
+  /**
+   * After a scan-confirm settlement, refresh the route. The scanner returns the
+   * fully-updated route in the `/scan/confirm` response, so we apply it directly
+   * and avoid a second GET round-trip. Falls back to a reload if absent.
+   */
+  onScanConfirmed(route?: DispatchRoute) {
     this.showScannerModal.set(false);
-    this.load();
+    if (route) {
+      this.route.set(route);
+      this.service.invalidateStatsCache();
+    } else {
+      this.load();
+    }
   }
 
   /** Routes the documental/AI options-dropdown actions to their handlers. */

--- a/apps/frontend/src/app/shared/components/dropdown/dropdown.component.ts
+++ b/apps/frontend/src/app/shared/components/dropdown/dropdown.component.ts
@@ -1,7 +1,10 @@
 import {
   Component,
+  DestroyRef,
   ElementRef,
   HostListener,
+  effect,
+  inject,
   output,
   signal,
   viewChild,
@@ -14,6 +17,7 @@ import {
   template: `
     <div class="relative inline-block text-left" #root>
       <button
+        #trigger
         type="button"
         class="inline-flex w-full justify-center gap-x-1.5 rounded-md bg-[var(--color-background)] px-3 py-2 text-sm font-semibold text-[var(--color-text-primary)] shadow-sm ring-1 ring-inset ring-[var(--color-border)] hover:bg-[var(--color-surface)]"
         (click)="toggle($event)"
@@ -22,9 +26,18 @@ import {
       </button>
 
       @if (open()) {
+        <!--
+          Panel anchored with position: fixed against the trigger rect so it
+          escapes any ancestor with overflow:hidden (e.g. .table-container).
+          Coordinates are recomputed on open and on window scroll/resize.
+        -->
         <div
-          class="absolute right-0 z-50 mt-2 w-56 origin-top-right rounded-md bg-[var(--color-background)] shadow-lg ring-1 ring-[var(--color-border)] focus:outline-none"
+          #panel
+          class="fixed z-[10000] w-56 origin-top-right rounded-md bg-[var(--color-background)] shadow-lg ring-1 ring-[var(--color-border)] focus:outline-none"
           role="menu"
+          [style.top.px]="panelTop()"
+          [style.left.px]="panelLeft()"
+          [style.visibility]="positioned() ? 'visible' : 'hidden'"
         >
           <div class="py-1" role="none">
             <ng-content select="[dropdown-item]"></ng-content>
@@ -37,27 +50,121 @@ import {
 export class DropdownComponent {
   open = signal(false);
   readonly isOpenChange = output<boolean>();
+
   readonly rootRef = viewChild.required<ElementRef<HTMLElement>>('root');
+  readonly triggerRef = viewChild.required<ElementRef<HTMLButtonElement>>('trigger');
+  readonly panelRef = viewChild<ElementRef<HTMLElement>>('panel');
+
+  private readonly destroyRef = inject(DestroyRef);
+
+  /** Fixed-position coordinates (viewport space) computed from the trigger rect. */
+  readonly panelTop = signal(0);
+  readonly panelLeft = signal(0);
+  /** Hidden until measured so the panel never flashes at (0,0). */
+  readonly positioned = signal(false);
+
+  /** Panel width matches the `w-56` Tailwind class (14rem = 224px). */
+  private readonly panelWidth = 224;
+  /** Estimated panel height to decide up/down flip before it is rendered. */
+  private readonly panelEstimatedHeight = 240;
+  /** Gap between trigger and panel, mirroring the previous `mt-2`. */
+  private readonly gap = 8;
+
+  /** Bound reference so the same listener can be added and removed. */
+  private readonly reposition = (): void => this.updatePosition();
+
+  constructor() {
+    // Manage scroll/resize listeners reactively based on open state, and
+    // re-measure when the panel element appears in the DOM. Depending on
+    // panelRef() (the viewChild signal) makes this effect re-run once the
+    // @if renders the panel, so the height-based up/down flip uses the real
+    // measured height instead of the estimate.
+    effect((onCleanup) => {
+      if (!this.open()) return;
+      // Read panelRef so the effect re-runs when the panel mounts.
+      this.panelRef();
+      this.updatePosition();
+      window.addEventListener('scroll', this.reposition, true);
+      window.addEventListener('resize', this.reposition);
+      onCleanup(() => {
+        window.removeEventListener('scroll', this.reposition, true);
+        window.removeEventListener('resize', this.reposition);
+      });
+    });
+
+    // Safety net: ensure listeners are gone if the component is destroyed
+    // while open (effect cleanup already covers normal close paths).
+    this.destroyRef.onDestroy(() => {
+      window.removeEventListener('scroll', this.reposition, true);
+      window.removeEventListener('resize', this.reposition);
+    });
+  }
 
   toggle(event?: MouseEvent) {
     event?.stopPropagation();
-    this.open.set(!this.open());
-    this.isOpenChange.emit(this.open());
+    const next = !this.open();
+    if (next) {
+      // Reset measurement state; the open effect (re-)positions the panel
+      // once the @if renders it, keeping it hidden until measured.
+      this.positioned.set(false);
+    }
+    this.open.set(next);
+    this.isOpenChange.emit(next);
   }
 
   close() {
     if (this.open()) {
       this.open.set(false);
+      this.positioned.set(false);
       this.isOpenChange.emit(false);
     }
   }
 
+  /**
+   * Anchors the fixed panel to the trigger using getBoundingClientRect().
+   * Right-aligns the panel to the trigger (matching the previous `right-0`)
+   * and flips above the trigger when there is not enough space below,
+   * mirroring the drop-up logic in `selector.component.ts`.
+   */
+  private updatePosition(): void {
+    const trigger = this.triggerRef()?.nativeElement;
+    if (!trigger) return;
+
+    const rect = trigger.getBoundingClientRect();
+    const viewportHeight = typeof window !== 'undefined' ? window.innerHeight : 0;
+    const viewportWidth = typeof window !== 'undefined' ? window.innerWidth : 0;
+
+    const panelEl = this.panelRef()?.nativeElement;
+    const measuredHeight = panelEl?.offsetHeight || this.panelEstimatedHeight;
+
+    const spaceBelow = viewportHeight - rect.bottom;
+    const spaceAbove = rect.top;
+    const openUpward =
+      spaceBelow < measuredHeight + this.gap && spaceAbove > spaceBelow;
+
+    // Right-align panel to the trigger's right edge.
+    let left = rect.right - this.panelWidth;
+    // Clamp inside the viewport with an 8px margin.
+    left = Math.max(8, Math.min(left, viewportWidth - this.panelWidth - 8));
+
+    const top = openUpward
+      ? rect.top - measuredHeight - this.gap
+      : rect.bottom + this.gap;
+
+    this.panelLeft.set(left);
+    this.panelTop.set(top);
+    this.positioned.set(true);
+  }
+
   @HostListener('document:click', ['$event'])
   onDocumentClick(e: MouseEvent) {
+    if (!this.open()) return;
     const root = this.rootRef()?.nativeElement;
-    if (!root) return;
-    if (!root.contains(e.target as Node)) {
-      this.close();
-    }
+    const panel = this.panelRef()?.nativeElement;
+    const target = e.target as Node;
+    // The panel is now portaled in viewport space but still a DOM child of
+    // root; check both so clicks inside the panel don't close it.
+    if (root?.contains(target) || panel?.contains(target)) return;
+    this.close();
   }
 }


### PR DESCRIPTION
## Resumen

Segundo lote de correcciones del flujo de despachos con remisiones (ruta/planilla), enfocado en **sincronización de estados** orden↔remisión y en eliminar los pagos parciales de la ruta.

### 🎯 Prioridad: sincronización de estados (no quedan desactualizados)
- `close()` de la ruta ahora avanza **incondicionalmente** toda orden con parada `delivered` por `shipped → delivered → finished`. Se eliminó el gate `collected` (re-consulta de `remaining_balance`) que dejaba órdenes entregadas atascadas en `shipped`.
- Contrato de estados resultante:
  - `orders.state`: `processing → shipped` (dispatch) `→ delivered` (settle si modo `live`; o `close`) `→ finished` (close).
  - `dispatch_notes.status`: `draft → confirmed` (dispatch) `→ delivered` (settle).
  - `delivered ⇒ pagado 100%` (o prepaga). `rejected`/`released` ⇒ la orden NO avanza.

### 🚫 Sin pagos parciales/pendientes en ruta
- `settleStop` rechaza `result='partial'` con `DISPATCH_ROUTE_PARTIAL_DISABLED` (HTTP 400). Resultados válidos: `delivered`, `rejected`, `released`.
- `credit_amount` fijo en 0; `emitCreditSale` con guard `amount>0` (rama de cuentas por cobrar en ruta queda inerte).
- Frontend: el modal de liquidación y el del escáner eliminan "Entrega parcial", crédito y anticipo; "Entregado" exige monto completo.

### 🔁 scan/confirm idempotente (arregla 400 "La parada ya está 'delivered'")
- `confirmAndSettle` reconcilia contra el estado vivo: salta paradas terminales (`already_settled`) y fuera de ruta (`not_in_route`), no aborta el batch ante un fallo, y devuelve `{ settled, skipped, errors, route }`.
- El modal del escáner filtra del payload las paradas ya liquidadas y muestra resumen `Liquidadas / Conciliadas / Errores`.

### 🧾 Retención fiscal (agentes retenedores) preservada
- La eliminación de parciales **no** elimina la retención: para clientes `is_withholding_agent`, el modal de liquidación y el del escáner re-exponen el desglose (retefuente/reteiva/reteica) **solo** para ese segmento. El pago sigue siendo completo (`efectivo + retención = total`), sin cuenta por cobrar. El backend deriva `withholding_amount` de la suma del desglose en el flujo de escáner.

### ✨ Mejoras UX
- Dropdown de acciones (`app-dropdown`) ahora se ancla con `position: fixed` + `getBoundingClientRect()` → ya no lo recorta el `overflow:hidden` del contenedor de la tabla.
- "Ver ruta" desde el detalle de la remisión y desde el modal de confirmación post-generación de remisión.
- Fecha de entrega del wizard de remisión preseteada a HOY (`toLocalDateString`, sin off-by-one).

## Sin migraciones de BD
No se eliminan enums ni columnas. `partial`/`credit_amount`/`anticipo_amount` permanecen en el schema, solo dejan de usarse en el flujo de ruta.

## Verificación
- Backend `tsc -p tsconfig.build.json --noEmit`: 0 errores. Nest arranca limpio.
- Frontend build de producción (AOT): `NG_EXIT=0`, 0 errores.
- Code review (gate 80%): 88/100 → APPROVE; el único hallazgo HIGH (bloqueo de liquidación a agente retenedor) quedó resuelto en este PR.
