### PR TITLE
fix(analytics): top sellers order by units_sold instead of total_price

### DIFF
--- a/apps/backend/src/domains/store/analytics/services/products-analytics.service.ts
+++ b/apps/backend/src/domains/store/analytics/services/products-analytics.service.ts
@@ -130,7 +130,7 @@ export class ProductsAnalyticsService {
         total_price: true,
       },
       orderBy: {
-        _sum: { total_price: 'desc' },
+        _sum: { quantity: 'desc' },
       },
       take: query.limit || 10,
     });

--- a/apps/frontend/src/app/private/modules/store/analytics/pages/products/product-performance.component.ts
+++ b/apps/frontend/src/app/private/modules/store/analytics/pages/products/product-performance.component.ts
@@ -223,8 +223,9 @@ this.store.dispatch(ProductsActions.clearProductsAnalyticsState());
       return;
     }
 
-    // Top 5 by units
-    const top5 = topSellers.slice(0, 5);
+    // Top 5 by units (defensa: re-ordenamos por units_sold por si el backend cambia)
+    const sorted = [...topSellers].sort((a, b) => b.units_sold - a.units_sold);
+    const top5 = sorted.slice(0, 5);
     const names = top5.map((p) => p.product_name);
     const units = top5.map((p) => p.units_sold);
 


### PR DESCRIPTION
## Summary

Cierra el bug **FIX/ Top unidades de venta ordena por ingreso en lugar de cantidad** reportado en demo Vendix Moto & Car.

**Causa raíz**: el endpoint `GET /api/store/analytics/products/top-sellers` ordenaba por `_sum.total_price` (ingresos) cuando el reporte dice "Top 5 por Unidades Vendidas". Productos baratos con muchas unidades quedaban relegados.

**Fix**: 1 línea en backend + 2 líneas defensivas en frontend.

### Cambios

- **Backend** (`apps/backend/src/domains/store/analytics/services/products-analytics.service.ts:133`): `orderBy: { _sum: { total_price: 'desc' } }` → `orderBy: { _sum: { quantity: 'desc' } }`
- **Frontend** (`apps/frontend/.../pages/products/product-performance.component.ts:226-228`): sort defensivo por `units_sold` antes del `slice(0, 5)` — mismo patrón que `top-sellers.component.ts:84-90`. Protege el chart ante futuros cambios del backend.

### Ejemplo del fix

**Antes** (orden por ingresos):
1. Set variado (4 und, $1.2M)
2. Kit de arrastre (3 und, $207K)
3. Bobina de encendido (2 und, $150K) ← mal posicionado
4. Protector de discos (3 und, $148K)
5. Kit de freno (3 und, $130K)
6. Pastas Laterales (3 und, $99K) ← mal posicionado
7. Bocina (1 und, $37.5K)

**Después** (orden por unidades vendidas, esperado por el usuario):
1. Set variado (4)
2-5. Kit arrastre, Protector, Kit freno, Pastas Laterales (3 c/u)
6. Bobina de encendido (2)
7. Bocina (1)

### Consumidores beneficiados automáticamente

- `apps/frontend/.../pages/products/top-sellers.component.ts` — ya tiene su propio sort defensivo
- `apps/frontend/.../reports/config/report-registry.ts` + `product-top-sellers-report.component.ts` — comparten el endpoint, heredan el fix

### Severidad

Alta (workaround incómodo — el usuario veía datos incorrectos y no detectaba el problema hasta cruzar contra otras vistas).

## Verificación

1. **Manual UI** (local `localhost:4200/admin/analytics/products/top-sellers`): verificar que el orden de los productos coincide con unidades vendidas desc.
2. **API raw**: `curl -H "Authorization: Bearer <token>" "http://localhost:3000/api/store/analytics/products/top-sellers?dateFrom=2026-07-01&dateTo=2026-07-12&limit=5"` → array debe estar ordenado por `units_sold` desc.

## Quién revisa / mergea

- **Líder técnico**: revisa y mergea (no se mergea automáticamente).
- **QA**: valida en demo que el orden visual es el correcto.