### PR TITLE
fix(deploy): Redis maxmemory en caliente + auto-inyección del HMAC secret

### DIFF
--- a/.github/workflows/deploy-backend-ec2.yml
+++ b/.github/workflows/deploy-backend-ec2.yml
@@ -110,6 +110,11 @@ jobs:
           echo "🔑 Fetching secrets from AWS Secrets Manager..."
           DATABASE_URL=\$(aws secretsmanager get-secret-value --secret-id vendix/production/database --query SecretString --output text | python3 -c "import sys, json; print(json.load(sys.stdin)['DATABASE_URL'])")
           JWT_SECRET=\$(aws secretsmanager get-secret-value --secret-id vendix/production/jwt --query SecretString --output text | python3 -c "import sys, json; print(json.load(sys.stdin)['JWT_SECRET'])")
+          # Refresh-token HMAC key (lives beside JWT_SECRET). .get(...,'') is tolerant:
+          # if the key is not yet in the secret, this is empty and the backend uses its
+          # documented dev fallback (no deploy break). Add the key once and every future
+          # deploy injects it automatically — mirrors how JWT_SECRET flows.
+          REFRESH_TOKEN_HMAC_SECRET=\$(aws secretsmanager get-secret-value --secret-id vendix/production/jwt --query SecretString --output text | python3 -c "import sys, json; print(json.load(sys.stdin).get('REFRESH_TOKEN_HMAC_SECRET', ''))")
           EMAIL_PASSWORD=\$(aws secretsmanager get-secret-value --secret-id vendix/production/email --query SecretString --output text | python3 -c "import sys, json; data=json.load(sys.stdin); print(data.get('EMAIL_PASSWORD', ''))")
 
           # Fetch app configuration secrets
@@ -151,6 +156,16 @@ jobs:
               -v vendix-redis-data:/data \\
               redis:7-alpine redis-server --appendonly yes --save 60 1000 \\
               --maxmemory 1gb --maxmemory-policy allkeys-lru
+          else
+            # Already running: the guard above never recreates a live container (to
+            # preserve uptime/data), so a Redis started before this ceiling existed
+            # would keep 'noeviction' + maxmemory 0. Reconcile in place — no downtime,
+            # data preserved — so the OOM protection actually applies on every deploy.
+            # CONFIG REWRITE persists it to the container's redis.conf.
+            echo "♻️  vendix-redis already running — reconciling memory ceiling in place..."
+            sudo docker exec vendix-redis redis-cli CONFIG SET maxmemory 1gb || true
+            sudo docker exec vendix-redis redis-cli CONFIG SET maxmemory-policy allkeys-lru || true
+            sudo docker exec vendix-redis redis-cli CONFIG REWRITE || true
           fi
 
           echo "🛑 Stopping current container..."
@@ -164,6 +179,7 @@ jobs:
             --restart unless-stopped \\
             -p 3000:3000 \\
             --env-file /opt/vendix/.env \\
+            -e REFRESH_TOKEN_HMAC_SECRET="\$REFRESH_TOKEN_HMAC_SECRET" \\
             -e BASE_DOMAIN="\$BASE_DOMAIN" \\
             -e FRONTEND_URL="\$FRONTEND_URL" \\
             -e PORT="\$PORT" \\

--- a/apps/backend/src/domains/store/carrier/carrier-delivery.controller.ts
+++ b/apps/backend/src/domains/store/carrier/carrier-delivery.controller.ts
@@ -95,10 +95,10 @@ export class CarrierDeliveryController {
       map((payload) => ({ data: JSON.stringify(payload) }) as MessageEvent),
     );
 
-    // Heartbeat every 30s — emitted as an SSE comment (leading ":") so it
-    // keeps proxies/CDNs alive WITHOUT triggering client reconnection. This
-    // is what lets a non-clean disconnect surface as `req.on('close')` and
-    // release the shared Subject (fixes the SSE heap leak).
+    // Heartbeat every 30s — a periodic keep-alive write so proxies/CDNs don't
+    // idle-close the stream. Forcing socket I/O also makes a non-clean
+    // disconnect surface as `req.on('close')`, releasing the shared Subject
+    // (fixes the SSE heap leak).
     const heartbeat$ = interval(30_000).pipe(
       map(() => ({ data: `: heartbeat ${Date.now()}` }) as MessageEvent),
     );

