### PR TITLE
fix(sidebar): order Compras before Clientes per QUI-377 section 3

### DIFF
--- a/apps/frontend/src/app/private/layouts/store-admin/store-admin-layout.component.ts
+++ b/apps/frontend/src/app/private/layouts/store-admin/store-admin-layout.component.ts
@@ -639,15 +639,15 @@ export class StoreAdminLayoutComponent {
           alwaysVisible: true,
         },
         {
-          label: 'Clientes',
-          icon: 'circle',
-          route: '/admin/analytics/customers',
-          alwaysVisible: true,
-        },
-        {
           label: 'Compras',
           icon: 'shopping-cart',
           route: '/admin/analytics/purchases',
+          alwaysVisible: true,
+        },
+        {
+          label: 'Clientes',
+          icon: 'circle',
+          route: '/admin/analytics/customers',
           alwaysVisible: true,
         },
         {
@@ -693,15 +693,15 @@ export class StoreAdminLayoutComponent {
           alwaysVisible: true,
         },
         {
-          label: 'Clientes',
-          icon: 'circle',
-          route: '/admin/reports/customers',
-          alwaysVisible: true,
-        },
-        {
           label: 'Compras',
           icon: 'circle',
           route: '/admin/reports/purchases',
+          alwaysVisible: true,
+        },
+        {
+          label: 'Clientes',
+          icon: 'circle',
+          route: '/admin/reports/customers',
           alwaysVisible: true,
         },
         {


### PR DESCRIPTION
Fixes ISSUE-06 (QUI-377 sub-criterio: Orden segun tabla de seccion 3).

El submenu Analiticas y Reportes no seguia la tabla de seccion 3 del issue padre QUI-377. Compras quedaba entre Clientes y Reseñas, en lugar de entre Productos y Clientes.

**Orden aplicado (identico en ambas secciones):**
```
Resumen > Ventas > Inventario > Productos > Compras > Clientes > Reseñas > Financiero
```

**Cambios:**
- `apps/frontend/src/app/private/layouts/store-admin/store-admin-layout.component.ts` — mueve el bloque `Compras` antes de `Clientes` en la seccion Analiticas (~linea 642) y Reportes (~linea 696).

**No se tocan:**
- Mappings de panel_ui (Compras -> analytics_purchases, Reseñas -> analytics_reviews) — ya correctos en origin/dev.
- Iconos (Compras=shopping-cart, Reseñas=star) — ya correctos en origin/dev.
- Rutas — ya apuntan a shells (/admin/analytics/purchases, /admin/reports/purchases).

**Verificacion post-merge:** abrir /admin/analytics/overview en dev, desplegar el submenu Analiticas y Reportes, confirmar que el orden visual coincide con la tabla de QUI-377 seccion 3.