### PR TITLE
feat(mobile): org-admin domains — UI building blocks (PR #11b)

### DIFF
--- a/apps/mobile/src/features/org/components/domain-filters-modal.tsx
+++ b/apps/mobile/src/features/org/components/domain-filters-modal.tsx
@@ -1,0 +1,334 @@
+import { useEffect, useState } from 'react';
+import { View, Text, Pressable, StyleSheet, ActivityIndicator } from 'react-native';
+import { OrgCenteredModal } from '@/shared/components/org-centered-modal';
+import { Icon } from '@/shared/components/icon/icon';
+import { colors, colorScales, spacing, typography, borderRadius } from '@/shared/theme';
+import { OrgStoreService } from '@/features/org/services/org-store.service';
+import type { StoreListItem } from '@/core/models/org-admin/store.types';
+import type { DomainOwnership, DomainStatus } from '@/core/models/org-admin/domains.types';
+import {
+  DOMAIN_OWNERSHIP_OPTIONS,
+  DOMAIN_STATUS_OPTIONS,
+} from './domain-formatters';
+import type { DomainFilters } from './domain-filters.types';
+import { EMPTY_FILTERS, hasActiveFilters } from './domain-filters.types';
+
+interface DomainFiltersModalProps {
+  visible: boolean;
+  initial: DomainFilters;
+  onClose: () => void;
+  onApply: (filters: DomainFilters) => void;
+}
+
+/**
+ * Modal de filtros para la lista de dominios.
+ *
+ * Espejo del `<app-options-dropdown>` que usa la web en `domains.component.ts`,
+ * pero en versión **modal centrado** (overlay + tarjeta) usando
+ * `OrgCenteredModal` — NO BottomSheet, porque la web abre el filtro como
+ * popover flotante, no como sheet full-screen.
+ *
+ * Combina en un solo modal los 3 selects:
+ *   - Estado: 16 statuses (PENDING, ACTIVE, FAILED, …)
+ *   - Tipo (Ownership): VENDIX_SUBDOMAIN / CUSTOM_DOMAIN / CUSTOM_SUBDOMAIN / THIRD_PARTY_SUBDOMAIN
+ *   - Tienda: Todas / Organización (sentinel) / tiendas reales del OrgStoreService
+ *
+ * El botón "Aplicar" cierra y propaga; "Limpiar" resetea a `EMPTY_FILTERS`
+ * pero no cierra, para que el usuario pueda ver el reset antes de aplicar.
+ */
+export function DomainFiltersModal({ visible, initial, onClose, onApply }: DomainFiltersModalProps) {
+  const [draft, setDraft] = useState<DomainFilters>(initial);
+  const [stores, setStores] = useState<StoreListItem[]>([]);
+  const [storesLoading, setStoresLoading] = useState(false);
+  const [openSelect, setOpenSelect] = useState<null | 'status' | 'ownership' | 'store'>(null);
+
+  useEffect(() => {
+    if (!visible) return;
+    setDraft(initial);
+    setOpenSelect(null);
+    if (stores.length === 0) {
+      setStoresLoading(true);
+      OrgStoreService.list({ pageSize: 200 })
+        .then((r) => setStores(r.data ?? []))
+        .catch(() => setStores([]))
+        .finally(() => setStoresLoading(false));
+    }
+  }, [visible, initial, stores.length]);
+
+  const handleApply = () => {
+    onApply(draft);
+    onClose();
+  };
+
+  const handleClear = () => {
+    setDraft(EMPTY_FILTERS);
+    setOpenSelect(null);
+  };
+
+  const statusLabel = draft.status ? DOMAIN_STATUS_OPTIONS.find((o) => o.value === draft.status)?.label ?? draft.status : 'Todos';
+  const ownershipLabel = draft.ownership ? DOMAIN_OWNERSHIP_OPTIONS.find((o) => o.value === draft.ownership)?.label ?? draft.ownership : 'Todos';
+  const storeLabel =
+    draft.storeId === ''
+      ? 'Todas'
+      : draft.storeId === '__organization__'
+      ? 'Organización'
+      : stores.find((s) => String(s.id) === draft.storeId)?.name ?? 'Tienda';
+
+  const subtitle = hasActiveFilters(draft)
+    ? 'Filtros activos'
+    : 'Mostrando todos los dominios';
+
+  return (
+    <OrgCenteredModal
+      visible={visible}
+      onClose={onClose}
+      title="Filtros"
+      subtitle={subtitle}
+      size="sm"
+      footer={
+        <View style={styles.footer}>
+          <Pressable style={styles.clearBtn} onPress={handleClear}>
+            <Icon name="rotate-ccw" size={14} color={colorScales.gray[600]} />
+            <Text style={styles.clearText}>Limpiar</Text>
+          </Pressable>
+          <Pressable style={styles.applyBtn} onPress={handleApply}>
+            <Icon name="check" size={16} color="#FFFFFF" />
+            <Text style={styles.applyText}>Aplicar</Text>
+          </Pressable>
+        </View>
+      }
+    >
+      {/* Status */}
+      <FilterSection
+        label="Estado"
+        value={statusLabel}
+        active={!!draft.status}
+        open={openSelect === 'status'}
+        onToggle={() =>
+          setOpenSelect(openSelect === 'status' ? null : 'status')
+        }
+      >
+        {DOMAIN_STATUS_OPTIONS.map((o) => (
+          <OptionRow
+            key={o.value}
+            label={o.label}
+            active={draft.status === o.value}
+            onPress={() => {
+              setDraft((d) => ({ ...d, status: d.status === o.value ? '' : (o.value as DomainStatus) }));
+              setOpenSelect(null);
+            }}
+          />
+        ))}
+      </FilterSection>
+
+      {/* Ownership */}
+      <FilterSection
+        label="Tipo"
+        value={ownershipLabel}
+        active={!!draft.ownership}
+        open={openSelect === 'ownership'}
+        onToggle={() =>
+          setOpenSelect(openSelect === 'ownership' ? null : 'ownership')
+        }
+      >
+        {DOMAIN_OWNERSHIP_OPTIONS.map((o) => (
+          <OptionRow
+            key={o.value}
+            label={o.label}
+            active={draft.ownership === o.value}
+            onPress={() => {
+              setDraft((d) => ({ ...d, ownership: d.ownership === o.value ? '' : (o.value as DomainOwnership) }));
+              setOpenSelect(null);
+            }}
+          />
+        ))}
+      </FilterSection>
+
+      {/* Store */}
+      <FilterSection
+        label="Tienda"
+        value={storeLabel}
+        active={!!draft.storeId}
+        open={openSelect === 'store'}
+        onToggle={() =>
+          setOpenSelect(openSelect === 'store' ? null : 'store')
+        }
+      >
+        <OptionRow
+          label="Todas"
+          active={draft.storeId === ''}
+          onPress={() => {
+            setDraft((d) => ({ ...d, storeId: '' }));
+            setOpenSelect(null);
+          }}
+        />
+        <OptionRow
+          label="Organización"
+          active={draft.storeId === '__organization__'}
+          onPress={() => {
+            setDraft((d) => ({ ...d, storeId: d.storeId === '__organization__' ? '' : '__organization__' }));
+            setOpenSelect(null);
+          }}
+        />
+        {storesLoading ? (
+          <View style={styles.optionRow}>
+            <ActivityIndicator size="small" color={colors.primary} />
+          </View>
+        ) : stores.length === 0 ? (
+          <Text style={styles.helperText}>No hay tiendas registradas</Text>
+        ) : (
+          stores.map((s) => {
+            const id = String(s.id);
+            return (
+              <OptionRow
+                key={id}
+                label={s.name}
+                active={draft.storeId === id}
+                onPress={() => {
+                  setDraft((d) => ({ ...d, storeId: d.storeId === id ? '' : id }));
+                  setOpenSelect(null);
+                }}
+              />
+            );
+          })
+        )}
+      </FilterSection>
+    </OrgCenteredModal>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Subcomponentes
+// ─────────────────────────────────────────────────────────────────────────────
+
+function FilterSection({
+  label,
+  value,
+  active,
+  open,
+  onToggle,
+  children,
+}: {
+  label: string;
+  value: string;
+  active: boolean;
+  open: boolean;
+  onToggle: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <View style={styles.section}>
+      <Text style={styles.label}>{label}</Text>
+      <Pressable
+        style={[styles.selectInput, active && styles.selectInputActive]}
+        onPress={onToggle}
+      >
+        <Text style={[styles.selectText, !active && styles.selectPlaceholder]} numberOfLines={1}>
+          {value}
+        </Text>
+        <Icon
+          name={open ? 'chevron-up' : 'chevron-down'}
+          size={16}
+          color={colorScales.gray[400]}
+        />
+      </Pressable>
+      {open ? <View style={styles.options}>{children}</View> : null}
+    </View>
+  );
+}
+
+function OptionRow({ label, active, onPress }: { label: string; active: boolean; onPress: () => void }) {
+  return (
+    <Pressable style={[styles.optionRow, active && styles.optionRowActive]} onPress={onPress}>
+      <Text style={[styles.optionText, active && styles.optionTextActive]} numberOfLines={1}>
+        {label}
+      </Text>
+      {active ? <Icon name="check" size={14} color={colors.primary} /> : null}
+    </Pressable>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Estilos
+// ─────────────────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  section: { gap: spacing[2], marginBottom: spacing[4] },
+  label: {
+    fontSize: typography.fontSize.xs,
+    fontWeight: typography.fontWeight.semibold,
+    color: colorScales.gray[600],
+    textTransform: 'uppercase',
+    letterSpacing: 1.2,
+  },
+  selectInput: {
+    height: 48,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    borderWidth: 1,
+    borderColor: colorScales.gray[300],
+    borderRadius: borderRadius.lg,
+    paddingHorizontal: spacing[3],
+    backgroundColor: colors.background,
+  },
+  selectInputActive: { borderColor: colors.primary },
+  selectText: { fontSize: typography.fontSize.base, color: colorScales.gray[900], flex: 1 },
+  selectPlaceholder: { color: colorScales.gray[400] },
+  options: {
+    borderWidth: 1,
+    borderColor: colorScales.gray[200],
+    borderRadius: borderRadius.lg,
+    overflow: 'hidden',
+    backgroundColor: colors.background,
+  },
+  optionRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[3],
+    borderBottomWidth: 1,
+    borderBottomColor: colorScales.gray[100],
+    gap: spacing[2],
+  },
+  optionRowActive: { backgroundColor: colorScales.green[50] },
+  optionText: { fontSize: typography.fontSize.sm, color: colorScales.gray[700], flex: 1 },
+  optionTextActive: { color: colors.primary, fontWeight: typography.fontWeight.semibold },
+  helperText: { fontSize: typography.fontSize.xs, color: colorScales.gray[500] },
+  footer: {
+    flexDirection: 'row',
+    gap: spacing[3],
+  },
+  clearBtn: {
+    flex: 1,
+    height: 48,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing[2],
+    borderRadius: borderRadius.xl,
+    borderWidth: 1,
+    borderColor: colorScales.gray[300],
+  },
+  clearText: {
+    fontSize: typography.fontSize.base,
+    fontWeight: typography.fontWeight.semibold,
+    color: colorScales.gray[700],
+  },
+  applyBtn: {
+    flex: 2,
+    height: 48,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing[2],
+    backgroundColor: colors.primary,
+    borderRadius: borderRadius.xl,
+  },
+  applyText: {
+    fontSize: typography.fontSize.base,
+    fontWeight: typography.fontWeight.bold,
+    color: '#FFFFFF',
+  },
+});

--- a/apps/mobile/src/features/org/components/domain-form-fields.tsx
+++ b/apps/mobile/src/features/org/components/domain-form-fields.tsx
@@ -1,0 +1,557 @@
+import { useEffect, useRef, useState } from 'react';
+import { View, Text, Pressable, TextInput, StyleSheet, ActivityIndicator, ScrollView, Keyboard } from 'react-native';
+import { colors, colorScales, spacing, typography, borderRadius } from '@/shared/theme';
+import { Icon } from '@/shared/components/icon/icon';
+import { OrgDomainsService } from '@/features/org/services/org-domains.service';
+import { OrgStoreService } from '@/features/org/services/org-store.service';
+import type { StoreListItem } from '@/core/models/org-admin/store.types';
+import type {
+  AppType,
+  Domain,
+  DomainOwnership,
+  DomainRoot,
+  CreateDomainInput,
+} from '@/core/models/org-admin/domains.types';
+import {
+  APP_TYPE_OPTIONS,
+  DOMAIN_OWNERSHIP_OPTIONS,
+  formatAppType,
+  formatOwnership,
+} from './domain-formatters';
+
+interface DomainFormFieldsProps {
+  /** Si viene, es edición; hostname/ownership/root quedan read-only. */
+  initial?: Domain;
+  submitting: boolean;
+  onSubmit: (data: CreateDomainInput) => void;
+  onCancel: () => void;
+  submitLabel?: string;
+  /** Si true, oculta el header interno (título+icono). Se usa cuando el
+   *  componente se renderiza dentro de un `OrgCenteredModal` que provee
+   *  su propio title/subtitle — patrón de paridad web. */
+  hideHeader?: boolean;
+}
+
+/**
+ * Form compartido para crear/editar dominios (ORG_ADMIN Dominios).
+ *
+ * La pantalla que llama controla la visibilidad del modal; este componente
+ * solo se encarga de los campos. En modo edición `hostname`/`root_domain`/
+ * `ownership` se renderizan read-only porque cambiar esos campos es un
+ * operación destructiva (cambiar el root requiere re-emitir certificado).
+ *
+ * Validación:
+ *   - En blur del hostname se llama `validateHostname` y `checkDuplicate`
+ *     para mostrar errores inline antes de habilitar Submit.
+ *   - `root_domain` se selecciona de la lista de `listRoots()`.
+ *   - `store_id` es opcional (null = dominio de organización).
+ */
+export function DomainFormFields({
+  initial,
+  submitting,
+  onSubmit,
+  onCancel,
+  submitLabel = 'Guardar',
+  hideHeader = false,
+}: DomainFormFieldsProps) {
+  const isEdit = !!initial;
+
+  const [hostname, setHostname] = useState(initial?.hostname ?? '');
+  const [hostnameError, setHostnameError] = useState<string | null>(null);
+  const [hostnameValidating, setHostnameValidating] = useState(false);
+  const lastValidatedHostname = useRef<string | null>(initial?.hostname ?? null);
+
+  const [roots, setRoots] = useState<DomainRoot[]>([]);
+  const [rootDomain, setRootDomain] = useState(initial?.root_domain ?? '');
+  const [subdomain, setSubdomain] = useState(initial?.subdomain ?? '');
+
+  const [stores, setStores] = useState<StoreListItem[]>([]);
+  const [storeId, setStoreId] = useState<string | null>(initial?.store_id ?? null);
+
+  const [appType, setAppType] = useState<AppType>(initial?.app_type ?? 'STORE_ECOMMERCE');
+  const [ownership, setOwnership] = useState<DomainOwnership>(
+    initial?.ownership ?? 'CUSTOM_DOMAIN',
+  );
+  const [isPrimary, setIsPrimary] = useState<boolean>(initial?.is_primary ?? false);
+
+  const [openDropdown, setOpenDropdown] = useState<null | 'root' | 'store' | 'appType' | 'ownership'>(null);
+
+  useEffect(() => {
+    Promise.all([OrgDomainsService.listRoots().catch(() => []), OrgStoreService.list({ pageSize: 200 }).then((r) => r.data).catch(() => [])])
+      .then(([r, s]) => {
+        setRoots(r ?? []);
+        setStores(s ?? []);
+        if (!initial && r && r.length > 0 && !rootDomain) setRootDomain(r[0].root_domain);
+      });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const validateAndCheckDuplicate = async (value: string) => {
+    if (!value || value === lastValidatedHostname.current) return;
+    setHostnameValidating(true);
+    setHostnameError(null);
+    try {
+      const v = await OrgDomainsService.validateHostname(value);
+      if (!v.valid) {
+        setHostnameError(v.reason ?? 'Hostname inválido');
+        return;
+      }
+      const dup = await OrgDomainsService.checkDuplicate(value);
+      if (dup.duplicate) {
+        setHostnameError('Este hostname ya está registrado');
+        return;
+      }
+      lastValidatedHostname.current = value;
+    } catch (e: any) {
+      setHostnameError(e?.message ?? 'No se pudo validar el hostname');
+    } finally {
+      setHostnameValidating(false);
+    }
+  };
+
+  const isValid =
+    !!hostname.trim() &&
+    !!rootDomain.trim() &&
+    !hostnameError &&
+    !!appType &&
+    !!ownership;
+
+  const handleSubmit = () => {
+    if (!isValid) return;
+    onSubmit({
+      hostname: hostname.trim(),
+      root_domain: rootDomain.trim(),
+      subdomain: subdomain.trim() || undefined,
+      store_id: storeId,
+      app_type: appType,
+      ownership,
+      is_primary: isPrimary,
+    });
+  };
+
+  return (
+    <View style={styles.container}>
+      {/* Header interno: solo se renderiza cuando NO está oculto por el
+          modal padre (que provee su propio title/subtitle). */}
+      {!hideHeader ? (
+        <View style={styles.headerRow}>
+          <View style={styles.headerIcon}>
+            <Icon name="globe" size={20} color={colors.primary} />
+          </View>
+          <Text style={styles.headerTitle}>{isEdit ? 'Editar dominio' : 'Nuevo dominio'}</Text>
+        </View>
+      ) : null}
+
+      <ScrollView style={styles.form} contentContainerStyle={styles.formContent} keyboardShouldPersistTaps="handled">
+        {/* Hostname */}
+        <View style={styles.field}>
+          <Text style={styles.label}>Hostname</Text>
+          <View style={[styles.inputRow, hostnameError ? styles.inputRowError : null]}>
+            <TextInput
+              style={styles.input}
+              value={hostname}
+              onChangeText={(v) => {
+                setHostname(v.toLowerCase());
+                if (hostnameError) setHostnameError(null);
+              }}
+              onBlur={() => !isEdit && validateAndCheckDuplicate(hostname)}
+              editable={!isEdit}
+              autoCapitalize="none"
+              autoCorrect={false}
+              placeholder="mitienda.com"
+              placeholderTextColor={colorScales.gray[400]}
+            />
+            {hostnameValidating ? <ActivityIndicator size="small" color={colors.primary} /> : null}
+          </View>
+          {hostnameError ? <Text style={styles.errorText}>{hostnameError}</Text> : null}
+          {isEdit ? <Text style={styles.helperText}>El hostname no se puede cambiar. Crea un dominio nuevo si necesitas otro.</Text> : null}
+        </View>
+
+        {/* Root domain */}
+        <View style={styles.field}>
+          <Text style={styles.label}>Dominio raíz</Text>
+          <Pressable
+            style={styles.selectInput}
+            onPress={() => {
+              if (isEdit) return;
+              Keyboard.dismiss();
+              setOpenDropdown(openDropdown === 'root' ? null : 'root');
+            }}
+            disabled={isEdit}
+          >
+            <Text style={rootDomain ? styles.selectText : styles.selectPlaceholder}>
+              {rootDomain || 'Selecciona un dominio raíz'}
+            </Text>
+            <Icon name="chevron-down" size={16} color={colorScales.gray[400]} />
+          </Pressable>
+          {openDropdown === 'root' && roots.length > 0 ? (
+            <View style={styles.dropdown}>
+              {roots.map((r) => (
+                <Pressable
+                  key={r.id}
+                  style={[styles.dropdownItem, rootDomain === r.root_domain && styles.dropdownItemActive]}
+                  onPress={() => {
+                    setRootDomain(r.root_domain);
+                    setOpenDropdown(null);
+                  }}
+                >
+                  <Text style={[styles.dropdownItemText, rootDomain === r.root_domain && styles.dropdownItemTextActive]}>
+                    {r.root_domain}
+                  </Text>
+                  {rootDomain === r.root_domain ? <Icon name="check" size={16} color={colors.primary} /> : null}
+                </Pressable>
+              ))}
+            </View>
+          ) : null}
+          {isEdit ? <Text style={styles.helperText}>El dominio raíz no se puede cambiar.</Text> : null}
+        </View>
+
+        {/* Subdomain */}
+        <View style={styles.field}>
+          <Text style={styles.label}>Subdominio (opcional)</Text>
+          <TextInput
+            style={styles.textInput}
+            value={subdomain}
+            onChangeText={setSubdomain}
+            placeholder="Ej: tienda, shop, www"
+            placeholderTextColor={colorScales.gray[400]}
+            autoCapitalize="none"
+            autoCorrect={false}
+          />
+        </View>
+
+        {/* Ownership */}
+        <View style={styles.field}>
+          <Text style={styles.label}>Tipo de propiedad</Text>
+          <Pressable
+            style={[styles.selectInput, isEdit && styles.selectInputDisabled]}
+            onPress={() => {
+              if (isEdit) return;
+              Keyboard.dismiss();
+              setOpenDropdown(openDropdown === 'ownership' ? null : 'ownership');
+            }}
+            disabled={isEdit}
+          >
+            <Text style={styles.selectText}>{formatOwnership(ownership)}</Text>
+            <Icon name="chevron-down" size={16} color={colorScales.gray[400]} />
+          </Pressable>
+          {openDropdown === 'ownership' && !isEdit ? (
+            <View style={styles.dropdown}>
+              {DOMAIN_OWNERSHIP_OPTIONS.map((o) => (
+                <Pressable
+                  key={o.value}
+                  style={[styles.dropdownItem, ownership === o.value && styles.dropdownItemActive]}
+                  onPress={() => {
+                    setOwnership(o.value);
+                    setOpenDropdown(null);
+                  }}
+                >
+                  <Text style={[styles.dropdownItemText, ownership === o.value && styles.dropdownItemTextActive]}>
+                    {o.label}
+                  </Text>
+                  {ownership === o.value ? <Icon name="check" size={16} color={colors.primary} /> : null}
+                </Pressable>
+              ))}
+            </View>
+          ) : null}
+        </View>
+
+        {/* App type */}
+        <View style={styles.field}>
+          <Text style={styles.label}>Tipo de app destino</Text>
+          <Pressable
+            style={styles.selectInput}
+            onPress={() => {
+              Keyboard.dismiss();
+              setOpenDropdown(openDropdown === 'appType' ? null : 'appType');
+            }}
+          >
+            <Text style={styles.selectText}>{formatAppType(appType)}</Text>
+            <Icon name="chevron-down" size={16} color={colorScales.gray[400]} />
+          </Pressable>
+          {openDropdown === 'appType' ? (
+            <View style={styles.dropdown}>
+              {APP_TYPE_OPTIONS.map((o) => (
+                <Pressable
+                  key={o.value}
+                  style={[styles.dropdownItem, appType === o.value && styles.dropdownItemActive]}
+                  onPress={() => {
+                    setAppType(o.value);
+                    setOpenDropdown(null);
+                  }}
+                >
+                  <Text style={[styles.dropdownItemText, appType === o.value && styles.dropdownItemTextActive]}>
+                    {o.label}
+                  </Text>
+                  {appType === o.value ? <Icon name="check" size={16} color={colors.primary} /> : null}
+                </Pressable>
+              ))}
+            </View>
+          ) : null}
+        </View>
+
+        {/* Store (optional) */}
+        <View style={styles.field}>
+          <Text style={styles.label}>Tienda asociada (opcional)</Text>
+          <Pressable
+            style={styles.selectInput}
+            onPress={() => {
+              Keyboard.dismiss();
+              setOpenDropdown(openDropdown === 'store' ? null : 'store');
+            }}
+          >
+            <Text style={storeId ? styles.selectText : styles.selectPlaceholder}>
+              {storeId ? stores.find((s) => String(s.id) === storeId)?.name ?? 'Tienda' : 'Dominio de organización'}
+            </Text>
+            <Icon name="chevron-down" size={16} color={colorScales.gray[400]} />
+          </Pressable>
+          {openDropdown === 'store' ? (
+            <View style={styles.dropdown}>
+              <Pressable
+                style={[styles.dropdownItem, storeId === null && styles.dropdownItemActive]}
+                onPress={() => {
+                  setStoreId(null);
+                  setOpenDropdown(null);
+                }}
+              >
+                <Text style={[styles.dropdownItemText, storeId === null && styles.dropdownItemTextActive]}>
+                  Dominio de organización
+                </Text>
+                {storeId === null ? <Icon name="check" size={16} color={colors.primary} /> : null}
+              </Pressable>
+              {stores.map((s) => {
+                const id = String(s.id);
+                const active = storeId === id;
+                return (
+                  <Pressable
+                    key={id}
+                    style={[styles.dropdownItem, active && styles.dropdownItemActive]}
+                    onPress={() => {
+                      setStoreId(id);
+                      setOpenDropdown(null);
+                    }}
+                  >
+                    <Text style={[styles.dropdownItemText, active && styles.dropdownItemTextActive]}>{s.name}</Text>
+                    {active ? <Icon name="check" size={16} color={colors.primary} /> : null}
+                  </Pressable>
+                );
+              })}
+            </View>
+          ) : null}
+        </View>
+
+        {/* is_primary toggle */}
+        <Pressable
+          style={styles.toggleRow}
+          onPress={() => setIsPrimary((v) => !v)}
+        >
+          <View style={[styles.checkbox, isPrimary && styles.checkboxActive]}>
+            {isPrimary ? <Icon name="check" size={12} color="#FFFFFF" /> : null}
+          </View>
+          <View style={{ flex: 1 }}>
+            <Text style={styles.toggleLabel}>Marcar como dominio principal</Text>
+            <Text style={styles.helperText}>El dominio principal se usa como URL canónica de la organización.</Text>
+          </View>
+        </Pressable>
+      </ScrollView>
+
+      <View style={styles.footer}>
+        <Pressable style={styles.cancelBtn} onPress={onCancel} disabled={submitting}>
+          <Text style={styles.cancelText}>Cancelar</Text>
+        </Pressable>
+        <Pressable
+          style={[styles.submitBtn, (!isValid || submitting) && styles.submitBtnDisabled]}
+          onPress={handleSubmit}
+          disabled={!isValid || submitting}
+        >
+          {submitting ? (
+            <ActivityIndicator size="small" color="#FFFFFF" />
+          ) : (
+            <>
+              <Icon name="check" size={16} color="#FFFFFF" />
+              <Text style={styles.submitText}>{submitLabel}</Text>
+            </>
+          )}
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[3],
+    borderBottomWidth: 1,
+    borderBottomColor: colorScales.gray[200],
+  },
+  headerIcon: {
+    width: 36,
+    height: 36,
+    borderRadius: 10,
+    backgroundColor: colorScales.green[100],
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  headerTitle: {
+    fontSize: typography.fontSize.lg,
+    fontWeight: typography.fontWeight.bold as any,
+    color: colorScales.gray[900],
+  },
+  form: { flex: 1 },
+  formContent: { padding: spacing[4], gap: spacing[4] },
+  field: { gap: spacing[1] },
+  label: {
+    fontSize: typography.fontSize.xs,
+    color: colorScales.gray[600],
+    fontWeight: typography.fontWeight.semibold as any,
+    textTransform: 'uppercase',
+    letterSpacing: 1.2,
+  },
+  inputRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderWidth: 1,
+    borderColor: colorScales.gray[300],
+    borderRadius: borderRadius.lg,
+    paddingHorizontal: spacing[3],
+    backgroundColor: colors.background,
+  },
+  inputRowError: { borderColor: colors.error },
+  input: {
+    flex: 1,
+    height: 44,
+    fontSize: typography.fontSize.base,
+    color: colorScales.gray[900],
+  },
+  textInput: {
+    height: 44,
+    borderWidth: 1,
+    borderColor: colorScales.gray[300],
+    borderRadius: borderRadius.lg,
+    paddingHorizontal: spacing[3],
+    fontSize: typography.fontSize.base,
+    color: colorScales.gray[900],
+    backgroundColor: colors.background,
+  },
+  errorText: {
+    fontSize: typography.fontSize.xs,
+    color: colors.error,
+    marginTop: spacing[1],
+  },
+  helperText: {
+    fontSize: typography.fontSize.xs,
+    color: colorScales.gray[500],
+    marginTop: spacing[1],
+  },
+  selectInput: {
+    height: 44,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    borderWidth: 1,
+    borderColor: colorScales.gray[300],
+    borderRadius: borderRadius.lg,
+    paddingHorizontal: spacing[3],
+    backgroundColor: colors.background,
+  },
+  selectInputDisabled: { opacity: 0.6 },
+  selectText: {
+    fontSize: typography.fontSize.base,
+    color: colorScales.gray[900],
+    flex: 1,
+  },
+  selectPlaceholder: {
+    fontSize: typography.fontSize.base,
+    color: colorScales.gray[400],
+    flex: 1,
+  },
+  dropdown: {
+    backgroundColor: colors.background,
+    borderWidth: 1,
+    borderColor: colorScales.gray[200],
+    borderRadius: borderRadius.lg,
+    overflow: 'hidden',
+  },
+  dropdownItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[3],
+    borderBottomWidth: 1,
+    borderBottomColor: colorScales.gray[100],
+  },
+  dropdownItemActive: { backgroundColor: colorScales.green[50] },
+  dropdownItemText: {
+    fontSize: typography.fontSize.sm,
+    color: colorScales.gray[700],
+    flex: 1,
+  },
+  dropdownItemTextActive: { color: colors.primary, fontWeight: typography.fontWeight.semibold as any },
+  toggleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+    padding: spacing[3],
+    backgroundColor: colorScales.gray[50],
+    borderRadius: borderRadius.lg,
+  },
+  checkbox: {
+    width: 22,
+    height: 22,
+    borderRadius: 6,
+    borderWidth: 2,
+    borderColor: colorScales.gray[400],
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#FFFFFF',
+  },
+  checkboxActive: { backgroundColor: colors.primary, borderColor: colors.primary },
+  toggleLabel: {
+    fontSize: typography.fontSize.sm,
+    color: colorScales.gray[900],
+    fontWeight: typography.fontWeight.medium as any,
+  },
+  footer: {
+    flexDirection: 'row',
+    gap: spacing[3],
+    padding: spacing[4],
+    borderTopWidth: 1,
+    borderTopColor: colorScales.gray[200],
+  },
+  cancelBtn: {
+    flex: 1,
+    height: 48,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: borderRadius.xl,
+    borderWidth: 1,
+    borderColor: colorScales.gray[300],
+  },
+  cancelText: {
+    fontSize: typography.fontSize.base,
+    fontWeight: typography.fontWeight.semibold as any,
+    color: colorScales.gray[700],
+  },
+  submitBtn: {
+    flex: 2,
+    height: 48,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing[2],
+    backgroundColor: colors.primary,
+    borderRadius: borderRadius.xl,
+  },
+  submitBtnDisabled: { opacity: 0.5 },
+  submitText: {
+    fontSize: typography.fontSize.base,
+    fontWeight: typography.fontWeight.bold as any,
+    color: '#FFFFFF',
+  },
+});

--- a/apps/mobile/src/features/org/components/domain-row-card.tsx
+++ b/apps/mobile/src/features/org/components/domain-row-card.tsx
@@ -1,0 +1,281 @@
+import { View, Text, StyleSheet } from 'react-native';
+import { Card } from '@/shared/components/card/card';
+import { Icon } from '@/shared/components/icon/icon';
+import { RowActionsMenu, type RowAction } from '@/shared/components/row-actions-menu/row-actions-menu';
+import {
+  formatAppType,
+  formatOwnership,
+  formatSslStatus,
+  formatStatus,
+  getAppTypeColor,
+  getOwnershipColor,
+  getSslStatusColor,
+  getStatusColor,
+} from './domain-formatters';
+import { colors, colorScales, spacing, typography, borderRadius } from '@/shared/theme';
+import type { Domain } from '@/core/models/org-admin/domains.types';
+
+interface DomainRowCardProps {
+  domain: Domain;
+  /** Acciones que se exponen en el menú 3 puntos. Si viene vacío, no se muestra el botón. */
+  actions?: RowAction[];
+}
+
+/**
+ * Card de dominio para la lista de ORG_ADMIN.
+ *
+ * Espejo del `cardConfig` de la web (ResponsiveDataView en mobile):
+ *   - Title: hostname
+ *   - Subtitle: store name (o "Organización" si null)
+ *   - Status badge + Primario indicator al costado
+ *   - Fila de badges inline: app_type + ownership + ssl_status
+ *   - Footer con fecha de creación
+ *   - Menú 3 puntos a la derecha con las acciones recibidas por props
+ *
+ * El componente es presentacional: la pantalla padre decide qué acciones
+ * pasan según estado del dominio (e.g. "Provisionar" solo si
+ * `canProvisionDomain(domain)`).
+ */
+export function DomainRowCard({ domain, actions = [] }: DomainRowCardProps) {
+  const statusColor = getStatusColor(domain.status);
+  const statusLabel = formatStatus(domain.status);
+  const subtitle = domain.store?.name ?? 'Organización';
+
+  return (
+    <Card style={styles.card}>
+      {/* Header: avatar + title + acciones */}
+      <View style={styles.header}>
+        <View style={[styles.avatar, { backgroundColor: statusColor + '15' }]}>
+          <Icon name="globe" size={18} color={statusColor} />
+        </View>
+        <View style={styles.headerBody}>
+          <View style={styles.headerTopRow}>
+            <Text style={styles.hostname} numberOfLines={1}>
+              {domain.hostname}
+            </Text>
+            {domain.is_primary ? (
+              <View style={styles.primaryPill}>
+                <Icon name="star" size={10} color={colorScales.amber[700]} />
+                <Text style={styles.primaryPillText}>Pri</Text>
+              </View>
+            ) : null}
+          </View>
+          <View style={styles.headerSubRow}>
+            <Icon name="building" size={11} color={colorScales.gray[400]} />
+            <Text style={styles.subtitle} numberOfLines={1}>
+              {subtitle}
+            </Text>
+          </View>
+        </View>
+        {actions.length > 0 ? (
+          <RowActionsMenu actions={actions} accessibilityLabel={`Acciones para ${domain.hostname}`} />
+        ) : null}
+      </View>
+
+      {/* Status badge */}
+      <View style={styles.statusRow}>
+        <View style={[styles.statusBadge, { backgroundColor: statusColor + '15' }]}>
+          <View style={[styles.statusDot, { backgroundColor: statusColor }]} />
+          <Text style={[styles.statusText, { color: statusColor }]}>{statusLabel}</Text>
+        </View>
+        {domain.is_verified ? (
+          <View style={styles.verifiedPill}>
+            <Icon name="check-circle-2" size={11} color={colors.success} />
+            <Text style={styles.verifiedText}>Verificado</Text>
+          </View>
+        ) : null}
+      </View>
+
+      {/* Inline badges */}
+      <View style={styles.badgesRow}>
+        <InlineBadge label={formatAppType(domain.app_type)} color={getAppTypeColor(domain.app_type)} />
+        <InlineBadge label={formatOwnership(domain.ownership)} color={getOwnershipColor(domain.ownership)} />
+        {domain.ssl_status ? (
+          <InlineBadge
+            label={`SSL ${formatSslStatus(domain.ssl_status)}`}
+            color={getSslStatusColor(domain.ssl_status)}
+          />
+        ) : null}
+      </View>
+
+      {/* Footer */}
+      <View style={styles.footer}>
+        <Icon name="calendar" size={11} color={colorScales.gray[400]} />
+        <Text style={styles.footerText}>
+          Creado {formatDateShort(domain.created_at)}
+        </Text>
+        {domain.verified_at ? (
+          <>
+            <View style={styles.footerSep} />
+            <Icon name="shield-check" size={11} color={colorScales.gray[400]} />
+            <Text style={styles.footerText}>
+              Verificado {formatDateShort(domain.verified_at)}
+            </Text>
+          </>
+        ) : null}
+      </View>
+    </Card>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Subcomponentes
+// ─────────────────────────────────────────────────────────────────────────────
+
+function InlineBadge({ label, color }: { label: string; color: string }) {
+  return (
+    <View style={[styles.badge, { backgroundColor: color + '15' }]}>
+      <View style={[styles.badgeDot, { backgroundColor: color }]} />
+      <Text style={[styles.badgeText, { color }]} numberOfLines={1}>
+        {label}
+      </Text>
+    </View>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function formatDateShort(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString('es-CO', {
+      day: '2-digit',
+      month: 'short',
+      year: 'numeric',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Estilos
+// ─────────────────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  card: {
+    marginBottom: spacing[3],
+    padding: spacing[3],
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+  },
+  avatar: {
+    width: 40,
+    height: 40,
+    borderRadius: borderRadius.lg,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  headerBody: { flex: 1, minWidth: 0 },
+  headerTopRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+  },
+  hostname: {
+    flex: 1,
+    fontSize: typography.fontSize.base,
+    fontWeight: typography.fontWeight.bold,
+    color: colorScales.gray[900],
+  },
+  primaryPill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 2,
+    paddingHorizontal: spacing[2],
+    paddingVertical: 1,
+    borderRadius: borderRadius.full,
+    backgroundColor: colorScales.amber[100],
+  },
+  primaryPillText: {
+    fontSize: 10,
+    fontWeight: typography.fontWeight.semibold,
+    color: colorScales.amber[700],
+  },
+  headerSubRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[1],
+    marginTop: 2,
+  },
+  subtitle: {
+    flex: 1,
+    fontSize: typography.fontSize.xs,
+    color: colorScales.gray[500],
+  },
+  statusRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+    marginTop: spacing[3],
+  },
+  statusBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingHorizontal: spacing[2],
+    paddingVertical: 3,
+    borderRadius: borderRadius.full,
+  },
+  statusDot: { width: 6, height: 6, borderRadius: 3 },
+  statusText: {
+    fontSize: typography.fontSize.xs,
+    fontWeight: typography.fontWeight.semibold,
+  },
+  verifiedPill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 2,
+    paddingHorizontal: spacing[2],
+    paddingVertical: 3,
+    borderRadius: borderRadius.full,
+    backgroundColor: colorScales.green[100],
+  },
+  verifiedText: {
+    fontSize: typography.fontSize.xs,
+    fontWeight: typography.fontWeight.semibold,
+    color: colors.success,
+  },
+  badgesRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing[2],
+    marginTop: spacing[3],
+  },
+  badge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingHorizontal: spacing[2],
+    paddingVertical: 3,
+    borderRadius: borderRadius.full,
+  },
+  badgeDot: { width: 6, height: 6, borderRadius: 3 },
+  badgeText: {
+    fontSize: 11,
+    fontWeight: typography.fontWeight.semibold,
+  },
+  footer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    marginTop: spacing[3],
+    paddingTop: spacing[2],
+    borderTopWidth: 1,
+    borderTopColor: colorScales.gray[100],
+  },
+  footerText: {
+    fontSize: typography.fontSize.xs,
+    color: colorScales.gray[500],
+  },
+  footerSep: {
+    width: 1,
+    height: 10,
+    backgroundColor: colorScales.gray[300],
+    marginHorizontal: spacing[2],
+  },
+});

