### PR TITLE
fix(ecommerce): close </span> tags on same line in cart-promotions (NG5002)

### DIFF
--- a/apps/frontend/src/app/private/modules/ecommerce/components/cart-promotions/cart-promotions.component.ts
+++ b/apps/frontend/src/app/private/modules/ecommerce/components/cart-promotions/cart-promotions.component.ts
@@ -101,21 +101,19 @@ import {
                       class="text-text-secondary"
                       [ngClass]="compact() ? 'text-[11px]' : 'text-sm'"
                       [title]="promo.name"
-                      >{{ promo.name }}</span
-                    >
+                      >{{ promo.name }}</span>
                     @if (promo.affectedLabel) {
                       <span
                         class="text-text-muted"
                         [ngClass]="compact() ? 'text-[10px]' : 'text-xs'"
                         [title]="'Aplicada a: ' + promo.affectedLabel"
-                        >({{ promo.affectedLabel }})</span
-                      >
+                        >({{ promo.affectedLabel }})</span>
                     }
                   </div>
                   <span
                     class="shrink-0 font-semibold text-green-600"
                     [ngClass]="compact() ? 'text-[11px]' : 'text-sm'"
-                    >-{{ promo.discount_amount | currency }}</span
+                    >-{{ promo.discount_amount | currency }}</span>
                 </div>
                 <div class="flex items-center gap-1.5">
                   <app-badge


### PR DESCRIPTION
El layout nuevo del cart-promotions tenia 3 cierres de </span> divididos en dos lineas (uno con '</span' y el siguiente con '>'). Eso dispara NG5002: Unexpected character "<" porque el parser de Angular template no tolera tags split entre lineas.

**Archivos afectados:** 1 (cart-promotions.component.ts)

**Lineas consolidadas:**
- Linea 104: nombre de la promo
- Linea 111: affected label '({{ promo.affectedLabel }})'
- Linea 118: monto del descuento

**Sin cambios funcionales.** Solo sintaxis.

Stacktrace del error:
```
NG5002: Unexpected character "<"
src/app/private/modules/ecommerce/components/cart-promotions/cart-promotions.component.ts:119:16
```