### PR TITLE
fix(reviews): 4 bugs in review module

### DIFF
--- a/apps/backend/src/domains/ecommerce/reviews/reviews.service.ts
+++ b/apps/backend/src/domains/ecommerce/reviews/reviews.service.ts
@@ -142,10 +142,13 @@ export class EcommerceReviewsService {
     const context = RequestContextService.getContext()!;
     const user_id = context.user_id!;
 
-    // Check if user has a delivered/finished order with this product
-    // EcommercePrismaService scopes orders by store_id + customer_id automatically
+    // Check if THIS USER has a delivered/finished order with this product.
+    // EcommercePrismaService scopes orders by store_id automatically, but
+    // the user/customer check must be applied here — otherwise ANY delivered
+    // order for the product (from any customer) would validate the review.
     const order = await this.prisma.orders.findFirst({
       where: {
+        user_id,
         state: { in: ['delivered', 'finished'] },
         order_items: { some: { product_id: productId } },
       },

--- a/apps/frontend/src/app/private/modules/store/customers/reviews/reviews.component.ts
+++ b/apps/frontend/src/app/private/modules/store/customers/reviews/reviews.component.ts
@@ -394,6 +394,18 @@ import { formatDateOnlyUTC } from '../../../../../shared/utils/date.util';
             }
           </div>
         </div>
+      } @else {
+        <div class="py-10 text-center text-sm text-gray-500">
+          <div
+            class="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-gray-100"
+          >
+            <app-icon name="alert-circle" [size]="20" class="text-gray-400"></app-icon>
+          </div>
+          <p>No se encontró la reseña solicitada.</p>
+          <p class="mt-1 text-xs text-gray-400">
+            Es posible que haya sido eliminada o que el enlace haya expirado.
+          </p>
+        </div>
       }
     </app-modal>
   `,
@@ -632,11 +644,20 @@ export class ReviewsComponent {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (res) => {
-          this.reviews.set(res.data || []);
-          if (res.meta) {
-            this.totalItems.set(res.meta.total || 0);
-            this.totalPages.set(
-              res.meta.totalPages || res.meta.total_pages || 0,
+          // Support both response shapes: { data: [...] } and
+          // { data: { items: [...] } }. Some backends wrap the list
+          // inside an items object for pagination metadata.
+          const payload = res?.data;
+          const items = Array.isArray(payload)
+            ? payload
+            : Array.isArray(payload?.items)
+            ? payload.items
+            : [];
+          this.reviews.set(items);
+          const meta = res?.meta ?? payload?.meta;
+          if (meta) {
+            this.totalItems.set(meta.total || 0);
+            this.totalPages.set(meta.totalPages || meta.total_pages || 0,
             );
             this.currentPage.set(res.meta.page || 1);
           }
@@ -760,7 +781,10 @@ export class ReviewsComponent {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (res) => {
-          this.selectedReview.set(res.data || res);
+          // Support both response shapes: { data: {...} } and a flat
+          // response object. Pick whichever has the review fields.
+          const candidate = res?.data ?? res;
+          this.selectedReview.set(candidate?.id ? candidate : null);
           this.detailLoading.set(false);
         },
         error: (error) => {


### PR DESCRIPTION
## Summary

Four bugs in the reviews module (e-commerce customer + admin):

1. **Verified purchase check bypassed** — any customer could leave a
   review of a product even if they hadn't purchased it. The backend
   query for "can review" was missing the `user_id` filter, so any
   delivered order for the product (from any customer) would validate
   the review.

2. **Admin reviews list empty** — even with 2 pending + 1 approved
   reviews in the database, the admin /admin/customers/reviews list
   rendered "No hay reseñas para mostrar". The frontend response
   handler assumed the list was always a top-level array, but the
   backend sometimes wraps paginated responses inside
   `{ data: { items: [...] } }`.

3. **Notification link broken** — clicking a "Nueva Reseña"
   notification did not navigate to the review detail. The route
   itself was correct (`/admin/customers/reviews?review_id=X`), but
   the empty list (Bug 2) meant `watchRouteReviewId()` could not
   find the review to open the modal. Resolved by Bug 2 fix.

4. **Review detail modal blank** — when a review could not be
   resolved (e.g. because the GET request failed or the response
   shape didn't match), the modal opened with no content. Added a
   friendly fallback message and a more robust response handler
   that validates `.id` before setting the review signal.

## Files

- `apps/backend/src/domains/ecommerce/reviews/reviews.service.ts`
  - `canReview()` now filters orders by `user_id` (was missing).
- `apps/frontend/src/app/private/modules/store/customers/reviews/reviews.component.ts`
  - `loadReviews()` accepts both `res.data` and `res.data.items`
    response shapes.
  - `openDetailById()` validates the response has `.id` before
    setting the review signal.
  - Modal template gets a fallback `@else` block with a friendly
    "not found" message.

## Verification

### Manual
1. **Verified purchase:** log in as a customer who has never bought
   a product. Try to leave a review → should fail with
   `REV_PURCHASE_001`.
2. **Admin list:** reload `/admin/customers/reviews` → the 2
   pending + 1 approved reviews should appear.
3. **Notification:** click a review notification → navigates to the
   review detail with content.
4. **Modal:** the detail modal shows the rating, comment, product
   info, and action buttons.

### Edge cases
- Reviews are NOT auto-approved (state defaults to `pending` per
  the schema, see `reviews.state @default(pending)` in
  `schema.prisma`).
- Backend logs are clean after the changes.

## Migration

None — code-only fix, no schema or data changes.

## Related

This PR does not address the upstream test-seeder state where 3
test reviews are seeded with `state: 'approved'` (those are
intentional for development).