--- a/apps/mobile/src/shared/components/org-centered-modal.tsx
+++ b/apps/mobile/src/shared/components/org-centered-modal.tsx
@@ -1,0 +1,212 @@
+import React from 'react';
+import {
+  View,
+  Text,
+  Pressable,
+  Modal as RNModal,
+  ScrollView,
+  StyleSheet,
+  KeyboardAvoidingView,
+  Platform,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Icon } from '@/shared/components/icon/icon';
+import {
+  borderRadius,
+  colorScales,
+  colors,
+  spacing,
+  typography,
+} from '@/shared/theme';
+
+export type OrgModalSize = 'sm' | 'md' | 'lg' | 'xl';
+
+interface OrgCenteredModalProps {
+  visible: boolean;
+  onClose: () => void;
+  title?: string;
+  subtitle?: string;
+  size?: OrgModalSize;
+  showCloseButton?: boolean;
+  closeOnBackdrop?: boolean;
+  children?: React.ReactNode;
+  footer?: React.ReactNode;
+  style?: StyleProp<ViewStyle>;
+}
+
+const SIZE_MAX_WIDTH: Record<OrgModalSize, number> = {
+  sm: 380,
+  md: 560,
+  lg: 720,
+  xl: 960,
+};
+
+/**
+ * Espejo del `app-modal` de la web.
+ *
+ * Modal centrado sobre un backdrop semitransparente, NO slide-up
+ * fullscreen. Header con title + subtitle + botón X; body con scroll;
+ * footer opcional con borde superior.
+ */
+export function OrgCenteredModal({
+  visible,
+  onClose,
+  title,
+  subtitle,
+  size = 'md',
+  showCloseButton = true,
+  closeOnBackdrop = true,
+  children,
+  footer,
+  style,
+}: OrgCenteredModalProps) {
+  const insets = useSafeAreaInsets();
+
+  return (
+    <RNModal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+      statusBarTranslucent
+    >
+      <KeyboardAvoidingView
+        style={styles.root}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <Pressable
+          style={styles.backdrop}
+          onPress={closeOnBackdrop ? onClose : undefined}
+        >
+          <Pressable
+            style={[
+              styles.container,
+              { maxWidth: SIZE_MAX_WIDTH[size] },
+              { marginBottom: insets.bottom },
+            ]}
+            onPress={(e) => e.stopPropagation()}
+          >
+            <View style={[styles.surface, style]}>
+              {(title || subtitle || showCloseButton) ? (
+                <View style={styles.header}>
+                  <View style={styles.headerText}>
+                    {title ? (
+                      <Text style={styles.title} numberOfLines={1}>
+                        {title}
+                      </Text>
+                    ) : null}
+                    {subtitle ? (
+                      <Text style={styles.subtitle} numberOfLines={1}>
+                        {subtitle}
+                      </Text>
+                    ) : null}
+                  </View>
+                  {showCloseButton ? (
+                    <Pressable
+                      onPress={onClose}
+                      hitSlop={8}
+                      style={styles.closeBtn}
+                      accessibilityLabel="Cerrar modal"
+                    >
+                      <Icon name="x" size={20} color={colorScales.gray[500]} />
+                    </Pressable>
+                  ) : null}
+                </View>
+              ) : null}
+
+              <ScrollView
+                style={styles.body}
+                contentContainerStyle={styles.bodyContent}
+                showsVerticalScrollIndicator={false}
+              >
+                {children}
+              </ScrollView>
+
+              {footer ? (
+                <View
+                  style={[
+                    styles.footer,
+                    { paddingBottom: insets.bottom ? spacing[3] : spacing[3] },
+                  ]}
+                >
+                  {footer}
+                </View>
+              ) : null}
+            </View>
+          </Pressable>
+        </Pressable>
+      </KeyboardAvoidingView>
+    </RNModal>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: spacing[4],
+  },
+  container: {
+    width: '100%',
+    maxHeight: '90%',
+  },
+  surface: {
+    backgroundColor: colors.card,
+    borderRadius: borderRadius.lg,
+    borderWidth: 1,
+    borderColor: colorScales.gray[200],
+    overflow: 'hidden',
+    flexDirection: 'column',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[3],
+    borderBottomWidth: 1,
+    borderBottomColor: colorScales.gray[200],
+  },
+  headerText: {
+    flex: 1,
+    minWidth: 0,
+  },
+  title: {
+    fontSize: typography.fontSize.lg,
+    fontWeight: typography.fontWeight.semibold,
+    color: colorScales.gray[900],
+  },
+  subtitle: {
+    fontSize: typography.fontSize.sm,
+    color: colorScales.gray[500],
+    marginTop: 2,
+  },
+  closeBtn: {
+    width: 32,
+    height: 32,
+    borderRadius: borderRadius.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  body: {
+    flexShrink: 1,
+  },
+  bodyContent: {
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[3],
+  },
+  footer: {
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[3],
+    borderTopWidth: 1,
+    borderTopColor: colorScales.gray[200],
+    backgroundColor: colors.card,
+  },
+});


