### PR TITLE
fix(pqr): desbloquear build de deploy — requester_email undefined (TS2322)

### DIFF
--- a/apps/backend/src/domains/support/pqr/pqr.service.ts
+++ b/apps/backend/src/domains/support/pqr/pqr.service.ts
@@ -893,7 +893,7 @@ export class PqrService {
         description: ticket.description,
         comment_content: dto.resolution_summary || '',
         author_name: 'Equipo Vendix',
-        requester_email: ticket.requester_email ?? null,
+        requester_email: ticket.requester_email ?? undefined,
         requester_name:
           (ticket.requester_first_name ?? '') +
           ' ' +
@@ -1120,7 +1120,7 @@ export class PqrService {
         comment_content: dto.content,
         author_name: authorName,
         new_status: ticket.status,
-        requester_email: ticket.requester_email ?? null,
+        requester_email: ticket.requester_email ?? undefined,
         requester_name:
           (ticket.requester_first_name ?? '') +
           ' ' +


### PR DESCRIPTION
## Resumen
Hotfix del build de deploy del backend (`nest build` / tsc) que falló tras mergear #384 a `main`.

`ticket.requester_email` es `string | null`, pero el evento `PqrResponseSentEvent` espera `string | undefined`. El `?? null` producía `null` → **TS2322** en el typecheck del build de producción (2 ocurrencias en `pqr.service.ts`). El dev-watch usa SWC (no typechequea), por eso el error quedó latente desde #380.

**Fix:** `?? null` → `?? undefined`.

## Verificación
- `npx nest build` (apps/backend) → **EXIT 0**, 0 errores.
- Sin migraciones. Solo cambio de tipos.

> Merge con `--admin` para re-disparar el workflow `deploy-backend-ec2`.