### PR TITLE
feat(backend): add system shipping methods seeder

### DIFF
--- a/apps/backend/prisma/seed.ts
+++ b/apps/backend/prisma/seed.ts
@@ -4,6 +4,7 @@ import { seedPermissionsAndRoles } from './seeds/permissions-roles.seed';
 import { seedOrganizationsAndStores } from './seeds/organizations-stores.seed';
 import { seedVendixPlatformOrg } from './seeds/vendix-platform-org.seed';
 import { seedSystemPaymentMethods } from './seeds/system-payment-methods.seed';
+import { seedSystemShippingMethods } from './seeds/system-shipping-methods.seed';
 import { seedLegalDocuments } from './seeds/legal-documents.seed';
 import { seedUsers } from './seeds/users.seed';
 import { seedProductsAndCategories } from './seeds/products-categories.seed';
@@ -60,6 +61,12 @@ const seedModules = [
     name: 'System Payment Methods',
     fn: seedSystemPaymentMethods,
     description: 'System-wide payment methods',
+  },
+  {
+    name: 'System Shipping Methods',
+    fn: seedSystemShippingMethods,
+    description:
+      'System-wide shipping methods (own_fleet, carrier, pickup) that stores can activate',
   },
   {
     name: 'Organizations & Stores',

--- a/apps/backend/prisma/seeds/system-shipping-methods.seed.ts
+++ b/apps/backend/prisma/seeds/system-shipping-methods.seed.ts
@@ -1,0 +1,99 @@
+import { PrismaClient } from '@prisma/client';
+import { getPrismaClient } from './shared/client';
+
+export interface SeedSystemShippingMethodsResult {
+  methodsCreated: number;
+  methodsSkipped: number;
+}
+
+/**
+ * DEPENDENCIES: This seed function has no dependencies.
+ * Can be run independently at any time.
+ *
+ * Creates system-wide shipping methods available to all stores.
+ * Stores activate them via the admin "Activar" button, which copies
+ * the system method into the store's namespace along with any
+ * pre-configured zones and rates.
+ *
+ * Mirrors the production state at `vendix.online` so fresh local
+ * environments (`vendix.com`) have the same starting point.
+ */
+export async function seedSystemShippingMethods(
+  prisma?: PrismaClient,
+): Promise<SeedSystemShippingMethodsResult> {
+  const client = prisma || getPrismaClient();
+
+  // Stable identifiers (lowercase, snake_case). The `name` is what shows
+  // up in the admin UI as the method label; `code` is an optional
+  // short tag for internal use.
+  const systemMethods = [
+    {
+      name: 'Entrega Rápida Local',
+      code: 'own_fleet_local',
+      type: 'own_fleet' as const,
+      description:
+        'Entrega local usando flota propia. Ideal para zonas metropolitanas y entregas dentro de la misma ciudad.',
+      min_days: 0,
+      max_days: 1,
+      transit_time_minutes: 240, // ~4h same-day
+      display_order: 0,
+    },
+    {
+      name: 'Envío Nacional',
+      code: 'national_shipping',
+      type: 'carrier' as const,
+      description:
+        'Envío a nivel nacional mediante transportadora. Tiempo de entrega según la distancia al destino.',
+      min_days: 2,
+      max_days: 15,
+      transit_time_minutes: 0, // depends on destination
+      display_order: 1,
+    },
+    {
+      name: 'Recoger En Tienda',
+      code: 'pickup_in_store',
+      type: 'pickup' as const,
+      description:
+        'El cliente recoge su pedido directamente en la tienda. Sin costo de envío.',
+      min_days: 0,
+      max_days: 1,
+      transit_time_minutes: 0, // instant pickup
+      display_order: 2,
+    },
+  ];
+
+  let methodsCreated = 0;
+  let methodsSkipped = 0;
+
+  for (const method of systemMethods) {
+    // Idempotency: skip if a system method with the same name already exists.
+    // We match on `name` (stable label) and `store_id IS NULL` (system-wide).
+    const existing = await client.shipping_methods.findFirst({
+      where: {
+        name: method.name,
+        store_id: null,
+      },
+      select: { id: true },
+    });
+
+    if (existing) {
+      methodsSkipped++;
+      continue;
+    }
+
+    await client.shipping_methods.create({
+      data: {
+        ...method,
+        is_active: true,
+        is_system: true,
+        store_id: null,
+      },
+    });
+    methodsCreated++;
+  }
+
+  return {
+    methodsCreated,
+    methodsSkipped,
+  };
+}


### PR DESCRIPTION
## Summary

The local test environment (vendix.com) has no system shipping methods in its database. As a result, the admin shows "No hay métodos de envío configurados" and the "+ Agregar Método" modal displays "¡Todos los métodos están activos!" — because the list of available system methods is empty.

Production (vendix.online) has 3 working shipping methods (Entrega Rápida Local, Envío Nacional, Recoger En Tienda) that stores can activate. The local DB has never had these seeded.

## Fix

Adds a new seeder that creates the 3 system shipping methods, mirroring production state. After running the seeder, fresh local environments have the same starting point as production.

## What gets created

| name | type | min_days | max_days | description |
|---|---|---|---|---|
| Entrega Rápida Local | own_fleet | 0 | 1 | Local delivery via own fleet |
| Envío Nacional | carrier | 2 | 15 | National shipping via carrier |
| Recoger En Tienda | pickup | 0 | 1 | Customer picks up in store |

All three are inserted with `is_system: true, store_id: null, is_active: true`. Stores activate them via the existing admin "Activar" button (one-click magic), which copies the method + its zones + its rates into the store's namespace.

## Files

- `apps/backend/prisma/seeds/system-shipping-methods.seed.ts` (new, +91 lines)
- `apps/backend/prisma/seed.ts` (registered the seeder in the runner, +6 lines)

## Verification

### Manual
1. Re-run the seeder to confirm idempotency:
   ```bash
   cd apps/backend
   npx ts-node -e "import {seedSystemShippingMethods} from './prisma/seeds/system-shipping-methods.seed'; seedSystemShippingMethods().then(console.log)"
   # Expected: { methodsCreated: 0, methodsSkipped: 3 }
   ```
2. Open `vendix.com/admin/settings/shipping` — the "+ Agregar Método" modal now lists the 3 system methods.
3. Activate them via the admin (one click each). Each activates the method and copies any system zones and rates.

### Database check
```sql
SELECT name, code, type, min_days, max_days
FROM shipping_methods
WHERE is_system = true AND store_id IS NULL
ORDER BY display_order;
-- Should return 3 rows: Entrega Rápida Local, Envío Nacional, Recoger En Tienda
```

## Edge cases

- **Idempotency:** re-running the seeder is a no-op (3 skipped).
- **Production safety:** production already has these methods (or variants). The `findFirst where name + store_id IS NULL` lookup prevents duplicates regardless of ID differences.
- **Fresh installs:** any new dev/CI environment running `npm run seed` automatically gets these 3 methods.

## Migration

None — this is data-only, no schema change.