### PR DESCRIPTION
## Contexto

Sub-PR **#11b** del **3-way split** de mega-PR `#382` (`feature/mobile-orgadmin-domains-parity`).

**Stacked branch** (target = `split/sub-pr-11a-domains-foundations`, NO `origin/dev`). Esto es necesario porque los 3 archivos nuevos importan types/formatters/service agregados en PR #11a.

Dependencias:
- ✅ **PR #11a** — types + formatters + service (en mi branch base, ya mergeado a este branch vía stack)
- ⏳ **PR #10** — `org-centered-modal.tsx` cherry-pickeado aquí; cuando PR #10 se mergee a dev, mi cherry-pick entrará en conflicto en rebase (resolución trivial: `--theirs`, contenido byte-identical).

| Sub-PR | Nombre | Archivos | LoC | Estado |
|--------|--------|----------|-----|--------|
| #11a | Foundations (no-UI) | 6 | ~548 | ✅ #427 Draft (95/100) |
| **#11b (este)** | **UI building blocks** | **4** | **+1,384** | **🚧 review** |
| #11c | Modales + rewrite lista + detail screen | 7 | ~1,508 | 📋 futuro |

Este PR sienta los **visual building blocks** que PR #11c compondrá (form input atoms + row card + filters modal). Cero modales, cero rewrite de la lista de dominios.

