### PR TITLE
release: POS checkout shell + payment-collector compartido + repartos + auth rate-limit + memberships/onboarding

### DIFF
--- a/apps/frontend/src/app/private/modules/store/pos/components/pos-checkout-shell/pos-checkout-shell.component.html
+++ b/apps/frontend/src/app/private/modules/store/pos/components/pos-checkout-shell/pos-checkout-shell.component.html
@@ -5,6 +5,15 @@
   [subtitle]="'Cobro y cliente'"
   (closed)="onModalClosed()"
 >
+  <!-- Contenido proyectado envuelto en @for keyed por contentEpoch(): al
+       FINALIZAR (venta directa/envío) resetState() incrementa contentEpoch y
+       este subárbol (payment-step + collector, shipping-step, consumo-step) se
+       DESTRUYE y RECREA limpio. Cancelar NO lo incrementa → preserva las
+       selecciones (invariante QUI-482). Es necesario porque el contenido
+       proyectado dentro de <app-modal> NO se destruye al cerrar (solo se
+       desprende del DOM), y el collector solo resetea al cambiar context()
+       (una vez), así que su estado sobreviviría entre ventas y modos. -->
+  @for (epoch of [contentEpoch()]; track epoch) {
   <div class="checkout-shell">
     <!-- Stepper -->
     <div class="checkout-stepper">
@@ -312,6 +321,7 @@
       </aside>
     </div>
   </div>
+  }
 
   <!-- Footer -->
   <div slot="footer" class="checkout-footer">

--- a/apps/frontend/src/app/private/modules/store/pos/components/pos-checkout-shell/pos-checkout-shell.component.ts
+++ b/apps/frontend/src/app/private/modules/store/pos/components/pos-checkout-shell/pos-checkout-shell.component.ts
@@ -307,6 +307,19 @@ export class PosCheckoutShellComponent {
     return 'Confirmar Pago';
   });
 
