### PR TITLE
fix(promotions): resolver TS2304 que rompía el build de backend en deploy

### DIFF
--- a/apps/backend/src/domains/store/promotions/promotions.service.ts
+++ b/apps/backend/src/domains/store/promotions/promotions.service.ts
@@ -6,6 +6,14 @@ import { VendixHttpException, ErrorCodes } from 'src/common/errors';
 import { CreatePromotionDto } from './dto/create-promotion.dto';
 import { UpdatePromotionDto } from './dto/update-promotion.dto';
 import { QueryPromotionsDto } from './dto/query-promotions.dto';
+import { QuantityTierDto } from './dto/quantity-tier.dto';
+
+/**
+ * Tipo de regla de promoción. Alias local (igual que en
+ * promotion-engine.service.ts): 'flat' = descuento único; 'quantity_tiered' =
+ * cortes por volumen definidos en quantity_tiers.
+ */
+type PromotionRuleType = 'flat' | 'quantity_tiered';
 
 @Injectable()
 export class PromotionsService {


### PR DESCRIPTION
## Summary
Hotfix del build de producción del backend: `promotions.service.ts` usaba `PromotionRuleType` y `QuantityTierDto` sin importarlos/definirlos → 7 errores TS2304 en `nest build` que hicieron fallar el step *Build/push Docker to ECR* del deploy a EC2 (run del merge #390).

Fix: import de `QuantityTierDto` desde `./dto/quantity-tier.dto` + alias local `type PromotionRuleType = 'flat' | 'quantity_tiered'` (igual que en `promotion-engine.service.ts`).

Sin migraciones. Typecheck `tsc -p tsconfig.build.json` limpio localmente.