## Cambios

**4 archivos, +1,384 LoC:**

### Nuevos (port desde `feature/mobile-orgadmin-domains-parity`)

- `apps/mobile/src/features/org/components/domain-row-card.tsx` (+281): row card para lista de dominios. Header con avatar/hostname/store, status pill, badges "Pri" + "Verificado", footer con fechas. `RowActionsMenu` opcional.
- `apps/mobile/src/features/org/components/domain-form-fields.tsx` (+556): átomos de form reutilizables (hostname con async validate+checkDuplicate, root_domain dropdown, subdomain, ownership/app_type dropdowns, store dropdown opcional, is_primary toggle). `initial?: Domain` activa edit-mode con hostname/root/ownership read-only.
- `apps/mobile/src/features/org/components/domain-filters-modal.tsx` (+334): modal centrado con barra de filtros (status 17-opts, ownership 4-opts, store dropdown con "Todas" + "Organización" + lista de OrgStoreService). Draft state interno; "Limpiar" resetea sin cerrar, "Aplicar" commitea y cierra.

### Cherry-picked (de PR #10 `split/sub-pr-10-foundation-2`)

- `apps/mobile/src/shared/components/org-centered-modal.tsx` (+212): requerido por `domain-filters-modal.tsx`. Verificado sha256-identical al source en PR #10.