+  /**
+   * Remount key for the projected checkout content. Incremented ONLY by
+   * {@link resetState} (successful finalization) to force Angular to destroy +
+   * recreate the payment-step/collector, shipping-step and consumo-step with a
+   * pristine internal state. Projected content inside <app-modal> is NOT
+   * destroyed on close (only detached from the DOM), and the collector only
+   * resets on `context()` change (fires once), so without this its selected
+   * method / cash amount / mode leak into the next sale — including across
+   * cobro↔envío flows. Cancel never bumps it, so a mid-checkout close preserves
+   * the operator's selections (QUI-482 invariant).
+   */
+  readonly contentEpoch = signal(0);
+
   constructor() {
     // Ensure currency is loaded for the Resumen rail (| currency pipe).
     this.currencyService.loadCurrency();
@@ -402,6 +415,9 @@ export class PosCheckoutShellComponent {
     this.capturedAddressId.set(null);
     this.submittingDraft.set(false);
     this.syncAnonymousSaleState();
+    // Remount the projected content so the child components (collector,
+    // shipping-step, consumo-step) drop their internal state for the next sale.
+    this.contentEpoch.update((n) => n + 1);
   }
 
   // ── Stepper navigation (non-blocking) ────────────────────────────────────


### PR DESCRIPTION
## Summary

Release de `dev` → `main` (53 commits). Agrupa el trabajo del sprint en curso:

### POS — rework del cobro (checkout shell + collector compartido)
- Nuevo `pos-checkout-shell` tipo wizard (Consumo → Cobro → Cliente / Envío) con pasos dinámicos por industria, intent y timing de pago.
- Paso **Cobro** como sub-wizard vertical (modo → método → monto), `app-payment-collector` en modo `stepped` + keypad lateral gateado por `pos.show_onscreen_keypad`.
- Paso **Cliente** sub-wizard con top-5 sugeridos y captura de dirección; paso **Envío** reducido a método+costo; paso **Consumo** dedicado (restaurante) con mesa inline.
- Navegación wizard (Anterior/Siguiente/Finalizar), layout 95vw / resumen a la izquierda, filas colapsadas con check + editar.
- **Fixes de ciclo de vida (B1):** finalizar cierra y limpia el shell; cancelar preserva selecciones (QUI-482). Corrección adicional: el contenido proyectado del modal no se destruía al cerrar → se remonta vía `@for` keyed por `contentEpoch()` solo al finalizar, evitando que método/monto/modo de la venta anterior se filtren a la siguiente (incluido entre cobro↔envío).
- Header del selector de cliente: botón "Crear cliente" al extremo derecho + contraste.

### Payment-collector compartido (FASE 2)
- `app-payment-collector` reusable capability-driven; adoptado por `pos-payment-interface`, `order-payment-modal`, `table-payment-modal` y el modal de renovación de membresías. Modelo canónico de método de pago (shared). Restaura fiado-libre + `initialMode` (crédito POS).

### Repartos / Despacho (fuente única de verdad orden↔remisión)
- `reconcileOrderFromDispatch` + helper COD compartido; ruta usa el reconciliador único post-commit (QUI-498).
- Carrier: backend SSE pool en vivo + detalle de parada + historial; frontend pool en vivo, detalle/editar dirección, tab Usuario.
- Planillas de ruta: switch A/B (adjuntar remisiones vs crear desde órdenes) en wizard y add-notes-modal, `lockedNoteIds` scoped por tienda, quick-accept (QUI-483/484/497).

### Auth — rate limit (QUI-489)
- `RateLimitLockModalComponent` con countdown + mailto soporte; modal 429 en login admin y ecommerce; propagación de `retryAfter`.

### Memberships / Aforo
- Reingreso configurable (warn/block/off, ventana Nh) + UI de alerta + fix de unicidad de PIN.

### Onboarding / Dominios
- Persistir industrias en `store_settings` + fuente única de metadata de industrias; fixes de re-entrada del wizard.
- Resolución de `app_type` por `domain_type` (VENDIX_LANDING solo en dominios core) + backfill.

### Purchase-orders / POP / Contabilidad
- Anticipo a proveedor + pago/recepción con override por remisión; reconexión de modales POP; propagación de overrides de precio a la recepción por remisión (QUI-425).
- Endpoint `GET /store/customers/top`.

## ⚠️ DATABASE MIGRATION

> **ATENCIÓN**: este PR incluye **5 migraciones**. Ejecutar `prisma migrate deploy` antes/durante el despliegue. Todas son **no destructivas e idempotentes** (sin TRUNCATE/DROP/DELETE/CASCADE). Las que mutan datos (`backfill_domain_app_type`, `backfill_store_settings_industries_mirror`) fueron aprobadas para LOCAL; **PROD requiere aprobación explícita + snapshot** antes de correrlas.

```sql
-- 20260718120000_membership_access_re_entry  (schema-only, fuera de transacción)
ALTER TYPE "membership_access_result_enum" ADD VALUE IF NOT EXISTS 'denied_re_entry';

-- 20260718130000_backfill_domain_app_type  (UPDATE acotado por WHERE, 0 filas en re-run)
UPDATE "domain_settings" SET "app_type" = 'STORE_LANDING'::"app_type_enum",   "updated_at" = now()
  WHERE "app_type" = 'VENDIX_LANDING'::"app_type_enum" AND "domain_type" = 'store'::"domain_type_enum";
UPDATE "domain_settings" SET "app_type" = 'ORG_LANDING'::"app_type_enum",     "updated_at" = now()
  WHERE "app_type" = 'VENDIX_LANDING'::"app_type_enum" AND "domain_type" = 'organization'::"domain_type_enum";
UPDATE "domain_settings" SET "app_type" = 'STORE_ECOMMERCE'::"app_type_enum", "updated_at" = now()
  WHERE "app_type" = 'VENDIX_LANDING'::"app_type_enum" AND "domain_type" = 'ecommerce'::"domain_type_enum";

-- 20260719034534_backfill_store_settings_industries_mirror  (sincroniza mirror JSON desde stores.industries; idempotente vía IS DISTINCT FROM)
UPDATE "store_settings" ss
  SET "settings" = jsonb_set(
        jsonb_set(COALESCE(ss."settings", '{}'::jsonb), '{general}', COALESCE(ss."settings"->'general', '{}'::jsonb), true),
        '{general,industries}', to_jsonb(s."industries"::text[]), true),
      "updated_at" = NOW()
  FROM "stores" s
  WHERE ss."store_id" = s."id" AND s."industries" IS NOT NULL
    AND COALESCE(array_length(s."industries", 1), 0) >= 1
    AND (ss."settings"->'general'->'industries') IS DISTINCT FROM to_jsonb(s."industries"::text[]);

-- 20260719160000_add_dispatch_note_item_pricing_overrides  (columnas nullable, sin backfill)
ALTER TABLE "dispatch_note_items" ADD COLUMN IF NOT EXISTS "new_base_price"    DECIMAL(12,2);
ALTER TABLE "dispatch_note_items" ADD COLUMN IF NOT EXISTS "new_profit_margin" DECIMAL(5,2);

-- 20260719170000_seed_puc_133005_anticipos_proveedores  (INSERT NOT EXISTS por cada 1330; 0 filas en re-run)
INSERT INTO chart_of_accounts
  (accounting_entity_id, organization_id, code, name, account_type, level, parent_id, nature, accepts_entries, is_active, created_at)
SELECT p.accounting_entity_id, p.organization_id, '133005', 'A Proveedores', 'asset', 4, p.id, 'debit', TRUE, p.is_active, CURRENT_TIMESTAMP
FROM chart_of_accounts p
WHERE p.code = '1330'
  AND NOT EXISTS (
    SELECT 1 FROM chart_of_accounts c
    WHERE c.organization_id = p.organization_id AND c.code = '133005'
      AND c.accounting_entity_id IS NOT DISTINCT FROM p.accounting_entity_id);
```

## Verificación
- Frontend dev watch: `Application bundle generation complete` sin errores (NG8113 de PQR es ruido conocido).
- POS checkout B1 verificado E2E (Playwright, sin recarga): cancelar preserva; finalizar cierra+limpia y reabre Cobro sin fuga de estado.

## Issues relacionados
QUI-425, QUI-482, QUI-483, QUI-484, QUI-489, QUI-497, QUI-498

> Pendiente antes de merge: pasar `pr-code-review` (gate ≥80%, RULE 8 de git-workflow).
