### PR TITLE
feat(onboarding): onboarding de owner ineludible + fix zoneless MONEDA + gate reporte semanal

### DIFF
--- a/apps/backend/src/domains/organization/onboarding/onboarding-wizard.controller.ts
+++ b/apps/backend/src/domains/organization/onboarding/onboarding-wizard.controller.ts
@@ -22,9 +22,18 @@ import { SetupAppConfigWizardDto } from './dto/setup-app-config-wizard.dto';
 import { SelectAppTypeDto } from './dto/select-app-type.dto';
 import { ResponseService } from '@common/responses/response.service';
 import { AuthenticatedRequest } from '@common/interfaces/authenticated-request.interface';
+import { AllowCrossDomain } from '@common/decorators/allow-cross-domain.decorator';
 
 @ApiTags('Onboarding Wizard')
 @ApiBearerAuth()
+// Onboarding is a domain-transition surface: an owner who picked the
+// single-commerce (STORE) path has `user_settings.app_type = STORE_ADMIN`, so on
+// re-login their JWT is STORE_ADMIN-scoped. Without this, DomainScopeGuard would
+// 403 every wizard call (endpoints live under /organization/*), locking the
+// owner out of *finishing* onboarding (status/select-app-type/setup-*/complete
+// all fail). @AllowCrossDomain skips ONLY domain isolation; PermissionsGuard and
+// the service-level owner checks stay active.
+@AllowCrossDomain()
 @Controller('organization/onboarding-wizard')
 export class OnboardingWizardController {
   constructor(

--- a/apps/backend/src/domains/store/weekly-report/weekly-report.service.ts
+++ b/apps/backend/src/domains/store/weekly-report/weekly-report.service.ts
@@ -24,6 +24,16 @@ const COMPLETED_ORDER_STATES = ['delivered', 'finished'];
 const RECEIVED_PO_STATUS = 'received';
 const COLOMBIA_OFFSET_MIN = -5 * 60;
 
+// Un comercio recién creado NO debe recibir "Tu Semana en Vendix" hasta
+// superar el periodo de prueba (15 días) + su primera semana completa de
+// operación. Antes de eso el reporte sólo tendría ceros y confunde a un
+// negocio que apenas arranca. Primer reporte posible: a los 22 días de creado.
+const TRIAL_PERIOD_DAYS = 15;
+const FIRST_REPORT_GRACE_DAYS = 7;
+const MIN_STORE_AGE_DAYS_FOR_WEEKLY_REPORT =
+  TRIAL_PERIOD_DAYS + FIRST_REPORT_GRACE_DAYS; // 22
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+
 @Injectable()
 export class WeeklyReportService {
   private readonly logger = new Logger(WeeklyReportService.name);
@@ -46,11 +56,28 @@ export class WeeklyReportService {
 
     const store = await this.prisma.stores.findFirst({
       where: { id: store_id, is_active: true },
-      select: { id: true, name: true },
+      select: { id: true, name: true, created_at: true },
     });
     if (!store) {
       this.logger.warn(
         `Store ${store_id} is not active or not found, skipping weekly report`,
+      );
+      return null;
+    }
+
+    // Gate de antigüedad: un comercio debe superar el trial (15d) + su primera
+    // semana (7d) antes de recibir su primer reporte semanal. Este es el único
+    // punto de creación de snapshots, así que cubre tanto el cron como la
+    // regeneración on-demand desde el dashboard (getLatestForCurrentStore).
+    // Si no hay created_at (dato anómalo), se omite por seguridad ("jamás
+    // antes de tiempo").
+    const ageDays = store.created_at
+      ? (now.getTime() - store.created_at.getTime()) / MS_PER_DAY
+      : -1;
+    if (ageDays < MIN_STORE_AGE_DAYS_FOR_WEEKLY_REPORT) {
+      this.logger.log(
+        `Store ${store_id} is ${ageDays < 0 ? 'unknown' : ageDays.toFixed(1)}d old ` +
+          `(< ${MIN_STORE_AGE_DAYS_FOR_WEEKLY_REPORT}d), skipping weekly report`,
       );
       return null;
     }
@@ -162,6 +189,21 @@ export class WeeklyReportService {
     const store_id = context?.store_id;
     if (!store_id) {
       throw new NotFoundException('Store context required');
+    }
+
+    // Gate de antigüedad también al SERVIR: aunque `generateForStore` ya impide
+    // crear snapshots para comercios jóvenes, un snapshot heredado (creado antes
+    // de este gate) no debe mostrarse. Un comercio con menos de 22 días (trial
+    // 15d + primera semana 7d) nunca ve el reporte, aunque exista el registro.
+    const store = await this.prisma.stores.findFirst({
+      where: { id: store_id },
+      select: { created_at: true },
+    });
+    const ageDays = store?.created_at
+      ? (Date.now() - store.created_at.getTime()) / MS_PER_DAY
+      : -1;
+    if (ageDays < MIN_STORE_AGE_DAYS_FOR_WEEKLY_REPORT) {
+      return null;
     }
 
     const window = getClosedWeekWindow();

--- a/apps/frontend/src/app/core/guards/onboarding.guard.ts
+++ b/apps/frontend/src/app/core/guards/onboarding.guard.ts
@@ -1,0 +1,38 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router, UrlTree } from '@angular/router';
+
+import { AuthFacade } from '../store/auth/auth.facade';
+
+/**
+ * Owner onboarding gate.
+ *
+ * Forces OWNER accounts whose organization onboarding is not yet completed
+ * onto the dedicated `/admin/onboarding` page, and keeps everyone else out of
+ * it. The validated flag is `organizations.onboarding` (the account/owner
+ * flag), never `stores.onboarding`.
+ *
+ * Pure and side-effect free: returns `true` when the route may activate, or a
+ * `UrlTree` redirect otherwise (no navigation is triggered imperatively).
+ */
+export const onboardingGuard: CanActivateFn = (
+  _route,
+  state,
+): boolean | UrlTree => {
+  const auth = inject(AuthFacade);
+  const router = inject(Router);
+
+  const isOwner = auth.hasAnyRole(['owner', 'OWNER']);
+  const done = auth.getCurrentUser()?.organizations?.onboarding === true;
+  const onOnb = state.url.includes('/admin/onboarding');
+
+  // Non-owners, and owners who already finished onboarding, must never see the
+  // onboarding page. Bounce them to the dashboard if they land on it; allow
+  // any other admin route through.
+  if (!isOwner || done) {
+    return onOnb ? router.parseUrl('/admin/dashboard') : true;
+  }
+
+  // Owner with pending onboarding: allow the onboarding page and force every
+  // other admin route onto it.
+  return onOnb ? true : router.parseUrl('/admin/onboarding');
+};

--- a/apps/frontend/src/app/private/layouts/organization-admin/organization-admin-layout.component.ts
+++ b/apps/frontend/src/app/private/layouts/organization-admin/organization-admin-layout.component.ts
@@ -4,7 +4,6 @@ import {
   inject,
   signal,
   computed,
-  DestroyRef,
 } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import {
@@ -13,8 +12,6 @@ import {
 } from '../../../shared/components/sidebar/sidebar.component';
 import { HeaderComponent } from '../../../shared/components/header/header.component';
 import { AuthFacade } from '../../../core/store/auth/auth.facade';
-import { OnboardingWizardService } from '../../../core/services/onboarding-wizard.service';
-import { OnboardingModalComponent } from '../../../shared/components/onboarding-modal';
 // S1.2 — SubscriptionBannerComponent removed from ORG_ADMIN. The banner is
 // store-scoped only; org-level renders would either flash stale data or show
 // the wrong tienda's status.
@@ -23,7 +20,7 @@ import { FiscalObligationBannerComponent } from '../../../shared/components/fisc
 import { MenuFilterService } from '../../../core/services/menu-filter.service';
 
 import { map } from 'rxjs/operators';
-import { toSignal, takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { toSignal } from '@angular/core/rxjs-interop';
 
 import { ConfigFacade } from '../../../core/store/config';
 
@@ -44,7 +41,6 @@ import { ToastService } from '../../../shared/components/toast/toast.service';
     RouterModule,
     SidebarComponent,
     HeaderComponent,
-    OnboardingModalComponent,
     PaywallOutletComponent,
     FiscalObligationBannerComponent,
   ],
@@ -97,15 +93,6 @@ import { ToastService } from '../../../shared/components/toast/toast.service';
       </div>
     </div>
 
-    <!-- Onboarding Modal - Only render if onboarding is needed -->
-    @if (needsOnboarding()) {
-      <app-onboarding-modal
-        [isOpen]="showOnboardingModal()"
-        (isOpenChange)="showOnboardingModal.set($event)"
-        (completed)="onOnboardingCompleted($event)"
-      ></app-onboarding-modal>
-    }
-
     <!-- Subscription paywall (driven by interceptor + access service) -->
     <app-paywall-outlet />
   `,
@@ -114,9 +101,7 @@ import { ToastService } from '../../../shared/components/toast/toast.service';
 export class OrganizationAdminLayoutComponent {
   @ViewChild('sidebarRef') sidebarRef!: SidebarComponent;
 
-  private readonly destroyRef = inject(DestroyRef);
   private readonly authFacade = inject(AuthFacade);
-  private readonly onboardingWizardService = inject(OnboardingWizardService);
   private readonly storesService = inject(OrganizationStoresService);
   private readonly environmentSwitchService = inject(EnvironmentSwitchService);
   private readonly dialogService = inject(DialogService);
@@ -145,15 +130,9 @@ export class OrganizationAdminLayoutComponent {
     ),
     { initialValue: null as string | null },
   );
-  readonly needsOrganizationOnboarding = toSignal(
-    this.authFacade.needsOrganizationOnboarding$,
-    { initialValue: false },
-  );
 
   // --- Local state signals ---
   readonly sidebarCollapsed = signal(false);
-  readonly showOnboardingModal = signal(false);
-  readonly needsOnboarding = signal(false);
   readonly stores = signal<StoreListItem[]>([]);
   readonly isLoadingStores = signal(false);
 
@@ -436,50 +415,8 @@ export class OrganizationAdminLayoutComponent {
   );
 
   constructor() {
-    // Check onboarding status considering both organization state and user role
-    this.checkOnboardingWithRoleValidation();
-
-    // Subscribe to organization onboarding status from user data
-    this.authFacade.needsOrganizationOnboarding$
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((needsOnboarding: boolean) => {
-        this.needsOnboarding.set(needsOnboarding);
-        this.updateOnboardingModal();
-      });
-
     // Load stores for sidebar
     this.loadStores();
-  }
-
-  private checkOnboardingWithRoleValidation(): void {
-    const isOwner = this.authFacade.isOwner();
-    if (!isOwner) {
-      this.needsOnboarding.set(false);
-      this.showOnboardingModal.set(false);
-      return;
-    }
-
-    const currentUser = this.authFacade.getCurrentUser();
-    const organizationOnboarding = currentUser?.organizations?.onboarding;
-
-    this.needsOnboarding.set(!organizationOnboarding);
-    this.updateOnboardingModal();
-  }
-
-  private updateOnboardingModal(): void {
-    const isOwner = this.authFacade.isOwner();
-    if (!isOwner) {
-      this.showOnboardingModal.set(false);
-      return;
-    }
-
-    const currentUser = this.authFacade.getCurrentUser();
-    const organizationOnboarding = currentUser?.organizations?.onboarding;
-    const actuallyNeedsOnboarding = !organizationOnboarding;
-
-    this.showOnboardingModal.set(
-      actuallyNeedsOnboarding && this.needsOnboarding(),
-    );
   }
 
   loadStores(): void {
@@ -607,10 +544,5 @@ export class OrganizationAdminLayoutComponent {
     } else {
       this.sidebarCollapsed.update((v) => !v);
     }
-  }
-
-  onOnboardingCompleted(event: any): void {
-    this.authFacade.setOnboardingCompleted(true);
-    this.authFacade.loadUser();
   }
 }

--- a/apps/frontend/src/app/private/layouts/store-admin/store-admin-layout.component.ts
+++ b/apps/frontend/src/app/private/layouts/store-admin/store-admin-layout.component.ts
@@ -22,7 +22,6 @@ import { HeaderComponent } from '../../../shared/components/header/header.compon
 import { IconComponent } from '../../../shared/components/icon/icon.component';
 import { AuthFacade } from '../../../core/store/auth/auth.facade';
 import { ConfigFacade } from '../../../core/store/config';
-import { OnboardingModalComponent } from '../../../shared/components/onboarding-modal';
 import { TourModalComponent } from '../../../shared/components/tour/tour-modal/tour-modal.component';
 import { TourService } from '../../../shared/components/tour/services/tour.service';
 import { POS_TOUR_CONFIG } from '../../../shared/components/tour/configs/pos-tour.config';
@@ -46,7 +45,6 @@ import { map, distinctUntilChanged, skip, switchMap } from 'rxjs/operators';
     SidebarComponent,
     HeaderComponent,
     IconComponent,
-    OnboardingModalComponent,
     TourModalComponent,
     SubscriptionBannerComponent,
     FiscalObligationBannerComponent,
@@ -182,14 +180,6 @@ import { map, distinctUntilChanged, skip, switchMap } from 'rxjs/operators';
       </div>
     </div>
 
-    <!-- Onboarding Modal - Only render if onboarding is needed -->
-    @if (needsOnboarding()) {
-      <app-onboarding-modal
-        [(isOpen)]="showOnboardingModal"
-        (completed)="onOnboardingCompleted($event)"
-      ></app-onboarding-modal>
-    }
-
     <!-- Weekly Report Takeover (Tu Semana en Vendix) -->
     @if (showWeeklyReportTakeover() && weeklyReportSnapshot(); as wr) {
       <app-weekly-report-stories
@@ -221,8 +211,6 @@ export class StoreAdminLayoutComponent {
   // --- UI state signals ---
   readonly sidebarCollapsed = signal(false);
   readonly sidebarReady = signal(false);
-  readonly showOnboardingModal = signal(false);
-  readonly needsOnboarding = signal(false);
   readonly showTourModal = signal(false);
   readonly sidebarShimmer = signal(false);
 
@@ -943,15 +931,6 @@ export class StoreAdminLayoutComponent {
         }, 950);
       });
 
-    // Onboarding needs subscription
-    this.authFacade.needsOnboarding$
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe(() => {
-        this.needsOnboarding.set(false); // Temporalmente deshabilitado hasta desarrollar workflow
-        this.updateOnboardingModal();
-      });
-
-    this.checkOnboardingWithRoleValidation();
     this.checkAndStartPosTour();
 
     // S1.2 — Notify the subscription feature about store-context changes
@@ -974,40 +953,28 @@ export class StoreAdminLayoutComponent {
    */
   private checkAndStartPosTour(): void {
     const tourId = 'pos-first-sale';
+
+    // Gate: the welcome/POS tour is an OWNER-only, post-onboarding flow.
+    // - It must NEVER overlay the onboarding wizard. An owner with pending
+    //   onboarding is held on /admin/onboarding by onboardingGuard, but this
+    //   STORE_ADMIN layout still mounts underneath the overlay and would
+    //   otherwise fire the tour on top of it.
+    // - It must NEVER reach a non-owner (store staff share this layout).
+    // Mirrors onboardingGuard exactly: owner = hasAnyRole(['owner','OWNER']),
+    // done = organizations.onboarding === true (fail-closed when the flag is
+    // absent, so an unknown state never leaks the tour).
+    const isOwner = this.authFacade.hasAnyRole(['owner', 'OWNER']);
+    const onboardingDone =
+      this.authFacade.getCurrentUser()?.organizations?.onboarding === true;
+    if (!isOwner || !onboardingDone) {
+      return;
+    }
+
     if (this.tourService.canShowTour(tourId)) {
       setTimeout(() => {
         this.showTourModal.set(true);
       }, 1500);
     }
-  }
-
-  private checkOnboardingWithRoleValidation(): void {
-    const isOwner = this.authFacade.isOwner();
-    if (!isOwner) {
-      this.needsOnboarding.set(false);
-      this.showOnboardingModal.set(false);
-      return;
-    }
-
-    // this.needsOnboarding.set(!storeOnboarding);
-    this.needsOnboarding.set(false); // Temporalmente deshabilitado hasta desarrollar workflow
-    this.updateOnboardingModal();
-  }
-
-  private updateOnboardingModal(): void {
-    const isOwner = this.authFacade.isOwner();
-    if (!isOwner) {
-      this.showOnboardingModal.set(false);
-      return;
-    }
-
-    const currentUser = this.authFacade.getCurrentUser();
-    const storeOnboarding = currentUser?.stores?.onboarding;
-    const actuallyNeedsOnboarding = !storeOnboarding;
-
-    this.showOnboardingModal.set(
-      actuallyNeedsOnboarding && this.needsOnboarding(),
-    );
   }
 
   toggleSidebar() {
@@ -1016,10 +983,5 @@ export class StoreAdminLayoutComponent {
     } else {
       this.sidebarCollapsed.update((v) => !v);
     }
-  }
-
-  onOnboardingCompleted(event: any): void {
-    this.authFacade.setOnboardingCompleted(true);
-    this.authFacade.loadUser();
   }
 }

--- a/apps/frontend/src/app/private/pages/onboarding/onboarding-page.component.ts
+++ b/apps/frontend/src/app/private/pages/onboarding/onboarding-page.component.ts
@@ -1,0 +1,117 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { Router } from '@angular/router';
+
+import { OnboardingModalComponent } from '../../../shared/components/onboarding-modal';
+import { IconComponent } from '../../../shared/components/icon/icon.component';
+import { AuthFacade } from '../../../core/store/auth/auth.facade';
+
+/**
+ * Dedicated full-screen host for the owner onboarding wizard.
+ *
+ * Route: `/admin/onboarding` (child of the private `admin` shell in both the
+ * org and store admin route trees). Reached only when `onboardingGuard`
+ * decides an OWNER still has `organizations.onboarding !== true`.
+ *
+ * This host owns no business logic: it renders the reusable
+ * `OnboardingModalComponent` non-cancelable and always open. The wizard's
+ * `completeWizard()` already performs the environment switch and navigation,
+ * so this component only refreshes the current user on completion and keeps a
+ * defensive navigation fallback.
+ *
+ * Because the host is a top-most overlay (`--z-modal-overlay`), it deliberately
+ * covers the app chrome — including the sidebar/header logout control. To avoid
+ * trapping the owner, it surfaces its own "Cerrar sesión" affordance. Logging
+ * out is NOT an onboarding bypass: `onboardingGuard` re-forces the wizard on the
+ * next login, and the wizard resumes from the backend-persisted step.
+ */
+@Component({
+  selector: 'app-onboarding-page',
+  standalone: true,
+  imports: [OnboardingModalComponent, IconComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="onboarding-page-host">
+      <app-onboarding-modal
+        [isOpen]="true"
+        (completed)="onCompleted()"
+      ></app-onboarding-modal>
+
+      <!-- Escape hatch: the full-screen overlay hides the chrome's logout on
+           purpose, but the owner must never be trapped. Re-login returns here
+           (guard re-forces onboarding), so this is not a bypass. -->
+      <button type="button" class="onboarding-logout" (click)="onLogout()">
+        <app-icon name="logout" size="16"></app-icon>
+        <span>Cerrar sesión</span>
+      </button>
+    </div>
+  `,
+  styles: [
+    `
+      .onboarding-page-host {
+        position: fixed;
+        inset: 0;
+        /* Top-most "cover everything" tier (above sidebar 30, header 35,
+         * modals 50, toasts 70, mobile sidebar 55). \`position: fixed\` creates
+         * its own stacking context, so without an explicit high z-index the
+         * chrome (which sets its own z-index) would paint over this host and
+         * the owner could still see/click the shell behind the wizard. This
+         * makes the onboarding a real full-screen, unavoidable overlay. */
+        z-index: var(--z-modal-overlay);
+        overflow-y: auto;
+        background-color: var(--background);
+      }
+
+      .onboarding-logout {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        /* Above the wizard modal, which renders at z-[9999] inside this host's
+         * stacking context, so the logout affordance stays clickable. */
+        z-index: calc(var(--z-modal-overlay) + 1);
+        display: inline-flex;
+        align-items: center;
+        gap: 0.375rem;
+        padding: 0.5rem 0.75rem;
+        font-size: 0.8125rem;
+        font-weight: 500;
+        color: var(--color-text-secondary);
+        background-color: var(--color-surface, var(--background));
+        border: 1px solid var(--color-border, rgba(0, 0, 0, 0.1));
+        border-radius: 0.5rem;
+        cursor: pointer;
+        transition:
+          color 0.15s ease,
+          border-color 0.15s ease;
+      }
+
+      .onboarding-logout:hover {
+        color: var(--color-text);
+        border-color: var(--color-primary);
+      }
+    `,
+  ],
+})
+export class OnboardingPageComponent {
+  private readonly auth = inject(AuthFacade);
+  private readonly router = inject(Router);
+
+  onCompleted(): void {
+    // Refresh /auth/me so `organizations.onboarding` reflects the completed
+    // state for the guard. The modal already handles the env-switch +
+    // navigation, so we do NOT duplicate aggressive navigation here.
+    this.auth.refreshUser();
+
+    // Defensive fallback only: if the env-switch failed to move us, don't
+    // strand the owner on the onboarding page.
+    if (this.router.url.includes('/admin/onboarding')) {
+      this.router.navigateByUrl('/admin/dashboard');
+    }
+  }
+
+  onLogout(): void {
+    // Clean, explicit logout (toast + session teardown + redirect handled by
+    // SessionService). Re-login re-triggers `onboardingGuard`, which brings the
+    // owner straight back to the wizard resumed at the persisted step.
+    this.auth.logout();
+  }
+}

--- a/apps/frontend/src/app/routes/private/org_admin.routes.ts
+++ b/apps/frontend/src/app/routes/private/org_admin.routes.ts
@@ -1,6 +1,7 @@
 import { Routes } from '@angular/router';
 import { AuthGuard } from '../../core/guards/auth.guard';
 import { fiscalManagementGuard } from '../../core/guards/fiscal-management.guard';
+import { onboardingGuard } from '../../core/guards/onboarding.guard';
 
 export const orgAdminRoutes: Routes = [
   {
@@ -9,12 +10,27 @@ export const orgAdminRoutes: Routes = [
       import('../../private/layouts/organization-admin/organization-admin-layout.component').then(
         (c) => c.OrganizationAdminLayoutComponent,
       ),
-    canActivate: [AuthGuard],
+    canActivate: [AuthGuard, onboardingGuard],
+    // canActivateChild re-runs onboardingGuard on EVERY child navigation
+    // (including sibling→sibling SPA nav where the parent `admin` stays
+    // mounted and its canActivate would NOT re-fire). This is what makes the
+    // owner onboarding truly unavoidable, not just on hard reload.
+    canActivateChild: [onboardingGuard],
     children: [
       {
         path: '',
         pathMatch: 'full',
         redirectTo: 'dashboard',
+      },
+      // Owner onboarding host — gated by `onboardingGuard` on the `admin`
+      // root. Only an OWNER with `organizations.onboarding !== true` ever
+      // resolves here; everyone else is bounced to the dashboard.
+      {
+        path: 'onboarding',
+        loadComponent: () =>
+          import('../../private/pages/onboarding/onboarding-page.component').then(
+            (m) => m.OnboardingPageComponent,
+          ),
       },
       {
         path: 'dashboard',

--- a/apps/frontend/src/app/routes/private/store_admin.routes.ts
+++ b/apps/frontend/src/app/routes/private/store_admin.routes.ts
@@ -3,6 +3,7 @@ import { provideState } from '@ngrx/store';
 import { provideEffects } from '@ngrx/effects';
 import { AuthGuard } from '../../core/guards/auth.guard';
 import { fiscalManagementGuard } from '../../core/guards/fiscal-management.guard';
+import { onboardingGuard } from '../../core/guards/onboarding.guard';
 import { subscriptionManagementGuard } from '../../core/guards/subscription-management.guard';
 import { manageUsersGuard } from '../../core/guards/manage-users.guard';
 import { invoicingReducer } from '../../private/modules/store/invoicing/state/reducers/invoicing.reducer';
@@ -21,12 +22,27 @@ export const storeAdminRoutes: Routes = [
       import('../../private/layouts/store-admin/store-admin-layout.component').then(
         (c) => c.StoreAdminLayoutComponent,
       ),
-    canActivate: [AuthGuard],
+    canActivate: [AuthGuard, onboardingGuard],
+    // canActivateChild re-runs onboardingGuard on EVERY child navigation
+    // (including sibling→sibling SPA nav where the parent `admin` stays
+    // mounted and its canActivate would NOT re-fire). This is what makes the
+    // owner onboarding truly unavoidable, not just on hard reload.
+    canActivateChild: [onboardingGuard],
     children: [
       {
         path: '',
         pathMatch: 'full',
         redirectTo: 'dashboard',
+      },
+      // Owner onboarding host — gated by `onboardingGuard` on the `admin`
+      // root. Only an OWNER with `organizations.onboarding !== true` ever
+      // resolves here; everyone else is bounced to the dashboard.
+      {
+        path: 'onboarding',
+        loadComponent: () =>
+          import('../../private/pages/onboarding/onboarding-page.component').then(
+            (m) => m.OnboardingPageComponent,
+          ),
       },
       {
         path: 'dashboard',

--- a/apps/frontend/src/app/shared/components/onboarding-modal/onboarding-modal.component.ts
+++ b/apps/frontend/src/app/shared/components/onboarding-modal/onboarding-modal.component.ts
@@ -248,7 +248,7 @@ interface WizardStep {
                     [disabled]="isSubmitting() || isProcessing()"
                     (clicked)="completeWizard()"
                     >
-                    {{ isSubmitting() ? 'Finalizando...' : 'Ir a mi tienda' }}
+                    {{ isSubmitting() ? 'Finalizando...' : 'Ir a mi comercio' }}
                     @if (!isSubmitting()) {
                       <app-icon
                         name="arrow-right"
@@ -380,7 +380,7 @@ export class OnboardingModalComponent {
     {
       id: 1,
       title: '¡Bienvenido a Vendix!',
-      description: 'Vamos a configurar tu tienda',
+      description: 'Vamos a configurar tu comercio',
       icon: 'sparkles',
     },
     {
@@ -397,7 +397,7 @@ export class OnboardingModalComponent {
     },
     {
       id: 4,
-      title: 'Configura tu tienda',
+      title: 'Configura tu comercio',
       description: 'Datos básicos de tu negocio',
       icon: 'store',
     },
@@ -416,7 +416,7 @@ export class OnboardingModalComponent {
     {
       id: 7,
       title: '¡Todo listo!',
-      description: 'Tu tienda está configurada',
+      description: 'Tu comercio está configurado',
       icon: 'check-circle',
     },
   ];
@@ -449,7 +449,7 @@ export class OnboardingModalComponent {
     },
     {
       id: 5,
-      title: 'Configura tu tienda',
+      title: 'Configura tu comercio',
       description: 'Tu punto de venta principal',
       icon: 'store',
     },
@@ -615,7 +615,7 @@ export class OnboardingModalComponent {
             const baseName = orgData.name.replace(/\s+Org$/i, '');
             this.storeForm.patchValue({
               name: baseName,
-              description: `Tienda principal de ${orgData.name}`,
+              description: `Comercio principal de ${orgData.name}`,
               phone: orgData.phone || '',
             });
           }
@@ -737,7 +737,7 @@ export class OnboardingModalComponent {
           this.storeForm.patchValue(
             {
               name: baseName,
-              description: `Tienda principal de ${orgData.name}`,
+              description: `Comercio principal de ${orgData.name}`,
               phone: orgData.phone || '',
             },
             { emitEvent: false },
@@ -1080,7 +1080,7 @@ export class OnboardingModalComponent {
         this.storeForm.get(key)?.markAsTouched();
       });
       this.toastService.warning(
-        'Por favor completa los campos requeridos de la tienda',
+        'Por favor completa los campos requeridos del comercio',
       );
       this.isProcessing.set(false);
       return;
@@ -1125,12 +1125,12 @@ export class OnboardingModalComponent {
         this.isProcessing.set(false);
         if (response.success) {
           this.wizardData.update((d) => ({ ...d, store: storeData }));
-          this.toastService.success('Tienda configurada correctamente');
+          this.toastService.success('Comercio configurado correctamente');
           // The service already calls nextStep() automatically
         }
       },
       error: (error) =>
-        this.handleOnboardingError(error, 'Error al configurar la tienda'),
+        this.handleOnboardingError(error, 'Error al configurar el comercio'),
     });
   }
 
@@ -1282,14 +1282,14 @@ export class OnboardingModalComponent {
               );
             } catch (switchError) {
               console.error('Error switching environment:', switchError);
-              this.toastService.error('Error al cambiar al entorno de tienda');
+              this.toastService.error('Error al cambiar al entorno de comercio');
               // Fallback reload to ensure clean state
               window.location.reload();
             }
           } else {
             // Si no hay slug, redirigir al dashboard general sin switch de entorno
             this.toastService.warning(
-              'No se pudo identificar la tienda específica, redirigiendo al panel general',
+              'No se pudo identificar el comercio específico, redirigiendo al panel general',
             );
             // Fallback reload to ensure clean state
             window.location.reload();
@@ -1362,7 +1362,7 @@ export class OnboardingModalComponent {
             case 'organization_setup':
               return 'Configuración de Organización';
             case 'store_setup':
-              return 'Configuración de Tienda';
+              return 'Configuración de Comercio';
             case 'app_configuration':
               return 'Configuración de Aplicación';
             default:

--- a/apps/frontend/src/app/shared/components/onboarding-modal/steps/app-config-step.component.ts
+++ b/apps/frontend/src/app/shared/components/onboarding-modal/steps/app-config-step.component.ts
@@ -646,7 +646,7 @@ import { ButtonComponent, IconComponent } from '../../index';
                   class="section-icon-element"
                 ></app-icon>
               </div>
-              <h3 class="section-title">Dominio de tu tienda</h3>
+              <h3 class="section-title">Dominio de tu comercio</h3>
             </div>
 
             <!-- Auto-generated Domain -->
@@ -662,7 +662,7 @@ import { ButtonComponent, IconComponent } from '../../index';
                 <h4>Dominio automático</h4>
                 <span class="domain-url">{{ generatedDomain }}</span>
                 <p class="domain-description">
-                  Tu tienda estará disponible en este dominio gratuito
+                  Tu comercio estará disponible en este dominio gratuito
                 </p>
               </div>
             </div>
@@ -689,7 +689,7 @@ import { ButtonComponent, IconComponent } from '../../index';
                 <input
                   type="text"
                   class="field-input"
-                  placeholder="mitienda.com"
+                  placeholder="micomercio.com"
                   formControlName="customDomain"
                 />
                 <div class="field-hint">
@@ -749,7 +749,7 @@ export class AppConfigStepComponent implements OnInit {
   ];
 
   // Domain properties
-  generatedDomain: string = 'mi-tienda.vendix.app';
+  generatedDomain: string = 'mi-comercio.vendix.app';
   useCustomDomain: boolean = false;
 
   onPrimaryColorChange(event: any): void {

--- a/apps/frontend/src/app/shared/components/onboarding-modal/steps/completion-step.component.ts
+++ b/apps/frontend/src/app/shared/components/onboarding-modal/steps/completion-step.component.ts
@@ -413,7 +413,7 @@ import { IconComponent } from '../../index';
         <!-- Title & Subtitle -->
         <div class="completion-header">
           <h2 class="completion-title">¡Configuración completada!</h2>
-          <p class="completion-subtitle">Tu tienda está lista para comenzar</p>
+          <p class="completion-subtitle">Tu comercio está listo para comenzar</p>
         </div>
 
         <!-- Stats with Separator -->
@@ -451,14 +451,14 @@ import { IconComponent } from '../../index';
               </div>
             </div>
 
-            <!-- Tienda -->
+            <!-- Comercio -->
             <div class="summary-card">
               <div class="summary-card-left">
                 <div class="summary-card-icon">
                   <app-icon name="store" size="18"></app-icon>
                 </div>
                 <div class="summary-card-info">
-                  <span class="summary-card-title">Tienda</span>
+                  <span class="summary-card-title">Comercio</span>
                   <span class="summary-card-subtitle">{{
                     wizardData()?.store?.name || 'Configurada'
                   }}</span>

--- a/apps/frontend/src/app/shared/components/onboarding-modal/steps/store-setup-step.component.ts
+++ b/apps/frontend/src/app/shared/components/onboarding-modal/steps/store-setup-step.component.ts
@@ -1,4 +1,4 @@
-import {Component, input, output, ChangeDetectionStrategy, OnInit, inject, DestroyRef} from '@angular/core';
+import {Component, input, output, ChangeDetectionStrategy, OnInit, inject, DestroyRef, signal} from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
@@ -428,7 +428,7 @@ import { StoreIndustry } from '../../../../shared/constants/industry-modules.con
             </div>
           </div>
           <div class="store-header-content">
-            <h2 class="store-title">Configura tu tienda</h2>
+            <h2 class="store-title">Configura tu comercio</h2>
             <p class="store-subtitle">
               Prepara tu punto de venta para empezar a vender
             </p>
@@ -454,9 +454,9 @@ import { StoreIndustry } from '../../../../shared/constants/industry-modules.con
               <div class="form-field">
                 <app-input
                   formControlName="name"
-                  [label]="'Nombre de la tienda'"
+                  [label]="'Nombre del comercio'"
                   styleVariant="modern"
-                  placeholder="Tienda Principal"
+                  placeholder="Comercio Principal"
                   tooltipText="El nombre visible para tus clientes"
                   [required]="true"
                 ></app-input>
@@ -497,7 +497,7 @@ import { StoreIndustry } from '../../../../shared/constants/industry-modules.con
                   class="section-icon-element"
                 ></app-icon>
               </div>
-              <h3 class="section-title">Tipo de tienda</h3>
+              <h3 class="section-title">Tipo de comercio</h3>
             </div>
     
             <div class="store-type-selector">
@@ -514,7 +514,7 @@ import { StoreIndustry } from '../../../../shared/constants/industry-modules.con
                   ></app-icon>
                 </div>
                 <div class="store-type-content">
-                  <h4 class="store-type-title">Tienda Híbrida</h4>
+                  <h4 class="store-type-title">Comercio Híbrido</h4>
                   <p class="store-type-description">
                     Ventas en persona y online
                   </p>
@@ -543,7 +543,7 @@ import { StoreIndustry } from '../../../../shared/constants/industry-modules.con
                   ></app-icon>
                 </div>
                 <div class="store-type-content">
-                  <h4 class="store-type-title">Tienda Online</h4>
+                  <h4 class="store-type-title">Comercio Online</h4>
                   <p class="store-type-description">
                     Ventas por internet y delivery
                   </p>
@@ -572,7 +572,7 @@ import { StoreIndustry } from '../../../../shared/constants/industry-modules.con
                   ></app-icon>
                 </div>
                 <div class="store-type-content">
-                  <h4 class="store-type-title">Tienda Física</h4>
+                  <h4 class="store-type-title">Comercio Físico</h4>
                   <p class="store-type-description">
                     Ventas en persona con caja física
                   </p>
@@ -662,7 +662,7 @@ import { StoreIndustry } from '../../../../shared/constants/industry-modules.con
                   [label]="'Calle y número'"
                   styleVariant="modern"
                   placeholder="Calle Principal #123"
-                  tooltipText="Dirección principal de la tienda"
+                  tooltipText="Dirección principal del comercio"
                 ></app-input>
               </div>
             </div>
@@ -775,9 +775,14 @@ export class StoreSetupStepComponent implements OnInit {
 
   countries: Country[] = [];
   timezones: Timezone[] = [];
-  departments: Department[] = [];
-  cities: City[] = [];
-  currencies: { value: string; label: string }[] = [];
+  // Async-loaded lists MUST be signals: they are populated after an `await`
+  // in ngOnInit / valueChanges handlers, and under Zoneless change detection a
+  // plain-field mutation post-await never re-renders the `[options]` bindings
+  // (the select stays empty). `countries`/`timezones` above load synchronously
+  // so they render on first CD and can stay plain fields.
+  readonly departments = signal<Department[]>([]);
+  readonly cities = signal<City[]>([]);
+  readonly currencies = signal<{ value: string; label: string }[]>([]);
   locationOptions: { value: number; label: string }[] = [];
 
   /**
@@ -835,8 +840,8 @@ export class StoreSetupStepComponent implements OnInit {
       if (code === 'CO') {
         this.loadDepartments();
       } else {
-        this.departments = [];
-        this.cities = [];
+        this.departments.set([]);
+        this.cities.set([]);
         depControl.setValue(null);
         cityControl.setValue(null);
       }
@@ -848,7 +853,7 @@ export class StoreSetupStepComponent implements OnInit {
         const numericDepId = Number(depId);
         this.loadCities(numericDepId);
       } else {
-        this.cities = [];
+        this.cities.set([]);
         cityControl.setValue(null);
       }
     });
@@ -884,24 +889,39 @@ export class StoreSetupStepComponent implements OnInit {
   }
 
   async loadDepartments(): Promise<void> {
-    this.departments = await this.countryService.getDepartments();
+    this.departments.set(await this.countryService.getDepartments());
   }
 
   async loadCities(depId: number): Promise<void> {
-    this.cities = await this.countryService.getCitiesByDepartment(depId);
+    this.cities.set(await this.countryService.getCitiesByDepartment(depId));
   }
 
   private async loadCurrencies(): Promise<void> {
     try {
       const active = await this.currencyService.getActiveCurrencies();
-      this.currencies = active.map(c => ({ value: c.code, label: `${c.name} (${c.code})` }));
+      // Fall back to the hardcoded list when the endpoint responds with an
+      // empty set (getActiveCurrencies swallows HTTP errors and returns []),
+      // otherwise MONEDA — a required field — would have no options and the
+      // owner could never finish the store step of onboarding.
+      if (active.length > 0) {
+        this.currencies.set(
+          active.map(c => ({ value: c.code, label: `${c.name} (${c.code})` })),
+        );
+      } else {
+        this.currencies.set(this.fallbackCurrencies());
+      }
     } catch {
-      this.currencies = [
-        { value: 'COP', label: 'Peso Colombiano (COP)' },
-        { value: 'USD', label: 'Dólar Americano (USD)' },
-        { value: 'EUR', label: 'Euro (EUR)' },
-      ];
+      this.currencies.set(this.fallbackCurrencies());
     }
+  }
+
+  /** Minimal currency list used when the backend has none active / errors. */
+  private fallbackCurrencies(): { value: string; label: string }[] {
+    return [
+      { value: 'COP', label: 'Peso Colombiano (COP)' },
+      { value: 'USD', label: 'Dólar Americano (USD)' },
+      { value: 'EUR', label: 'Euro (EUR)' },
+    ];
   }
 
   /**
@@ -937,7 +957,7 @@ export class StoreSetupStepComponent implements OnInit {
   }
 
   get currencyOptions() {
-    return this.currencies;
+    return this.currencies();
   }
 
   get timezoneOptions() {
@@ -949,10 +969,10 @@ export class StoreSetupStepComponent implements OnInit {
   }
 
   get departmentOptions() {
-    return this.departments.map(d => ({ value: d.id, label: d.name }));
+    return this.departments().map(d => ({ value: d.id, label: d.name }));
   }
 
   get cityOptions() {
-    return this.cities.map(c => ({ value: c.id, label: c.name }));
+    return this.cities().map(c => ({ value: c.id, label: c.name }));
   }
 }

--- a/apps/frontend/src/app/shared/components/onboarding-modal/steps/welcome-step.component.ts
+++ b/apps/frontend/src/app/shared/components/onboarding-modal/steps/welcome-step.component.ts
@@ -390,7 +390,7 @@ import { AppConfig } from '../../../../core/services/app-config.service';
           <div class="context-content">
             <h3>¿Qué estás haciendo?</h3>
             <p>
-              Configuraremos tu tienda, organización y preferencias para
+              Configuraremos tu comercio, organización y preferencias para
               que puedas vender hoy mismo.
             </p>
           </div>
@@ -414,7 +414,7 @@ import { AppConfig } from '../../../../core/services/app-config.service';
                 ></app-icon>
               </div>
               <div class="option-text">
-                <h4>Gestionar una tienda</h4>
+                <h4>Gestionar un comercio</h4>
                 <p>Ideal para un solo negocio o punto de venta.</p>
               </div>
             </div>
@@ -458,7 +458,7 @@ import { AppConfig } from '../../../../core/services/app-config.service';
               </div>
               <div class="option-text">
                 <h4>Enfoque organizacional</h4>
-                <p>Para múltiples tiendas, sucursales y escalabilidad.</p>
+                <p>Para múltiples comercios, sucursales y escalabilidad.</p>
               </div>
             </div>
 
@@ -470,7 +470,7 @@ import { AppConfig } from '../../../../core/services/app-config.service';
                   class="feature-icon"
                   [color]="primaryColor()"
                 ></app-icon>
-                <span>Múltiples tiendas y sucursales</span>
+                <span>Múltiples comercios y sucursales</span>
               </div>
               <div class="feature-item">
                 <app-icon


### PR DESCRIPTION
## Resumen

Dos cambios relacionados con el arranque de una cuenta nueva de owner:

1. **Onboarding de owner realmente ineludible** — a prueba de cambio de layout, navegación directa por URL y recarga, en org-admin **y** store-admin.
2. **El reporte semanal no se emite a comercios recién creados** (< 22 días).

---

## 1. Onboarding ineludible

### Problema
El gate de onboarding no era un guard: era un **modal condicional dentro de cada layout** (`@if (needsOnboarding())`). En `store-admin-layout` estaba **desactivado a fuerza** (`needsOnboarding.set(false)`, commit `98b8d448`). Al elegir "comercio único" en el paso 1, `selectAppType` cambia `user_settings.app_type` → `STORE_ADMIN` y `EnvironmentSwitchService` reconstruye las rutas **a mitad del wizard**: el modal se desmontaba y el owner quedaba con un panel STORE_ADMIN 100% usable **sin haber terminado el onboarding**. En prod hay 14 orgs con `onboarding=false` (8 en `state=active`).

### Solución
Enforcement central, **solo para owners**, basado en `organizations.onboarding` (flag de **cuenta**, no `stores.onboarding`):

- **`onboarding.guard.ts`** (`CanActivateFn`) montado en `canActivate` + `canActivateChild` de **ambos** árboles de rutas (`org_admin`, `store_admin`). Corre después del `resetConfig` del env-switch, así que sobrevive al cambio de layout.
- **`OnboardingPageComponent`**: host full-screen (`--z-modal-overlay`) que reutiliza el `OnboardingModalComponent` no-cancelable, con un escape hatch de "Cerrar sesión" (el re-login vuelve a forzar el wizard — no es un bypass).
- Se elimina la lógica de onboarding-modal divergente de **ambos** layouts (borra el hardcode que originó el bug).
- **Backend:** `@AllowCrossDomain()` en `OnboardingWizardController`. Un owner que eligió la ruta STORE tiene JWT `STORE_ADMIN`; sin esto, `DomainScopeGuard` daba **403** en todos los `/organization/onboarding-wizard/*` y lo dejaba **encerrado sin poder terminar el onboarding** tras re-login. Salta **solo** el aislamiento de dominio; `PermissionsGuard` y los checks de owner siguen activos.
- **Tour gate:** el tour "Bienvenido a Vendix" solo se muestra a owners con onboarding **terminado** (ya no se solapa con el modal en el re-login, ni aparece a otros roles).
- **Copy multi-industria:** "tienda" → "comercio" en todo el wizard.

### Fix zoneless (destapado por el endurecimiento)
En `store-setup-step.component.ts`, los `<select>` cargados async (**MONEDA**, DEPARTAMENTO, CIUDAD) eran **campos planos mutados tras un `await`**. Bajo `provideZonelessChangeDetection()`, una mutación de campo plano post-await **nunca** re-renderiza el binding `[options]`. MONEDA es **requerido** → quedaba vacío y **bloqueaba `completeWizard`**. Se migran a `signal()` + fallback si el endpoint de monedas responde vacío. Este bug estaba oculto porque, hasta ahora, los owners saltaban el onboarding entero y nunca llegaban al paso de comercio.

---

## 2. Reporte semanal solo tras 22 días

### Problema
Una cuenta recién creada recibía "Tu Semana en Vendix" con datos vacíos. El reporte se **regenera on-demand** en `getLatestForCurrentStore` cuando no hay snapshot de la semana actual, sin mirar la antigüedad del comercio.

### Solución (`weekly-report.service.ts`)
Regla de negocio: primer reporte solo tras superar el **trial (15 días) + primera semana (7 días) = 22 días** desde `created_at`.

- Gate en `generateForStore` (único punto de creación de snapshots → cubre cron **y** on-demand).
- Gate al **servir** en `getLatestForCurrentStore` (oculta snapshots heredados de comercios aún jóvenes).
- Fail-safe: `created_at` ausente → se omite (nunca se emite antes de tiempo).

---

## Verificación
- `build:prod` (AOT) frontend: **OK** (solo warnings pre-existentes NG8113/budget, ajenos a este PR).
- `tsc -p tsconfig.build.json` backend: **OK**.
- E2E adversarial (agent-browser, vhost) con cuenta nueva: owner queda bloqueado en `/admin/onboarding`; navegación directa a dashboard/pos/settings redirige; elegir "comercio único" (dispara env-switch a STORE_ADMIN) **sigue bloqueando**; logout + re-login **retoma** el wizard; completar libera a `/admin/dashboard`; recarga ya no bloquea. Reporte semanal desaparece para comercio joven.

---

## ⚠️ Prerrequisito de despliegue (NO desplegar el guard sin esto)
Al activar el guard, **todo owner con `organizations.onboarding=false` queda bloqueado**. Antes de desplegar a prod hay que **backfillear** `onboarding=true` para las orgs legacy **operativas** (con stores + actividad), vía migración versionada con `WHERE` acotado, snapshot previo y header `-- DATA IMPACT:`. Dejar bloqueadas solo las genuinamente incompletas (0 stores). Sin migraciones en este PR.

## Sin migraciones de BD
Este PR no incluye migraciones.

## Linear
- QUI-471 — FIX/ Onboarding de owner evitable / no ineludible [admin]
  https://linear.app/quickss/issue/QUI-471