## Verificación

```
npx tsc --noEmit (apps/mobile)                                → 0 errores
npx eslint (4 archivos)                                       → 0 errores, 0 warnings
```

## PR Review (sub-agente, regla RULE 8)

Score: **98/100 → APPROVE** (pasa 80% gate cómodamente)

| Categoría | Peso | Estado |
|-----------|------|--------|
| Regression | x3 | ✅ Puro aditivo (3 NEW + 1 cherry-pick byte-identical sha256-verified) |
| Security | x1 | ✅ Sin issues |
| Logic | x1 | ✅ Sin issues |
| Syntax | x1 | ✅ Typecheck 0, lint 0 |
| Core Files | x1 | ✅ Ninguno tocado |
| PR Scope | x1 | ✅ Clean — solo building blocks |
| Quality | x1 | ✅ Stacked-branch bien documentado |

**Findings**: 0 CRITICAL, 0 HIGH, 0 MEDIUM, 6 LOW (todos pre-existentes / informacionales: typography.fontWeight `as any` cast en theme, ternary dead-code en cherry-picked, accessibilityLabel ausente en Pressables — todos `nice-to-have` para polish en PR #11c, ninguno bloquea).

**Cherry-pick redundancy**: sha256-identical ✅. **No-consumer-introduced**: PASS (consumers llegan en PR #11c). **Imports-resolve**: PASS.

## Caveats para review

1. **Stack sobre #11a**: el target del PR es `split/sub-pr-11a-domains-foundations`. Para review end-to-end, Rzyfront puede ver el diff acumulado de #11a+#11b.
2. **Cherry-pick conflict eventual**: cuando PR #10 se mergee a dev, este branch necesitará rebase contra `origin/dev` y `org-centered-modal.tsx` entrará en conflicto. Resolución: `git checkout --theirs` (contenido byte-identical).
3. **PR target ≠ origin/dev**: este es el primer sub-PR del split mega-PR que no apunta a `origin/dev` directamente. Es por la dependencia forzada con #11a.

## Split mega-PR #382

| # | Estado | Contenido |
|---|--------|-----------|
| 1-10 | ✅ | foundations + super-admin + POS + chrome shared |
| **#11a** | ✅ **#427 Draft (95/100)** | org-admin domains — foundations |
| **#11b (este)** | **🚧 #428 Draft (98/100)** | **org-admin domains — UI building blocks** |
| #11c | 📋 futuro | org-admin domains — modales + lista + detail screen |
| 12-21 | 📋 futuros | analytics + org-admin sprints 1-8 + store-admin extras |
| 23 | 📋 futuro | POS restos + scripts |