--- a/apps/backend/src/domains/store/kitchen-fire/kitchen-fire.controller.ts
+++ b/apps/backend/src/domains/store/kitchen-fire/kitchen-fire.controller.ts
@@ -144,7 +144,7 @@ export class KitchenFireController {
    *   2) Live events from the per-store subject:
    *        ticket.created | ticket.started | ticket.ready |
    *        ticket.delivered | ticket.cancelled
-   *   3) A heartbeat comment every 30s to keep proxies alive.
+   *   3) A 30s heartbeat keep-alive write to keep proxies alive.
    *
    * Frontend reconciles via ticket id (snapshot = full replace, live
    * events = upsert / remove). The Subject is cleaned up on disconnect
@@ -239,8 +239,8 @@ export class KitchenFireController {
       map(
         () =>
           ({
-            // SSE comment line; the leading ":" makes NestJS treat it
-            // as a comment rather than a typed event.
+            // Keep-alive payload; NestJS emits it as a `data:` event whose
+            // text starts with ":" (not a true SSE comment).
             data: `: heartbeat ${Date.now()}`,
           }) as MessageEvent,
       ),

--- a/apps/backend/src/domains/store/membership-access/membership-access.controller.ts
+++ b/apps/backend/src/domains/store/membership-access/membership-access.controller.ts
@@ -120,10 +120,10 @@ export class MembershipAccessController {
       map((payload) => ({ data: JSON.stringify(payload) }) as MessageEvent),
     );
 
-    // Heartbeat every 30s — emitted as an SSE comment (leading ":") so it
-    // keeps proxies/CDNs alive WITHOUT triggering client reconnection. This
-    // is what lets a non-clean disconnect surface as `req.on('close')` and
-    // release the shared Subject (fixes the SSE heap leak).
+    // Heartbeat every 30s — a periodic keep-alive write so proxies/CDNs don't
+    // idle-close the stream. Forcing socket I/O also makes a non-clean
+    // disconnect surface as `req.on('close')`, releasing the shared Subject
+    // (fixes the SSE heap leak).
     const heartbeat$ = interval(30_000).pipe(
       map(() => ({ data: `: heartbeat ${Date.now()}` }) as MessageEvent),
     );

--- a/apps/backend/src/domains/store/notifications/notifications.controller.ts
+++ b/apps/backend/src/domains/store/notifications/notifications.controller.ts
@@ -191,10 +191,10 @@ export class NotificationsController {
       ),
     );
 
-    // Heartbeat every 30s — emitted as an SSE comment (leading ":") so it
-    // keeps proxies/CDNs alive WITHOUT triggering client reconnection. This
-    // is what lets a non-clean disconnect surface as `req.on('close')` and
-    // release the shared Subject (fixes the SSE heap leak).
+    // Heartbeat every 30s — a periodic keep-alive write so proxies/CDNs don't
+    // idle-close the stream. Forcing socket I/O also makes a non-clean
+    // disconnect surface as `req.on('close')`, releasing the shared Subject
+    // (fixes the SSE heap leak).
     const heartbeat$ = interval(30_000).pipe(
       map(() => ({ data: `: heartbeat ${Date.now()}` }) as MessageEvent),
     );

--- a/apps/backend/src/domains/store/tables/table-sessions.controller.ts
+++ b/apps/backend/src/domains/store/tables/table-sessions.controller.ts
@@ -131,8 +131,8 @@ export class TableSessionsController {
    *      `item_added`, `guest_count_changed`, `bill.requested`,
    *      `payment.*`, `kitchen.*`, `table_payment_*`). Anything NOT in
    *      `STAFF_EVENT_WHITELIST` is dropped — default-deny.
-   *   3) A 30s heartbeat comment (`: heartbeat <ts>`) so proxies and
-   *      CDNs see the stream is alive.
+   *   3) A 30s heartbeat keep-alive (`data: : heartbeat <ts>`) so proxies
+   *      and CDNs see the stream is alive.
    *
    * Auth: `JwtAuthGuard` is global and accepts `?token=` for SSE
    * clients (EventSource can't set Authorization headers). The store
@@ -218,8 +218,8 @@ export class TableSessionsController {
       ),
     );
 
-    // 3) Heartbeat every 30s — emitted as a comment (": ping") so it
-    //    doesn't trigger client-side reconnection logic.
+    // 3) Heartbeat every 30s — a keep-alive `data:` write so proxies don't
+    //    idle-close the stream.
     const heartbeat$ = interval(30_000).pipe(
       map(
         () =>


### PR DESCRIPTION
## Resumen

Follow-up de la estabilización de producción (PR #447). Cierra dos huecos operativos que quedaban del Tier 1 y corrige un comentario impreciso en los streams SSE.

## Cambios

### 1. Redis `maxmemory` ahora se aplica en cada deploy (no solo al crear)
El guard `if ! docker ps …running… ; then rm+run` solo recreaba `vendix-redis` cuando **no** estaba corriendo. En prod Redis siempre corre, así que el techo `--maxmemory 1gb --maxmemory-policy allkeys-lru` nunca se aplicaba al contenedor vivo (seguía en `noeviction` + `maxmemory 0`, riesgo de OOM).

Se agrega una rama `else` que **reconcilia en caliente** sin downtime ni pérdida de datos:
```bash
docker exec vendix-redis redis-cli CONFIG SET maxmemory 1gb
docker exec vendix-redis redis-cli CONFIG SET maxmemory-policy allkeys-lru
docker exec vendix-redis redis-cli CONFIG REWRITE
```

### 2. `REFRESH_TOKEN_HMAC_SECRET` inyectado automáticamente en el deploy
El backend (tras la migración bcrypt→HMAC del PR #447) lee `process.env.REFRESH_TOKEN_HMAC_SECRET`. El workflow ahora lo lee del secret `vendix/production/jwt` (junto a `JWT_SECRET`) y lo inyecta como `-e`, igual que `JWT_SECRET`.

Uso de `.get('REFRESH_TOKEN_HMAC_SECRET', '')` (tolerante): si la clave no existe, queda vacío y el backend usa su fallback documentado — **el deploy nunca se rompe**. La clave ya fue agregada al secret de prod.

### 3. Comentario `SSE comment` corregido (5 controllers)
El comentario afirmaba que el heartbeat se emitía "as an SSE comment (leading ':')". Es falso: NestJS `@Sse()` siempre escribe `data: <valor>`, así que `{ data: ': heartbeat …' }` sale como `data: : heartbeat 123` — un evento `message` cuyo texto empieza con `:`, no un comentario SSE real. El latido funciona igual (fuerza I/O al socket → destapa conexiones muertas → libera el `Subject`); solo se corrige la nota. Afecta: `notifications`, `carrier-delivery`, `membership-access`, `kitchen-fire`, `table-sessions`.

## ⚠️ Impacto en deploy

- **Re-login único** de los usuarios: el cambio bcrypt→HMAC (ya mergeado en #447) invalida los refresh tokens viejos por incompatibilidad de algoritmo. Las contraseñas NO se tocan. Conviene deployar en horario de bajo tráfico.
- Sin migraciones de base de datos.

## Verificación

- Redis: tras deploy, `redis-cli CONFIG GET maxmemory maxmemory-policy` → `1gb` / `allkeys-lru` aunque el contenedor ya estuviera corriendo.
- Token: `aws secretsmanager get-secret-value --secret-id vendix/production/jwt --query SecretString --output text | jq 'keys'` incluye `REFRESH_TOKEN_HMAC_SECRET`; el backend arranca sin usar el fallback.
- SSE: cambios de comentario, sin impacto en compilación ni runtime.

## Linear
- QUI-538 — DEV/ Estabilización de prod: SSE, latencia, scans async [infra]
  https://linear.app/quickss/issue/QUI-538